### PR TITLE
docs: expand CLI reference, 25-agent wording, Operator UX guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to Grok Imagine Cinematic Studio will be documented in this 
 ## [Unreleased]
 
 ### Changed
+- **CLI reference expansion** — `docs/CLI_REFERENCE.md` matches the live Typer tree (sequence nested tools, sfw/nsfw plate·motion, wave-a, handoff validate, TUI `--print`, meta installer); corrects `validate --strict-handoff` (strict flags live on `handoff validate` / `imagine agent-handoff`)
+- **25-agent core wording** — retire stale “23-agent” strings in CLI help, activation prompt, PDF report, and `/cinematic` slash command (align with `list-agents` core count)
 - **TUI command palette** — `/` or Ctrl+P opens allowlisted action search; KPI bar under status strip; `y` saves orient brief to `artifacts/tui_orient_brief.txt`; scroll preserved on refresh
 - **TUI non-TTY fallback** — `cinematic-studio ui --print` (and bare `ui` without a TTY) prints the orient dashboard instead of hard-failing; optional `artifacts/tui_orient_brief.txt`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to Grok Imagine Cinematic Studio will be documented in this 
 ## [Unreleased]
 
 ### Changed
+- **Operator UX guide** — `docs/guides/Operator_UX_Control_Plane.md` documents the shared studio snapshot, TUI/Web density, spend gates, handoffs, and multi-surface operator loop (linked from CLI Reference, Quick Start, docs index)
 - **CLI reference expansion** — `docs/CLI_REFERENCE.md` matches the live Typer tree (sequence nested tools, sfw/nsfw plate·motion, wave-a, handoff validate, TUI `--print`, meta installer); corrects `validate --strict-handoff` (strict flags live on `handoff validate` / `imagine agent-handoff`)
 - **25-agent core wording** — retire stale “23-agent” strings in CLI help, activation prompt, PDF report, and `/cinematic` slash command (align with `list-agents` core count)
 - **TUI command palette** — `/` or Ctrl+P opens allowlisted action search; KPI bar under status strip; `y` saves orient brief to `artifacts/tui_orient_brief.txt`; scroll preserved on refresh

--- a/commands/cinematic.md
+++ b/commands/cinematic.md
@@ -1,5 +1,5 @@
 ---
-description: Activate Grok Imagine Cinematic Studio v3.8.6 with the full 23-agent production suite, Grok 4.5 model stack, Imagine Agent Mode Handoff, and native Imagine Video 1.0/1.5 pipeline.
+description: Activate Grok Imagine Cinematic Studio v3.8.9 with the full 25-agent core production suite, Grok 4.5 model stack, Imagine Agent Mode Handoff, and native Imagine Video 1.0/1.5 pipeline.
 ---
 
 # Activate Cinematic Studio
@@ -27,7 +27,7 @@ Start a full multi-agent cinematic production session with unified Grok 4.5 cine
 
 State the activation phrase explicitly:
 
-> **Activate Grok Imagine Cinematic Studio v3.8.6**
+> **Activate Grok Imagine Cinematic Studio v3.8.9**
 
 ## Commands
 
@@ -55,7 +55,7 @@ python tools/cinematic_studio_cli.py generate-prompt "$ARGUMENTS" \
 ### Specialist activations (use as needed)
 
 - `ACTIVATE IMAGINE_VIDEO_1.5_FULL` — full native 1.5 video + audio mode
-- `ACTIVATE IMAGINE_AGENT_MODE_HANDOFF` — official planning→Imagine execution handoff (v3.8.6)
+- `ACTIVATE IMAGINE_AGENT_MODE_HANDOFF` — official planning→Imagine execution handoff (studio v3.8.9)
 - `ACTIVATE CHARACTER_DNA_EXTRACTOR` — DNA extraction and Identity Lock
 - `ACTIVATE NSFW_QUOTA_ORCHESTRATOR` — Heavy batch planning (explicit opt-in only)
 - `ACTIVATE AI_POLISH_DIRECTOR` — final delivery upscale pass
@@ -73,13 +73,13 @@ Confirm the session is in studio mode:
 
 ```
 ## Result
-- **Action**: Cinematic Studio v3.8.6 activated
+- **Action**: Cinematic Studio v3.8.9 activated
 - **Status**: success
 - **Project**: <title or brief from $ARGUMENTS>
 - **Pipeline**: Imagine Video 1.0 default / 1.5 when native audio
 - **Handoff**: Imagine Agent Mode Handoff ready (Studio Director owns surface routing)
 - **Stack**: grok-4.5 cinematic+Build (opt-in grok-4.3 for 1M)
-- **Agents**: 23 core (+ ErosForge opt-in)
+- **Agents**: 25 core (+ pipeline / Wave A / ErosForge opt-in)
 ```
 
 ## Next Steps

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -1,10 +1,25 @@
 # CLI Reference
+
 ## cinematic-studio (Grok Imagine Cinematic Studio v3.8.9)
 
 Primary entry points:
-- `cinematic-studio` (installed wrapper)
-- `python tools/cinematic_studio_cli.py`
-- `bash scripts/cinematic_studio.sh` (meta installer: install/update/verify/doctor/**grok**)
+
+| Entry | Role |
+|-------|------|
+| `cinematic-studio` | Installed wrapper (`~/.grok/bin`, often on `PATH` via `~/.local/bin`) |
+| `python tools/cinematic_studio_cli.py` | Python CLI from a clone (no wrapper required) |
+| `bash scripts/cinematic_studio.sh` | Meta installer: install / update / verify / declutter / doctor / **grok** |
+
+**Wrapper env:**
+
+| Variable | Purpose |
+|----------|---------|
+| `CINEMATIC_PROJECT_DIR` | Project root (default `$HOME/Grok-Cinematic-Projects`) |
+| `CINEMATIC_CLI_PY` | Override path to `cinematic_studio_cli.py` |
+
+**Runtime state dirs** (fixed in `tools/studio_paths.py` — do not relocate without updating that module):
+
+`characters/` · `sequences/` · `sfw_batches/` · `nsfw_batches/` · `artifacts/` · `.cinematic_project_state.json` · `.quota_config.json`
 
 ---
 
@@ -13,13 +28,19 @@ Primary entry points:
 ```bash
 cinematic-studio --help
 cinematic-studio <command> --help
+cinematic-studio version
+cinematic-studio status
+cinematic-studio stack [--json]
+cinematic-studio dashboard [--json] [--compact] [--watch] [--interval 5]
 ```
+
+Live help is authoritative when this doc lags. Framework: **Typer** + **Rich**; wiring in `tools/cinematic_studio_cli.py`, commands under `tools/cli/`.
 
 ---
 
 ## Grok Build CLI binary
 
-Manage the official **Grok Build** binary (min **0.2.93**). Method A install also ensures this automatically.
+Manage the official **Grok Build** binary (min **0.2.93**). Method A install also ensures this automatically. This is **not** the Studio Python CLI.
 
 ```bash
 cinematic-studio grok status              # path + version vs min
@@ -40,104 +61,140 @@ Env: `CINEMATIC_SKIP_GROK_CLI`, `CINEMATIC_FORCE_GROK_CLI`, `CINEMATIC_MIN_GROK_
 
 ---
 
-## Core Commands
+## Studio overview
 
-### Production Bible
 ```bash
-cinematic-studio create-bible --wizard          # Interactive guided wizard
-cinematic-studio create-bible "Project Title"   # Non-interactive
+cinematic-studio activate                 # Print activation phrase + stack
+cinematic-studio list-agents              # Core + specialist roster by category
+cinematic-studio list-role-cards
+cinematic-studio show-role-card <name>
+cinematic-studio doctor [--quick] [--json] [--strict]
+cinematic-studio validate                 # Docs, skills, models, workspace paths
+cinematic-studio report [-o production_report.pdf]
 ```
 
-### Character DNA
+Agent roster in CLI: **25 core** + pipeline / Wave A / opt-in specialists (see `list-agents`). Skills suite size is tracked separately (plugin index / AGENTS.md).
+
+---
+
+## Production Bible & memory
+
 ```bash
-cinematic-studio dna init --name "Character Name"
-cinematic-studio dna extract
-cinematic-studio dna lock
-cinematic-studio dna handoff
-cinematic-studio dna inject
+cinematic-studio create-bible --wizard              # Guided stages (requires TTY)
+cinematic-studio create-bible "Project Title" \
+  --genre Cinematic \
+  --chat-model grok-4.5 \
+  --video-model grok-imagine-video \
+  -o production_bible.json
+
+cinematic-studio generate-prompt "story beat..." \
+  --signature default \
+  --chat-model grok-4.5 \
+  --video-model grok-imagine-video
+
+cinematic-studio cost-simulate --duration 60 --complexity medium
+
+cinematic-studio memory add --name key --value "..."
+cinematic-studio memory list
+cinematic-studio memory load <name>
 ```
 
-### Sequences
+Chat model defaults to **`grok-4.5`**. Use `--chat-model grok-4.3` (or long-context aliases) only when 1M context is required.
+
+---
+
+## Character DNA
+
+```bash
+cinematic-studio dna init "Character Name" \
+  [--core ...] [--facial ...] [--hair ...] [--clothing ...] \
+  [--movement ...] [--emotion ...] [--motion ...] [--anchor ...] [-o path]
+
+cinematic-studio dna save <profile-or-path>
+cinematic-studio dna list
+cinematic-studio dna show <slug> [--inject]
+cinematic-studio dna handoff <slug>
+cinematic-studio dna lock <slug>
+cinematic-studio dna inject <slug>
+```
+
+Profiles live under `characters/{slug}/`. There is no `dna extract` subcommand — extraction is a **chat skill** (`character-dna-extractor`); CLI owns scaffold / lock / inject.
+
+---
+
+## Sequences (long-form)
+
 ```bash
 cinematic-studio sequence init <name>
-cinematic-studio sequence add-clip ...
-cinematic-studio sequence handoff
-cinematic-studio sequence extend
-cinematic-studio sequence qa
-cinematic-studio sequence color-grade
-cinematic-studio sequence polish
-cinematic-studio sequence deliver
+cinematic-studio sequence list
+cinematic-studio sequence show <name>
+cinematic-studio sequence add-clip <name> ...
+
+# Extend / stitch path
+cinematic-studio sequence handoff <name> ...
+cinematic-studio sequence extend-prompt <name> ...   # not "sequence extend"
+cinematic-studio sequence qa <name> ...
+cinematic-studio sequence qa-assist <name> ...
+cinematic-studio sequence run <name> ...             # API submit + poll + chain QA
+cinematic-studio sequence estimate-cost <name>
+cinematic-studio sequence health <name>
+
+# Evidence loops
+cinematic-studio sequence drift-score ...
+cinematic-studio sequence seam-report ...
+cinematic-studio sequence amv-check ...
+cinematic-studio sequence continuity-diff ...
+
+# Post
+cinematic-studio sequence edl <name>
+cinematic-studio sequence color-grade set|show ...
+cinematic-studio sequence polish <name> [--scale 2] [--face-restore] [--dry-run]
+cinematic-studio sequence deliver <name> ...
+
+# Nested tools
+cinematic-studio sequence memory show|sync ...
+cinematic-studio sequence regen plan|apply|run ...     # after chain QA No-Go
+cinematic-studio sequence temp set|show|gate ...
+cinematic-studio sequence cast arbitrate|inject ...
+cinematic-studio sequence artifact-lexicon list|pack|suggest ...
+cinematic-studio sequence replan plan|apply ...
 ```
 
-### Imagine / Handoff
+---
+
+## Imagine jobs & handoff
+
 ```bash
+cinematic-studio imagine verify
+cinematic-studio imagine submit ...
+cinematic-studio imagine status <job-id>
+cinematic-studio imagine list
+cinematic-studio imagine cancel <job-id>
+cinematic-studio imagine region ...
+cinematic-studio imagine workflow ...
+cinematic-studio imagine artifact ...
+cinematic-studio imagine artifacts
+cinematic-studio imagine report
+
+# Official Imagine Agent Mode Handoff (protocol v3.7.1 · studio v3.8.9)
 cinematic-studio imagine agent-handoff \
-  --batch <slug> --shot <id> \
+  [--batch <slug> --shot <id>] \
+  [--sequence <slug> --clip <id>] \
   --surface grok_build_tools \
-  --format json|markdown
+  --format markdown|json|clipboard \
+  [--strict-handoff] [--strict-wave-a] \
+  [--checklist dna,lock,curator,prompt,i2v] \
+  [-o path]
 
-cinematic-studio imagine bridge                 # Classic Surface C bridge
+# Classic Surface C (grok.com/imagine paste)
+cinematic-studio imagine bridge ...
+
+# Packet validation (not root validate)
+cinematic-studio handoff validate path/to/handoff.json \
+  [--strict-handoff] [--strict-wave-a]
 ```
 
-### Quota & Cost
-```bash
-cinematic-studio quota estimate --video-seconds 45 --tier heavy
-cinematic-studio quota dashboard
-cinematic-studio quota optimize
-```
-
-### Models & Validation
-```bash
-cinematic-studio models verify
-cinematic-studio models stack
-cinematic-studio validate
-cinematic-studio validate --strict-handoff
-```
-
-### Plugins
-```bash
-cinematic-studio plugin catalog
-cinematic-studio plugin packs
-cinematic-studio plugin catalog pin
-cinematic-studio plugin check --release
-```
-
-### Interactive TUI
-```bash
-cinematic-studio ui
-# Dashboard + safe launcher + production cockpit
-```
-
-### NSFW (requires prior ErosForge activation in chat)
-```bash
-cinematic-studio nsfw ...
-```
-
-### Generation Tracking
-```bash
-cinematic-studio generation log|list|summary|report|update
-```
-
-### Doctor / Health
-```bash
-cinematic-studio doctor          # or grok-doctor
-```
-
----
-
-## Common Flags
-
-| Flag | Purpose |
-|------|---------|
-| `--strict-handoff` | Enforce full packet + specialist checklist |
-| `--strict-plate` | Require plate lock |
-| `--strict-motion` | Require motion vector / I2V readiness |
-| `--format json\|markdown` | Output format for handoffs |
-| `--surface <name>` | Target execution surface |
-
----
-
-## Surfaces for Handoff
+### Surfaces
 
 | Code | Meaning |
 |------|---------|
@@ -145,6 +202,237 @@ cinematic-studio doctor          # or grok-doctor
 | `grok_agent_acp` | ACP / agent sessions |
 | `grok_com_imagine` | Web UI paste (Classic Bridge) |
 | `xai_api` | Live API jobs |
+
+---
+
+## SFW / NSFW batches
+
+SFW and NSFW share a similar command shape. NSFW tooling is for **explicit ErosForge-activated** pipelines only (chat policy still applies).
+
+```bash
+cinematic-studio sfw plan|list|next|decide|run|session|record|promote|quality-pending|retry
+cinematic-studio nsfw plan|list|next|decide|run|session|record|promote|quality-pending|retry|report
+
+# Plate + motion (both groups)
+cinematic-studio sfw plate set <batch> <shot> --status draft|approved|locked ...
+cinematic-studio sfw plate show ...
+cinematic-studio sfw motion set <batch> <shot> ...
+cinematic-studio sfw motion show ...
+
+# Spend with hard gates
+cinematic-studio sfw run ... --strict-plate --strict-motion [--strict-wave-a]
+cinematic-studio nsfw run ... --strict-plate --strict-motion [--strict-wave-a]
+
+# NSFW sensual extension (30–120s+)
+cinematic-studio nsfw extend plan|chain|prompt|camera|qa|export ...
+```
+
+---
+
+## Animatic
+
+```bash
+cinematic-studio animatic plan "Board title" [--beat ...] [--file beats.json] [-d 60]
+cinematic-studio animatic list
+cinematic-studio animatic show <name>
+cinematic-studio animatic promote <name> --frame <id> [--tier hero]
+```
+
+---
+
+## Quota & cost
+
+```bash
+cinematic-studio quota estimate --video-seconds 45 ...
+cinematic-studio quota clip ...
+cinematic-studio quota sequence <name>
+cinematic-studio quota dashboard
+cinematic-studio quota budget ...
+cinematic-studio quota record ...
+cinematic-studio quota optimize ...
+cinematic-studio quota sync
+cinematic-studio quota reconcile ...
+```
+
+---
+
+## Models
+
+```bash
+cinematic-studio models list
+cinematic-studio models stack
+cinematic-studio models verify
+```
+
+Registry default: cinematic + Build **`grok-4.5`**; Imagine video **`grok-imagine-video`** (1.0 cost default); optional chat **`grok-4.3`** for 1M.
+
+---
+
+## Wave A packets
+
+```bash
+cinematic-studio wave-a plate-motion ...
+cinematic-studio wave-a contact ...
+cinematic-studio wave-a hmu ...
+cinematic-studio wave-a dialogue ...
+cinematic-studio wave-a score ...
+cinematic-studio wave-a title ...
+cinematic-studio wave-a crop ...
+cinematic-studio wave-a briefs ...
+cinematic-studio wave-a validate <packet.json>
+cinematic-studio wave-a attach <handoff.json> ...   # merge onto agent-mode handoff
+```
+
+---
+
+## Plugins & catalog
+
+```bash
+cinematic-studio plugin packs
+cinematic-studio plugin status
+cinematic-studio plugin list [--grouped]
+cinematic-studio plugin declutter [--dry-run|--apply]
+cinematic-studio plugin catalog check [--release]
+cinematic-studio plugin catalog pin
+```
+
+Release flow: commit content first → `plugin catalog pin` → commit **only** `.grok-plugin/` as needed. Pre-publish: `plugin catalog check --release`.
+
+---
+
+## Generation ledger
+
+```bash
+cinematic-studio generation log ...
+cinematic-studio generation list
+cinematic-studio generation summary
+cinematic-studio generation report
+cinematic-studio generation update ...
+cinematic-studio generation import-jobs
+```
+
+---
+
+## Interactive TUI
+
+```bash
+cinematic-studio ui                    # Textual home + launcher + cockpit (TTY)
+cinematic-studio ui --interval 5
+cinematic-studio ui --print            # Non-TTY / agents / CI: orient dump
+cinematic-studio ui --print --no-artifact
+```
+
+Without a TTY, bare `ui` falls back to a one-shot orient dump (writes `artifacts/tui_orient_brief.txt` unless `--no-artifact`). Launcher only allows an allowlisted argv set.
+
+---
+
+## Meta installer (shell)
+
+```bash
+bash scripts/cinematic_studio.sh install
+bash scripts/cinematic_studio.sh update
+bash scripts/cinematic_studio.sh verify [--all|--plugin]
+bash scripts/cinematic_studio.sh declutter [--dry-run|--apply]
+bash scripts/cinematic_studio.sh version
+bash scripts/cinematic_studio.sh doctor [--quick]
+bash scripts/cinematic_studio.sh grok status|ensure|update|install
+```
+
+The `cinematic-studio` wrapper routes `install|update|verify|declutter` to this shell path when present under `CINEMATIC_PROJECT_DIR`.
+
+---
+
+## Common flags
+
+| Flag | Where | Purpose |
+|------|--------|---------|
+| `--strict-plate` | `sfw`/`nsfw` run/session (and spend paths) | Require plate lock (`approved`/`locked`) |
+| `--strict-motion` | same | Require full motion vector / I2V readiness |
+| `--strict-wave-a` | batch run, `imagine agent-handoff`, `handoff validate` | Wave A plate+motion hard path |
+| `--strict-handoff` | `imagine agent-handoff`, `handoff validate` | Exit 1 on readiness blockers (not root `validate`) |
+| `--strict` | `doctor` | Exit 1 on warnings |
+| `--format json\|markdown\|clipboard` | handoffs | Output format |
+| `--surface <name>` | `imagine agent-handoff` | Target execution surface |
+| `--chat-model` | bible / prompt | Default `grok-4.5`; `grok-4.3` for 1M |
+| `--video-model` / `-m` | bible / prompt | Imagine video slug or alias |
+| `--json` | dashboard, doctor, stack, … | Machine-readable output |
+| `--quick` / `-q` | doctor | Skip pytest and full plugin verify |
+| `--dry-run` | polish, declutter, … | Plan without side effects |
+
+**Note:** Root `cinematic-studio validate` checks workspace docs/skills/models only. Packet strictness is `handoff validate --strict-handoff` or `imagine agent-handoff --strict-handoff`.
+
+---
+
+## Typical operator flows
+
+### Greenfield
+
+```bash
+cinematic-studio create-bible "My Film" --wizard
+cinematic-studio dna init "Hero"
+cinematic-studio dna lock "hero"
+cinematic-studio sequence init "Act 1"
+cinematic-studio models verify
+cinematic-studio doctor --quick
+```
+
+### Still → video (spend-safe)
+
+```bash
+cinematic-studio sfw plan ...
+cinematic-studio sfw plate set <batch> <shot> --status locked ...
+cinematic-studio sfw motion set <batch> <shot> ...
+cinematic-studio sfw run ... --strict-plate --strict-motion
+```
+
+### Long-form extend
+
+```bash
+cinematic-studio sequence add-clip ...
+cinematic-studio sequence handoff ...
+cinematic-studio sequence extend-prompt ...
+cinematic-studio sequence run ...
+cinematic-studio sequence health ...
+cinematic-studio sequence polish ...
+cinematic-studio sequence deliver ...
+```
+
+### Planning → generation handoff
+
+```bash
+cinematic-studio imagine agent-handoff --surface grok_build_tools --strict-handoff
+cinematic-studio handoff validate artifacts/handoff.json --strict-handoff
+# or paste path:
+cinematic-studio imagine bridge
+```
+
+---
+
+## Architecture (for contributors)
+
+```
+tools/cinematic_studio_cli.py     # Typer app + group registration only
+tools/cli/*.py                    # Command modules (register(app))
+tools/cli/tui/                    # Textual TUI
+tools/*.py                        # Domain engines (models, doctor, DNA, chain, …)
+tools/studio_paths.py             # Canonical paths
+```
+
+| Module | Commands |
+|--------|----------|
+| `studio_commands` | dashboard, status, version, doctor, stack, agents, activate |
+| `bible_commands` | create-bible, generate-prompt, cost-simulate, memory |
+| `dna_commands` | dna.* |
+| `sequence_commands` | sequence.* (largest surface) |
+| `imagine_commands` | imagine.* |
+| `handoff_commands` | handoff validate |
+| `sfw_commands` / `nsfw_commands` | batches + plate/motion (+ nsfw extend) |
+| `quota_commands` / `models_commands` | quota.*, models.* |
+| `plugin_commands` / `wave_a_commands` | plugin.*, wave-a.* |
+| `generation_commands` / `report_commands` | generation.*, report, validate |
+| `grok_cli_commands` / `tui_commands` | grok.*, ui |
+| `animatic_commands` | animatic.* |
+| `spend_preflight` | Shared plate/motion/--strict-* helpers for batch run |
 
 ---
 

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -436,4 +436,11 @@ tools/studio_paths.py             # Canonical paths
 
 ---
 
+## See also
+
+- **[Operator UX — Studio Control Plane](guides/Operator_UX_Control_Plane.md)** — shared snapshot, TUI/Web density, spend gates, handoff journeys
+- [Quick Start](guides/Quick_Start_Guide.md) · [User Guide](guides/USER_GUIDE.md)
+
+---
+
 *Run any command with `--help` for full options. The CLI is the automation backbone of the Studio.*

--- a/docs/OFFICIAL_OVERVIEW.md
+++ b/docs/OFFICIAL_OVERVIEW.md
@@ -66,6 +66,7 @@ It is not a simple prompt wrapper. It is a full **virtual film studio** with spe
 | [User Guide](guides/USER_GUIDE.md) | Complete end-to-end workflow |
 | [Architecture](ARCHITECTURE.md) | System design, agents, protocols |
 | [CLI Reference](CLI_REFERENCE.md) | Full command reference |
+| [Operator UX Control Plane](guides/Operator_UX_Control_Plane.md) | Shared snapshot · TUI/Web · gates · handoffs |
 | [Quick Start](guides/Quick_Start_Guide.md) | Fast onboarding |
 | [Agent Index](../references/agents/AGENT_INDEX.md) | All Role Cards |
 | [Release Notes](releases/) | Version history |

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,5 @@
 # Documentation
-## Grok Imagine Cinematic Studio v3.8.7
+## Grok Imagine Cinematic Studio v3.8.9
 
 Project documentation index (community-maintained).
 
@@ -17,6 +17,7 @@ Project documentation index (community-maintained).
 | **[User Guide](guides/USER_GUIDE.md)** | Complete end-to-end production workflow |
 | **[Architecture](ARCHITECTURE.md)** | System design, layers, protocols |
 | **[CLI Reference](CLI_REFERENCE.md)** | Full command reference |
+| **[Operator UX — Control Plane](guides/Operator_UX_Control_Plane.md)** | Snapshot, TUI/Web density, spend gates, handoffs |
 | **[Quick Start Guide](guides/Quick_Start_Guide.md)** | Fast onboarding |
 
 ---
@@ -26,6 +27,7 @@ Project documentation index (community-maintained).
 - [Upgrade Guide](guides/UPGRADE_GUIDE.md)
 - [Installation Guide](guides/installation_guide.md)
 - [Streamlit Cloud Deploy](guides/streamlit_cloud_deploy.md)
+- [Operator UX Control Plane](guides/Operator_UX_Control_Plane.md)
 
 ## Templates
 

--- a/docs/guides/Operator_UX_Control_Plane.md
+++ b/docs/guides/Operator_UX_Control_Plane.md
@@ -1,0 +1,295 @@
+# Operator UX — Studio Control Plane
+
+**Studio:** v3.8.9 · Grok 4.5 stack  
+**Surfaces:** CLI · interactive TUI · Streamlit Web UI · grok.com (Activate / Imagine bridge)  
+**Design north-star:** `docs/development/superpowers/specs/2026-07-26-operator-ux-north-star-design.md`
+
+This guide folds the control-plane model into day-to-day operator language: one **snapshot**, shared **severity/attention**, **readiness gates**, and **surface-specific actions**.
+
+---
+
+## 1. One control plane, four adapters
+
+```text
+Operator journeys (orient → health → produce → gate → converge → deliver)
+        │
+        ▼
+┌────────────────────────────────────────────┐
+│  Studio Control Plane                      │
+│  · Snapshot: build_studio_dashboard()      │
+│  · Attention + severity (pure formatters)  │
+│  · Readiness: identity · plate/motion ·    │
+│    chain QA · converge · delivery          │
+│  · Actions: TUI allowlist · Web pages ·    │
+│    full CLI automation                     │
+└──────────────────┬─────────────────────────┘
+         ┌─────────┼──────────┬──────────────┐
+         ▼         ▼          ▼              ▼
+       TUI      Streamlit    CLI          grok.com
+    cinematic-  web_ui/   cinematic-    Activate +
+    studio ui   app.py    studio …      Imagine Bridge
+```
+
+| Surface | Best for | Safe default |
+|---------|----------|--------------|
+| **TUI** (`cinematic-studio ui`) | SSH / Termux / keyboard ops | No live spend tokens (`run`/`submit`/…) |
+| **Web** (`streamlit run web_ui/app.py`) | Scan dashboard, Bible wizard, DNA forms | Dashboard orient; Imagine pages can spend if key set |
+| **CLI** | Automation, strict gates, batches, sequences | Full power — use `--strict-*` before video |
+| **grok.com** | Chat multi-agent + manual Imagine paste | Bridge / agent-handoff packets |
+
+**Principle:** surfaces are thin. Business logic lives under `tools/`; UIs format and launch.
+
+---
+
+## 2. Shared studio snapshot
+
+Built by `tools/cli/dashboard.py` → `build_studio_dashboard()`.
+
+Same object powers:
+
+```bash
+cinematic-studio dashboard [--json] [--compact] [--watch]
+cinematic-studio ui          # Home panels
+cinematic-studio ui --print  # non-TTY orient dump
+streamlit run web_ui/app.py  # Dashboard page + sidebar severity
+```
+
+### Top-level keys
+
+| Key | Role |
+|-----|------|
+| `project` | Title, genre, bible loaded |
+| `studio` | Agents, role cards, skills, model compatibility |
+| `quota` | Spend, tier, risk, reconciliation |
+| `production` | Counts: sequences, DNA, batches, jobs |
+| `readiness` | Phase 2 rollup (identity · plate/motion · chain QA · next_actions) |
+| `chain_qa` | Per-sequence go/no-go summaries |
+| `sequences` / `characters` / batches / `recent_jobs` | Capped lists for density |
+| `parallel_briefs` | Discovered Wave A brief logs |
+| `convergence` | Checklist before agent-mode handoff |
+| `delivery` | Soft polish/deliver readiness per sequence |
+| `artifacts` / `production_report` | Artifact pipeline summary |
+
+Optional attach: **`quota_alignment`** (ledger recon) on TUI refresh and Web `attach_quota_alignment`.
+
+### Severity and attention
+
+| Severity | Meaning |
+|----------|---------|
+| **ok** | No blocking ops signals |
+| **warn** | Review attention items (risk, unlock DNA, …) |
+| **critical** | Models broken, chain QA no-go flood, etc. |
+
+Derived by pure formatters in `tools/cli/tui/widgets.py` (`strip_severity`, `collect_home_alerts`) — reused by Streamlit via `web_ui/lib/dashboard_ui.py`.
+
+---
+
+## 3. Operator loop (daily)
+
+Matches Quick Start control-plane section; expanded for production.
+
+### Phase 1 — Orient + health
+
+1. Open **TUI** (`ui`) or **Web Dashboard** (view **Ops** / radio **2**).  
+2. Read **status strip** severity and **Attention** list.  
+3. Health actions:
+   - TUI: **d** doctor · **v** validate · **s** quota sync · **m** models · **k** stack  
+   - Web: Dashboard **Health actions**  
+4. Refresh until Attention is clear or risk is accepted.
+
+```bash
+cinematic-studio doctor --quick
+cinematic-studio models verify
+cinematic-studio validate
+cinematic-studio quota sync
+```
+
+### Phase 2 — Produce + gate
+
+1. Bible / DNA / sequences (Web Production·DNA, TUI Cockpit, or CLI).  
+2. Check **READINESS**: identity locked · chain QA · plate/motion scan.  
+3. Before video spend: lock plates + motion briefs; prefer CLI strict flags.  
+4. Validate handoff packets after DNA lock / sequence handoff / agent-mode emit.
+
+```bash
+cinematic-studio sfw plate set <batch> <shot> --status locked --reference-image-id …
+cinematic-studio sfw motion set <batch> <shot> --action "…" --camera "…" --emotion "…"
+cinematic-studio sfw run … --strict-plate --strict-motion
+cinematic-studio handoff validate path.json --strict-handoff
+```
+
+### Phase 3 — Converge + deliver
+
+1. **Convergence** checklist → agent-mode handoff when gates OK.  
+2. **Parallel Brief** logs (`wave-a briefs`) for multi-agent sessions.  
+3. **Delivery** soft polish/deliver readiness; dry-run from TUI Cockpit.  
+4. Bridge preview for grok.com/imagine when API tools unavailable.
+
+```bash
+cinematic-studio wave-a briefs <session> -o artifacts/briefs_<session>.json
+cinematic-studio imagine agent-handoff -b … --shot … --strict-handoff -f json -o artifacts/handoff.json
+cinematic-studio imagine bridge -b … --shot … -f markdown
+cinematic-studio sequence polish "Act 1" --dry-run
+cinematic-studio sequence deliver "Act 1" --dry-run
+```
+
+---
+
+## 4. Density modes (TUI ↔ Web)
+
+| Mode | TUI | Web Dashboard | Intent |
+|------|-----|---------------|--------|
+| **compact** | key **1** | radio Compact | Orient: strip, KPI, attention, readiness |
+| **ops** | key **2** (default) | radio Ops | Gates + quota/studio + chain QA |
+| **full** | key **3** | radio Full | + sequences, DNA, jobs, briefs, JSON |
+
+TUI also: **Tab** cycle · **p** pause refresh · **y** save orient brief · **/** palette.
+
+---
+
+## 5. TUI action safety
+
+Registry: `tools/cli/tui/actions.py`.
+
+**Forbidden argv tokens** (never emitted):
+
+```
+--wizard  run  submit  record  cancel  declutter
+```
+
+| Surface | Role |
+|---------|------|
+| **Launcher** | Read/inspect: status, lists, doctor, validate, bridge, handoff validate |
+| **Cockpit** | Scaffold bible/DNA/sequence, quota budget/estimate, dry polish/deliver, briefs |
+| **Palette** | Union of both (`/` / Ctrl+P) |
+
+Execution path: `run_action(id, answers)` → validate form → build argv → reject forbidden → subprocess CLI.
+
+Live video spend is **CLI or Web Imagine**, not TUI.
+
+Full command tree: [CLI Reference](../CLI_REFERENCE.md).
+
+---
+
+## 6. Spend gates (before video credits)
+
+| Gate | Soft default | Hard flags |
+|------|--------------|------------|
+| **Plate** (still→video) | Warn if not approved/locked | `--strict-plate` · `--strict-wave-a` · agent `--strict-handoff` |
+| **Motion** (all video modes) | Free-text cues OK | `--strict-motion` / wave-a / agent strict (full triple) |
+| **Wave A field shapes** | Warnings | `--strict-wave-a` |
+
+Modules: `plate_readiness.py` · `motion_readiness.py` · `spend_readiness.py`.  
+Prefer official modes (`image_to_video`, not raw alias `i2v`) on batch shots so gates apply.
+
+Deep detail: plate PL-* codes, motion MB-* codes — see those modules and [CLI Reference — Common flags](../CLI_REFERENCE.md).
+
+---
+
+## 7. Handoff packets (planning → generation)
+
+| Packet | CLI | Purpose |
+|--------|-----|---------|
+| `imagine_agent_mode_handoff` | `imagine agent-handoff` | Multi-surface generation contract |
+| Classic bridge | `imagine bridge` | grok.com/imagine paste only |
+| `sequence_extend_handoff` | `sequence handoff` | Clip N → N+1 extend chain |
+
+Surfaces: `grok_build_tools` · `grok_agent_acp` · `grok_com_imagine` · `xai_api`.
+
+```bash
+cinematic-studio imagine agent-handoff \
+  -b <batch> --shot <id> \
+  --surface grok_build_tools \
+  --strict-handoff -f json -o artifacts/handoff.json
+cinematic-studio handoff validate artifacts/handoff.json --strict-handoff
+```
+
+Canonical protocol: `references/agents/IMAGINE_AGENT_MODE_HANDOFF_v3.7.1.md`.
+
+---
+
+## 8. Sequences (long-form)
+
+On disk: `sequences/<slug>/sequence.json` (schema 1.1).
+
+| Concept | Rule of thumb |
+|---------|----------------|
+| Chain QA | 10 weighted checks; pass **≥ 7.0**; critical fails → **no_go** |
+| Extend | Needs previous `last_frame_recap` + momentum / AMV |
+| Regen | Default **2** attempts/clip, **20**/sequence (`sequence regen plan|apply|run`) |
+| Identity drift | Pass when score **&lt; 2.5** |
+| Health | `sequence health` aggregates QA · drift · seam · AMV · regen · temp |
+
+```bash
+cinematic-studio sequence run "Act 1" --clip clip_001
+cinematic-studio sequence qa-assist "Act 1" --clip clip_001
+cinematic-studio sequence health "Act 1"
+```
+
+---
+
+## 9. Journey cheat sheet (J1–J8 style)
+
+| Journey | Primary surface | Success |
+|---------|-----------------|---------|
+| Orient | TUI Home / Web Dashboard | Severity understood; Attention empty or accepted |
+| Health | TUI keys / Web Health actions / `doctor` | Models OK, validate clean |
+| Bible | Web wizard / `create-bible` / Cockpit | Project state + stack locked |
+| DNA | Web DNA / Cockpit / `dna *` | Cast locked; inject ready |
+| Produce stills | CLI / Web Imagine | Plates approved/locked |
+| Video spend | CLI (`--strict-*`) | Plate + motion pass; no silent NSFW |
+| Handoff | CLI agent-handoff / Tools bridge | Packet validates; return_path set |
+| Deliver | `sequence polish` / `deliver` | Soft delivery readiness green; masters built |
+
+---
+
+## 10. Quick commands
+
+```bash
+# Orient
+cinematic-studio ui
+cinematic-studio ui --print
+cinematic-studio dashboard --compact
+streamlit run web_ui/app.py
+
+# Health
+cinematic-studio doctor --quick
+cinematic-studio models verify
+
+# Produce
+cinematic-studio create-bible "Title" --wizard
+cinematic-studio dna init "Hero" && cinematic-studio dna lock hero
+cinematic-studio sequence init "Act 1"
+
+# Gate + spend
+cinematic-studio sfw plate set … --status locked …
+cinematic-studio sfw motion set … --action … --camera … --emotion …
+cinematic-studio sfw run … --strict-plate --strict-motion
+
+# Converge
+cinematic-studio imagine agent-handoff … --strict-handoff -f json -o artifacts/handoff.json
+cinematic-studio handoff validate artifacts/handoff.json --strict-handoff
+
+# Deliver (preview then real)
+cinematic-studio sequence polish "Act 1" --dry-run
+cinematic-studio sequence deliver "Act 1" --dry-run
+```
+
+---
+
+## 11. Related docs
+
+| Doc | Use |
+|-----|-----|
+| [CLI Reference](../CLI_REFERENCE.md) | Full Typer command tree |
+| [Quick Start](Quick_Start_Guide.md) | First-session loop |
+| [User Guide](USER_GUIDE.md) | End-to-end production |
+| [Streamlit Cloud](streamlit_cloud_deploy.md) | Hosted Web UI caveats |
+| [Architecture](../ARCHITECTURE.md) | System layers |
+| North-star design | `docs/development/superpowers/specs/2026-07-26-operator-ux-north-star-design.md` |
+| Imagine handoff protocol | `references/agents/IMAGINE_AGENT_MODE_HANDOFF_v3.7.1.md` |
+| Identity continuity | `references/agents/IDENTITY_CONTINUITY_PROTOCOL_v3.8.md` |
+
+---
+
+*Operator UX control plane guide — studio v3.8.9 · shared snapshot across CLI · TUI · Web.*

--- a/docs/guides/Quick_Start_Guide.md
+++ b/docs/guides/Quick_Start_Guide.md
@@ -190,7 +190,8 @@ Before long generations, run the **control plane** loop (same signals on TUI Hom
 5. **Gate (Phase 2)** — Check Dashboard **READINESS** (identity · chain QA · plate/motion). On No-Go: fix → re-QA before extend. After DNA lock / sequence handoff: `cinematic-studio handoff validate <path>` (TUI Launcher/Cockpit or Web Tools).
 6. **Converge & deliver (Phase 3)** — Dashboard **Convergence** checklist before agent-mode handoff; **Parallel Brief** logs (`wave-a briefs`); **Delivery** polish/deliver readiness; preview bridge via `imagine bridge` or Web Tools (paste to grok.com/imagine). TUI Cockpit: polish/deliver **--dry-run** only.
 
-North-star: `docs/development/superpowers/specs/2026-07-26-operator-ux-north-star-design.md` (Phases 1–3).
+Operator guide (snapshot · gates · surfaces): `docs/guides/Operator_UX_Control_Plane.md`.  
+North-star design: `docs/development/superpowers/specs/2026-07-26-operator-ux-north-star-design.md` (Phases 1–3).
 
 ---
 

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -3,6 +3,7 @@
 | Guide | Description |
 |-------|-------------|
 | [docs/guides/Quick_Start_Guide.md](Quick_Start_Guide.md) | Onboarding and first production |
+| [Operator_UX_Control_Plane.md](Operator_UX_Control_Plane.md) | Shared snapshot · TUI/Web/CLI control plane · gates · handoffs |
 | [docs/guides/UPGRADE_GUIDE.md](UPGRADE_GUIDE.md) | Migrating between studio versions |
 | [installation_guide.md](installation_guide.md) | Install CLI, plugin, Grok Build config |
 | [install_comfyui_grok_build.md](install_comfyui_grok_build.md) | Use Grok Build to install and set up ComfyUI |

--- a/docs/guides/USER_GUIDE.md
+++ b/docs/guides/USER_GUIDE.md
@@ -112,7 +112,8 @@ cinematic-studio ui                    # Interactive TUI
 cinematic-studio validate
 ```
 
-See [CLI Reference](../CLI_REFERENCE.md) for the full command set.
+See [CLI Reference](../CLI_REFERENCE.md) for the full command set.  
+Control plane (snapshot · TUI/Web · gates): [Operator UX](Operator_UX_Control_Plane.md).
 
 ---
 
@@ -132,6 +133,7 @@ See [CLI Reference](../CLI_REFERENCE.md) for the full command set.
 
 - Role Cards: `references/agents/`
 - Quick Start: `docs/guides/Quick_Start_Guide.md`
+- Operator UX: `docs/guides/Operator_UX_Control_Plane.md`
 - Architecture: `docs/ARCHITECTURE.md`
 - Issues / Discussions: GitHub repository
 

--- a/tools/cinematic_studio_cli.py
+++ b/tools/cinematic_studio_cli.py
@@ -33,7 +33,7 @@ app = typer.Typer(
     name="cinematic-studio",
     help=(
         f"🎥 Grok Imagine Cinematic Studio v{STUDIO_VERSION} — "
-        "Grok 4.5 cinematic+Build · optional 4.3 1M · Imagine 1.0/1.5 · 23-agent CLI"
+        "Grok 4.5 cinematic+Build · optional 4.3 1M · Imagine 1.0/1.5 · 25-agent core CLI"
     ),
     add_completion=False,
     rich_markup_mode="rich",

--- a/tools/cli/production.py
+++ b/tools/cli/production.py
@@ -79,7 +79,7 @@ def build_activation_prompt(
 
 {chr(10).join(meta_lines)}
 
-You are now running the full **23-agent** Grok Imagine Cinematic Studio **v{STUDIO_VERSION}** with complete Role Cards from `references/agents/`.
+You are now running the full **25-agent core** Grok Imagine Cinematic Studio **v{STUDIO_VERSION}** with complete Role Cards from `references/agents/`.
 
 **Model Layer (Grok 4.5):** orchestration + Build default **`grok-4.5`**; optional **`grok-4.3`** only for 1M-context Bibles/memory banks. Imagine video **1.0** cost default; **1.5** when native audio is required. Prefer stable `prompt_cache_key` (project slug). Reasoning **high** for Bibles, QA, Identity Lock, and Sequence Director.
 

--- a/tools/cli/report_commands.py
+++ b/tools/cli/report_commands.py
@@ -52,7 +52,7 @@ def register(app: typer.Typer) -> None:
         pdf.cell(
             0,
             8,
-            f"Status: Production in progress — studio v{STUDIO_VERSION} · Grok 4.5 · 23-agent core",
+            f"Status: Production in progress — studio v{STUDIO_VERSION} · Grok 4.5 · 25-agent core",
             ln=True,
         )
 

--- a/tools/cli/studio_commands.py
+++ b/tools/cli/studio_commands.py
@@ -146,7 +146,7 @@ def register(app: typer.Typer) -> None:
 
     @app.command(name="list-agents")
     def list_agents():
-        """List all agents grouped by category (Role Card labels · studio v3.7.1)."""
+        """List all agents grouped by category (Role Card labels · studio v3.8.9)."""
         table = Table(
             title=(
                 f"🎬 Grok Imagine Cinematic Studio v{STUDIO_VERSION} — "


### PR DESCRIPTION
## Summary
- Expand `docs/CLI_REFERENCE.md` to the live Typer tree (sequence nested tools, sfw/nsfw plate·motion, wave-a, handoff validate, TUI `--print`, meta installer).
- Fix incorrect `validate --strict-handoff` guidance (strict flags on `handoff validate` / `imagine agent-handoff`).
- Retire stale **23-agent** strings → **25-agent core** (CLI help, activation, PDF report, `/cinematic`).
- Add **`docs/guides/Operator_UX_Control_Plane.md`** — shared studio snapshot, TUI/Web density, spend gates, handoffs, multi-surface operator loop.
- Cross-link from docs index, Quick Start, User Guide, Official Overview, CLI Reference; CHANGELOG Unreleased notes.

## Test plan
- [x] CLI `--help` shows 25-agent core
- [ ] Skim Operator UX guide against TUI Home / Web Dashboard / CLI
- [ ] Confirm links resolve from docs/README.md and guides/README.md