### PR TITLE
fix(spend): map i2v mode aliases for plate/motion gates

### DIFF
--- a/.grok/skills/cinematic-studio-meta-installer/SKILL.md
+++ b/.grok/skills/cinematic-studio-meta-installer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cinematic-studio-meta-installer
-description: Meta installer for Grok Imagine Cinematic Studio v3.8.9. Installs updates and verifies the full 54-skill suite plus CLI tools Grok Build config and marketplace multi-plugin packs into Grok with unified Grok 4.5 cinematic+Build stack and dual Imagine Video 1.0 + 1.5 Native. Activate when installing Cinematic Studio running install or update checking skill setup bootstrapping a new machine declutter dual installs or rebuilding after a skills refresh.
+description: Meta installer for Grok Imagine Cinematic Studio v3.8.9. Installs updates and verifies the full 62-skill suite plus CLI tools Grok Build config and marketplace multi-plugin packs into Grok with unified Grok 4.5 cinematic+Build stack and dual Imagine Video 1.0 + 1.5 Native. Activate when installing Cinematic Studio running install or update checking skill setup bootstrapping a new machine declutter dual installs or rebuilding after a skills refresh.
 ---
 
 # Cinematic Studio Meta Installer v3.8.9 (Grok 4.5 · Meta Installer)
@@ -39,14 +39,14 @@ Always begin: **"Starting Cinematic Studio Meta Installer v3.8.9…"**
 
 ## Install Methods (choose one)
 
-Both methods can ship the same **54 skills** (plugin suite). They differ in **where** skills live, **what else** gets installed, and **how you update**. As of **v3.8.0+**, Method B also exposes **modular packs** (full suite recommended + 5 satellites).
+Both methods can ship the same **62 skills** (plugin suite). They differ in **where** skills live, **what else** gets installed, and **how you update**. As of **v3.8.0+**, Method B also exposes **modular packs** (full suite recommended + 5 satellites).
 
 | | **Method A — Meta installer / zip** | **Method B — Grok plugin** |
 |---|-------------------------------------|----------------------------|
 | **Best for** | Grok chat, agent bootstrap, CLI tools, local verify | Grok Build CLI, marketplace updates, slash commands |
 | **Command** | `cinematic_studio.sh install` (curl, local repo, or zip) | `grok plugin install FineComputer14451/Grok-Imagine-Cinematic-Studio --trust` |
 | **Skills path** | `~/.grok/skills/` | Plugin-managed under `~/.grok/installed-plugins/` |
-| **Also installs** | `~/Grok-Cinematic-Projects/` — references, `tools/`, `config/`, scripts; **ensures Grok Build CLI binary** (`grok` ≥ 0.2.93 via `x.ai/cli/install.sh` / `grok update`) + `cinematic-studio` / `grok-doctor` wrappers | Full suite: **54 skills + slash commands**; or modular packs (see matrix) |
+| **Also installs** | `~/Grok-Cinematic-Projects/` — references, `tools/`, `config/`, scripts; **ensures Grok Build CLI binary** (`grok` ≥ 0.2.93 via `x.ai/cli/install.sh` / `grok update`) + `cinematic-studio` / `grok-doctor` wrappers | Full suite: **62 skills + slash commands**; or modular packs (see matrix) |
 | **Verify** | `bash scripts/cinematic_studio.sh verify` or `verify --all` | `bash scripts/cinematic_studio.sh verify --plugin` or `grok plugin details grok-imagine-cinematic-studio` |
 | **Update** | `bash scripts/cinematic_studio.sh update` | `grok plugin update grok-imagine-cinematic-studio` |
 
@@ -58,12 +58,12 @@ Both methods can ship the same **54 skills** (plugin suite). They differ in **wh
 
 | Plugin name | Pack id | Skills | Soft requires | Role |
 |-------------|---------|--------|---------------|------|
-| **`grok-imagine-cinematic-studio`** | *(full suite)* | **54** | — | **Recommended** one-click install |
-| `grok-imagine-cinematic-core` | `core` | **20** | — | Orchestration / DNA / wardrobe / Imagine / QA / quota / meta |
-| `grok-imagine-camera-image` | `camera-image` | 9 | `core` | DoP, design, i2i, key art, i2v |
-| `grok-imagine-sequence-narrative` | `sequence-narrative` | 16 | `core` | Sequence, continuity, performance, audio, action/VFX, SFW |
+| **`grok-imagine-cinematic-studio`** | *(full suite)* | **62** | — | **Recommended** one-click install |
+| `grok-imagine-cinematic-core` | `core` | **21** | — | Orchestration / DNA / wardrobe / Imagine / QA / quota / meta |
+| `grok-imagine-camera-image` | `camera-image` | **11** | `core` | DoP, design, i2i, key art, i2v |
+| `grok-imagine-sequence-narrative` | `sequence-narrative` | **19** | `core` | Sequence, continuity, performance, audio, action/VFX, SFW |
 | `grok-imagine-nsfw` | `nsfw` | 4 | `core` | Opt-in NSFW (ErosForge + NSFW QA/quota) |
-| `grok-imagine-delivery-post` | `delivery-post` | 5 | `core` | Assembly, color, polish, upscale, ffmpeg |
+| `grok-imagine-delivery-post` | `delivery-post` | **7** | `core` | Assembly, color, polish, upscale, ffmpeg |
 
 Source of truth: `config/plugin_packs.yaml`. List: `cinematic-studio plugin packs` (needs CLI / Method A or clone).
 
@@ -212,7 +212,7 @@ Auth: export `XAI_API_KEY` or first-run login. TUI/headless: **`grok-build-runne
 
 ### Declutter rules (v3.8.0+)
 
-1. **Method A + Method B:** removes Method A copies of the **54** studio skills (plugin keeps them); prunes old `~/.grok/skills-backup-*`. User-global skills (`help`, `create-skill`, …) stay in `~/.grok/skills/`.
+1. **Method A + Method B:** removes Method A copies of the **62** studio skills (plugin keeps them); prunes old `~/.grok/skills-backup-*`. User-global skills (`help`, `create-skill`, …) stay in `~/.grok/skills/`.
 2. **Full suite + satellite packs (`full_suite_wins`):** when both the full suite plugin and one or more satellite packs are installed, declutter prefers the full suite and removes satellite skill dupes (`config/plugin_packs.yaml` → `declutter.policy: full_suite_wins`).
 
 Always dry-run first when the user is unsure: `declutter --dry-run`.
@@ -297,13 +297,13 @@ If network install fails, use the release zip:
 
 `grok-imagine-cinematic-studio`, `ai-video-upscaler`, `cinematic-sequence-extender`, `studio-director`, `quality-assurance-guardian`, `identity-lock-specialist`, `workflow-quota-optimizer`
 
-Full list: `scripts/required_skills.manifest` (54 skills; same set as `.grok-plugin/plugin-index.json` after catalog pin).
+Full list: `scripts/required_skills.manifest` (62 skills; same set as `.grok-plugin/plugin-index.json` after catalog pin).
 
 **Verify tiers:**
 
 - **core** (default) — 7 `# core` skills + `models verify`
-- **all** — all 54 manifest skills in `~/.grok/skills/` (Method A)
-- **plugin** — all 54 skills + slash commands in the Grok plugin checkout (Method B)
+- **all** — all 62 manifest skills in `~/.grok/skills/` (Method A)
+- **plugin** — all 62 skills + slash commands in the Grok plugin checkout (Method B)
 
 ## Handoff After Install
 

--- a/.grok/skills/cinematic-studio-meta-installer/references/install_paths.md
+++ b/.grok/skills/cinematic-studio-meta-installer/references/install_paths.md
@@ -17,7 +17,7 @@ Studio release: **v3.8.6** (`VERSION`)
 
 ## Install Methods
 
-Both paths can deliver the same skill suite (`scripts/required_skills.manifest` ≡ `.grok-plugin/plugin-index.json`, **52 skills** in-tree). Method B marketplace install resolves to the **catalog pin SHA** in `.grok-plugin/marketplace.json` — skill count matches the tree only **after** `cinematic-studio plugin catalog pin` (or equivalent) for this branch. Method B also lists **6 marketplace plugins** (full suite + 5 packs) from `config/plugin_packs.yaml`.
+Both paths can deliver the same skill suite (`scripts/required_skills.manifest` ≡ `.grok-plugin/plugin-index.json`, **62 skills** in-tree). Method B marketplace install resolves to the **catalog pin SHA** in `.grok-plugin/marketplace.json` — skill count matches the tree only **after** `cinematic-studio plugin catalog pin` (or equivalent) for this branch. Method B also lists **6 marketplace plugins** (full suite + 5 packs) from `config/plugin_packs.yaml`.
 
 ### Method A — Meta installer / release zip
 
@@ -52,7 +52,7 @@ grok plugin install grok-imagine-cinematic-studio@finecomputer14451/grok-imagine
 
 | Plugin | Pack id | Role |
 |--------|---------|------|
-| `grok-imagine-cinematic-studio` | full suite (52 in-tree; pin SHA may lag) | Recommended |
+| `grok-imagine-cinematic-studio` | full suite (62 in-tree; pin SHA may lag) | Recommended |
 | `grok-imagine-cinematic-core` | `core` | Orchestration base |
 | `grok-imagine-camera-image` | `camera-image` | Camera / image |
 | `grok-imagine-sequence-narrative` | `sequence-narrative` | Sequence / narrative |

--- a/.grok/skills/grok-imagine-cinematic-studio/SKILL.md
+++ b/.grok/skills/grok-imagine-cinematic-studio/SKILL.md
@@ -145,7 +145,7 @@ Studio Director **owns** surface selection and must not hand off video without I
 - NSFW via ErosForge + `nsfw-quota-orchestrator` + `nsfw-sequence-extender` (explicit only)
 - Quota-aware production with xAI per-second pricing (`workflow-quota-optimizer`)
 - **Grok 4.5 / v9-4p5 model stack** — CLI `grok-4.5` (min 0.2.93) / fork `grok-build`; opt-in `grok-v9-4p5-multi` / `grok-v9-4p5-chat-expert` / `grok-4-auto`; 1M `grok-4.3`; Imagine 1.0 default + 1.5 native audio (`tools/models.py`, `references/agents/MODEL_LAYER_v4.5.md`)
-- Plugin marketplace (54 skills + 11 commands) with release-pin hygiene
+- Plugin marketplace (62 skills + 11 commands) with release-pin hygiene
 - Authoritative Role Cards in `references/agents/` (each embeds Model Layer Grok 4.5)
 
 ## Quick Commands

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -212,7 +212,7 @@ If native Imagine tools are unavailable, use `imagine-execution-bridge` / CLI (`
 
 ### Document Tasks
 
-Document skills are typically **session / user-global** (not always in the 54-skill project suite). Use when available:
+Document skills are typically **session / user-global** (not always in the 62-skill project suite). Use when available:
 
 - PDF: `pdf` skill
 - Word (.docx): `docx` skill
@@ -370,7 +370,7 @@ Entry points by task (not exhaustive). Prefer slugs; full map = `AGENT_INDEX.md`
 | **GitHub Management** | `github-repo-manager` | Git lifecycle, PRs, releases, skill/plugin catalog pin hygiene |
 | **Documents** | `pdf`, `docx`, `pptx`, `xlsx` | Professional docs (session skills when available) |
 | **Memory** | `memory-edit` | Personal facts/preferences worth remembering |
-| **Grok Plugin & Meta** | `cinematic-studio-meta-installer` | Bootstrap/install/update the full **54-skill** suite (v3.8.9; packs + declutter `full_suite_wins`) |
+| **Grok Plugin & Meta** | `cinematic-studio-meta-installer` | Bootstrap/install/update the full **62-skill** suite (v3.8.9; packs + declutter `full_suite_wins`) |
 | **Localization** | `localization-subtitle-specialist` | SDH, multi-language, cultural adaptation |
 | **Production Bible** | `production-bible-workflow` | Guided create-bible / DNA / sequence / quota onboarding |
 
@@ -382,7 +382,7 @@ Entry points by task (not exhaustive). Prefer slugs; full map = `AGENT_INDEX.md`
 - Plugin marketplace lives in `.grok-plugin/` (full suite + 5 packs, **62 skills** + commands; Wave A P0 included). Install full suite via `grok plugin install FineComputer14451/Grok-Imagine-Cinematic-Studio --trust`.
 - Workspace supports SFW cinematic work and NSFW/erotic pipelines (**ErosForge only when explicitly activated**).
 - **Model stack:** cinematic + Build/coding registry default **`grok-4.5`**; specialist routing **v9-4p5 / grok-4-auto** when available; optional 1M **`grok-4.3`**; Imagine **1.0** default; `VIDEO_PIPELINE_SPEC` via registry helpers; **1.5** for native-audio / high-physics / intimacy workflows.
-- Full suite: **54/54** skills + Role Cards (includes `grok-doctor`, `multi-clip-continuity-orchestrator`, `ai-image-recreation`).
+- Full suite: **62/62** skills + Role Cards (includes `grok-doctor`, `multi-clip-continuity-orchestrator`, `ai-image-recreation`).
 - **Recent history:** **3.8.9** — TUI + Streamlit compact/ops/full view modes. **3.8.8** — Operator UX control plane (density · readiness · convergence · delivery · handoff validate). **3.8.7** — Wave A · Parallel Brief Protocol · Grok Doctor · Multi-Clip Continuity. **3.8.6** — dual-model polish pin. **3.8.4** — interactive CLI TUI. **3.8.1** — Identity Continuity. **3.8.0** — plugin packs. **3.7.1** — Imagine Agent Mode Handoff.
 - Keep this `AGENTS.md` in sync with the GitHub repository and other canonical docs (README, CHANGELOG, `docs/releases/`, `references/MODELS.md`, `references/agents/MODEL_LAYER_v4.5.md`, `docs/guides/Quick_Start_Guide.md`).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,7 @@ All notable changes to Grok Imagine Cinematic Studio will be documented in this 
 
 ### Changed
 - **Studio version** — `VERSION` → **3.8.7**; activation `Activate Grok Imagine Cinematic Studio v3.8.7`
-- **Suite size** — **54 skills** · **25** Role-Card core agents; packs core **20**, sequence-narrative **16**
+- **Suite size** — **62 skills** · **25** Role-Card core agents; packs core **21**, camera-image **11**, sequence-narrative **19**, nsfw **4**, delivery-post **7**
 - Handoff `PROTOCOL_OK` includes **3.8.7**; `STUDIO_COMPATIBILITY_VERSION` / agent version stamps aligned
 - Grok Doctor prefers full git clone when present; quota recon + catalog pin checks hardened
 - Quota cascade / dashboard / TUI alignment improvements (ledger-backed recon)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to Grok Imagine Cinematic Studio will be documented in this 
 
 ## [Unreleased]
 
+### Fixed
+- **Spend-gate mode aliases** — `resolve_execution_mode` maps batch shorthand (`i2v`, `still`, `video`, …) to official modes so plate/motion readiness no longer silently skips when shots only set `recommended_mode: "i2v"`
+
 ### Changed
 - **TUI command palette** — `/` or Ctrl+P opens allowlisted action search; KPI bar under status strip; `y` saves orient brief to `artifacts/tui_orient_brief.txt`; scroll preserved on refresh
 - **TUI non-TTY fallback** — `cinematic-studio ui --print` (and bare `ui` without a TTY) prints the orient dashboard instead of hard-failing; optional `artifacts/tui_orient_brief.txt`

--- a/MASTER_PROMPT.md
+++ b/MASTER_PROMPT.md
@@ -3,7 +3,7 @@
 **The most advanced multi-agent cinematic production system for Grok Build 0.2.93+ · Grok 4.5 (cinematic + coding default) · optional Grok 4.3 (1M) · Grok Imagine Video (1.0 default; 1.5 native audio available)**
 
 **Version:** 3.8.9 "Odyssey Native" (July 2026) — Full v4.5 Dual-Model Wave  
-**Agents:** 23 Specialized Agents with full v4.0 personalities (v3.6 upgrades for Imagine Video 1.5)  
+**Agents:** 25 Role-Card core agents with full v4.0 personalities (v3.6 upgrades for Imagine Video 1.5)  
 **Key Improvements:** Unified Grok 4.5 cinematic+Build default (optional Grok 4.3 1M), Grok Build ≥ 0.2.93, Imagine Video 1.0 default / 1.5 native audio, structured outputs, AUDIO_MOMENTUM_VECTOR, optimized prompt schemas, per-second video pricing.
 
 > [!NOTE]
@@ -13,13 +13,13 @@
 
 ## ✨ Current State (July 2026 — v3.8.9)
 
-- **23 Specialized Agents** with complete Role Cards in `references/agents/` (v3.6.5 labels; studio release **v3.8.9**)
+- **25 Role-Card core agents** with complete Role Cards in `references/agents/` (v3.6.5 labels; studio release **v3.8.9**)
 - **Authoritative Role Card System** — Core Mission, v3.6 upgrades (1.5 & unified Grok 4.5 stack), Decision Frameworks, Activation Triggers, Integration Notes
 - **Mature CLI + Web UI** — model pickers, native audio toggle, 720p/duration, live cost estimation, **Guided Production Bible wizard** (`create-bible --wizard` / Web Guided Bible Creator)
 - **Native Grok Imagine Video 1.5 Pipeline** — image-to-video, one-pass audio, extend/stitch, Fast mode (1.0 remains cost default)
 - **Grok Build + unified Grok 4.5 stack** — CLI default `grok-4.5` (fork `grok-build`, min CLI **0.2.93**); opt-in `grok-v9-4p5-multi` / `grok-v9-4p5-chat-expert` / `grok-4-auto`; optional 1M `grok-4.3`
 - **v4.5 Dual-Model Wave (v3.8.9)** — 16 core skills with dual Imagine Video 1.0 + 1.5 Native documentation and Role Cards (`references/agents/MODEL_LAYER_v4.5.md`)
-- **Plugin marketplace** — 54 skills + 11 commands; release-pin hygiene for catalog commits
+- **Plugin marketplace** — 62 skills + 11 commands; release-pin hygiene for catalog commits
 - v3.5 heritage retained: Memory Bank, LAST_FRAME_RECAP + MOMENTUM_VECTOR + AUDIO_MOMENTUM_VECTOR, 7-Metric Self-Improvement Loop
 
 ---

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
 
 It combines:
 
-- **52 specialized Grok skills** powering a **23+ agent cinematic department**
+- **62 specialized Grok skills** powering a **25-agent core** cinematic department
 - Professional **Production Bible** workflow (CLI wizard + Streamlit Web UI)
 - **Character DNA extraction + Identity Continuity Protocol** for zero-drift consistency across stills, clips, and long sequences
 - **Imagine Agent Mode Handoff** — validated routing from planning agents into Grok’s native generation surfaces
@@ -99,7 +99,7 @@ flowchart TB
     subgraph Tools["🛠️ Tools, CLI & Interfaces"]
         CLI["cinematic-studio CLI<br/>(models, dna, sequence, quota, nsfw, plugin...)"]
         WEBUI["Streamlit Web UI<br/>Guided Bible • DNA Bank • Cost Estimator"]
-        SKILLS["52 Custom Grok Skills<br/>(.grok/skills/)"]
+        SKILLS["62 Custom Grok Skills<br/>(.grok/skills/)"]
     end
 
     subgraph Execution["🎥 Execution Layer"]
@@ -170,7 +170,7 @@ Grok Imagine Cinematic Studio v3.8.9  (Studio Director + 23+ Agents · Grok 4.5 
 ├── examples/                     # Production Bible templates
 ├── MASTER_PROMPT.md              # Primary activation prompt (v3.8+ compatible)
 ├── scripts/                      # Release helpers & verify shims
-└── .grok/skills/                 # 52 custom Grok skills (runtime engine)
+└── .grok/skills/                 # 62 custom Grok skills (runtime engine)
 ```
 
 **Key v3.8.9 Components**
@@ -226,7 +226,7 @@ or the shorter trigger:
 start cinematic production
 ```
 
-This loads the full **23+ agent department** with Production Bible support, Imagine Agent Mode Handoff, identity locking, and all specialists.
+This loads the full **25-agent core** department with Production Bible support, Imagine Agent Mode Handoff, identity locking, and all specialists.
 
 ### 3. CLI Power Tools (Automation & Scripting)
 

--- a/commands/cinematic.md
+++ b/commands/cinematic.md
@@ -1,5 +1,5 @@
 ---
-description: Activate Grok Imagine Cinematic Studio v3.8.6 with the full 23-agent production suite, Grok 4.5 model stack, Imagine Agent Mode Handoff, and native Imagine Video 1.0/1.5 pipeline.
+description: Activate Grok Imagine Cinematic Studio v3.8.9 with the full 25-agent core production suite, Grok 4.5 model stack, Imagine Agent Mode Handoff, and native Imagine Video 1.0/1.5 pipeline.
 ---
 
 # Activate Cinematic Studio

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -62,7 +62,7 @@ Post-Production & Delivery (Color → Polish → Assets)
 
 ### 4. Runtime & Tools
 
-- **52 Skills** under `.grok/skills/`
+- **62 Skills** under `.grok/skills/`
 - **Unified CLI** (`cinematic-studio` / `tools/cinematic_studio_cli.py`)
 - **Streamlit Web UI** for guided Bible, DNA bank, quota, sequences
 - **Plugin Marketplace** (`.grok-plugin/`) with full suite + satellite packs

--- a/docs/OFFICIAL_OVERVIEW.md
+++ b/docs/OFFICIAL_OVERVIEW.md
@@ -26,7 +26,7 @@ It is not a simple prompt wrapper. It is a full **virtual film studio** with spe
 | Capability | Description |
 |------------|-------------|
 | **23+ Specialist Agents** | Studio Director, DoP, Sequence Director, Identity Lock, ErosForge, AI Polish, Sonic Architect, and more |
-| **52 Custom Grok Skills** | Full runtime engine under `.grok/skills/` |
+| **62 Custom Grok Skills** | Full runtime engine under `.grok/skills/` |
 | **Production Bible** | Guided wizard (CLI + Streamlit) with `VIDEO_PIPELINE_SPEC` |
 | **Character DNA + Identity Continuity** | Forensic extraction, lock, inject, and drift detection across stills and long sequences |
 | **Imagine Agent Mode Handoff** | Validated routing from planning agents into Grok’s native generation surfaces (Build tools / ACP / web / API) |

--- a/docs/REPOSITORY_LAYOUT.md
+++ b/docs/REPOSITORY_LAYOUT.md
@@ -1,4 +1,4 @@
-# Repository Layout — v3.7.1 · Grok 4.5
+# Repository Layout — v3.8.9 · Grok 4.5
 
 Canonical map of the Grok Imagine Cinematic Studio monorepo. Runtime paths used by the CLI are fixed in `tools/studio_paths.py`.
 
@@ -18,7 +18,7 @@ Canonical map of the Grok Imagine Cinematic Studio monorepo. Runtime paths used 
 ## First-class packages
 
 ```
-.grok/skills/          # 48 studio skills (agent-only SKILL.md)
+.grok/skills/          # 62 studio skills (agent-only SKILL.md)
 .grok-plugin/          # marketplace.json, plugin.json, plugin-index.json
 commands/              # Slash commands for Grok Build plugin
 tools/                 # CLI + libraries (models.py is stack registry)

--- a/docs/guides/Quick_Start_Guide.md
+++ b/docs/guides/Quick_Start_Guide.md
@@ -1,7 +1,7 @@
 # Grok Imagine Cinematic Studio v3.8.9 — Quick Start Guide
 
 **Version:** 3.8.9 | **Last Updated:** July 23, 2026  
-**Suite:** 25 Role-Card core agents · **54 skills** · marketplace full suite + 5 packs
+**Suite:** 25 Role-Card core agents · **62 skills** · marketplace full suite + 5 packs
 
 > [!NOTE]
 > **Grok Imagine Cinematic Studio** is an **independent community project**. It is **not affiliated with, endorsed by, sponsored by, or officially connected to xAI**. Grok / Imagine access, quotas, and billing remain solely with your xAI (or host) account. Full notice: [DISCLAIMER.md](../../DISCLAIMER.md).
@@ -64,7 +64,7 @@ start cinematic production
 
 For a full lock-in on the web, paste `MASTER_PROMPT.md` first, then Activate.
 
-This loads the complete **v3.8.9** system: unified Grok 4.5 cinematic+Build stack (optional 4.3 1M), dual Imagine Video 1.0/1.5, guided Bible wizard, Imagine Agent Mode Handoff, Identity Continuity, and the **54-skill** suite.
+This loads the complete **v3.8.9** system: unified Grok 4.5 cinematic+Build stack (optional 4.3 1M), dual Imagine Video 1.0/1.5, guided Bible wizard, Imagine Agent Mode Handoff, Identity Continuity, and the **62-skill** suite.
 
 ### Start a New Project
 
@@ -247,7 +247,7 @@ North-star: `docs/development/superpowers/specs/2026-07-26-operator-ux-north-sta
 | **Identity Continuity**         | `references/agents/IDENTITY_CONTINUITY_PROTOCOL_v3.8.md` | Long-form drift gates            |
 | **Skills taxonomy / packs**     | `references/SKILLS_TAXONOMY.md`       | Groups, packs, declutter rules                    |
 | **Master Prompt**               | `MASTER_PROMPT.md`                    | Complete master prompt for new chats              |
-| **Skill Files**                 | `.grok/skills/`                       | 54-skill suite (agent-only; no README in skill dirs) |
+| **Skill Files**                 | `.grok/skills/`                       | 62-skill suite (agent-only; no README in skill dirs) |
 | **Production Bible Template**   | `docs/templates/Project_Bible_Template.md` | Professional Bible template                  |
 | **Install guide**               | `docs/guides/installation_guide.md`   | Method A / B + packs                              |
 | **CLI Toolkit**                 | `cinematic-studio` / `tools/cinematic_studio_cli.py` | Bible, DNA, sequence, catalog, doctor    |
@@ -261,4 +261,4 @@ Just say **"Activate Grok Imagine Cinematic Studio v3.8.9"** and begin.
 
 ---
 
-*Grok Imagine Cinematic Studio v3.8.9 — Grok 4.5 / Model Layer v4.5 · 54 skills · July 2026*
+*Grok Imagine Cinematic Studio v3.8.9 — Grok 4.5 / Model Layer v4.5 · 62 skills · July 2026*

--- a/docs/guides/UPGRADE_GUIDE.md
+++ b/docs/guides/UPGRADE_GUIDE.md
@@ -1,8 +1,8 @@
 # Grok Imagine Cinematic Studio — UPGRADE GUIDE
 
-**Current target:** **v3.8.7** — unified **Grok 4.5** cinematic+Build · Model Layer v4.5 (v9-4p5 / `grok-4-auto`) · optional **Grok 4.3** 1M · Imagine Agent Mode Handoff · Identity Continuity · **54 skills** · packs + `full_suite_wins`
+**Current target:** **v3.8.9** — unified **Grok 4.5** cinematic+Build · Model Layer v4.5 (v9-4p5 / `grok-4-auto`) · optional **Grok 4.3** 1M · Imagine Agent Mode Handoff · Identity Continuity · **62 skills** · packs + `full_suite_wins`
 
-**Quick path to current:** pull `main` → `models verify` → reinstall plugin if local clone is stale → activate `Activate Grok Imagine Cinematic Studio v3.8.7`  
+**Quick path to current:** pull `main` → `models verify` → reinstall plugin if local clone is stale → activate `Activate Grok Imagine Cinematic Studio v3.8.9`  
 **Day-to-day docs:** `docs/guides/Quick_Start_Guide.md` · `docs/guides/installation_guide.md` · `references/agents/MODEL_LAYER_v4.5.md`
 
 **Date:** July 23, 2026 (header); sections below retain historical upgrade notes from earlier 3.7.x waves.
@@ -14,7 +14,7 @@
 1. Pull / reinstall: `git pull` or `bash scripts/cinematic_studio.sh update` / reinstall Method B from clone if `plugin update` no-ops on local installs  
 2. Confirm `VERSION` is **3.8.7** and `python tools/cinematic_studio_cli.py models verify` shows Grok **4.5** cinematic+Build  
 3. Set `~/.grok/config.toml`: `[models] default = "grok-4.5"` · `[ui] fork_secondary_model = "grok-build"`  
-4. Activation: `Activate Grok Imagine Cinematic Studio v3.8.7`  
+4. Activation: `Activate Grok Imagine Cinematic Studio v3.8.9`  
 5. Model Layer: `references/agents/MODEL_LAYER_v4.5.md` (not the archived `MODEL_LAYER_v3.7.1.md`)  
 6. Contributors: content commit → `bash scripts/release_plugin_catalog.sh` → commit only `.grok-plugin/` → `bash scripts/verify_plugins.sh --release`
 
@@ -25,7 +25,7 @@
 1. Pull / reinstall the repo or run `bash scripts/cinematic_studio.sh update` / `grok plugin update grok-imagine-cinematic-studio`
 2. Confirm models verify shows Grok **4.5** cinematic+Build
 3. Set `~/.grok/config.toml` defaults: `[models] default = "grok-4.5"` · `[ui] fork_secondary_model = "grok-build"`
-4. Activation phrase: `Activate Grok Imagine Cinematic Studio v3.8.7` (current) — historical 3.7.1 phrase is obsolete
+4. Activation phrase: `Activate Grok Imagine Cinematic Studio v3.8.9` (current) — historical 3.7.1 phrase is obsolete
 5. Prefer `references/agents/MODEL_LAYER_v4.5.md` and `IMAGINE_AGENT_MODE_HANDOFF_v3.7.1.md` (handoff feature still current under studio 3.8.7)
 6. Re-pin plugin catalog after skill edits: `bash scripts/release_plugin_catalog.sh`
 
@@ -137,7 +137,7 @@ python tools/cinematic_studio_cli.py models verify
 ### Step 2: Activate the New Studio
 In a new **Grok 4.5** chat (default) or **Grok 4.3** for very long Bibles, paste `MASTER_PROMPT.md` and type:
 ```
-Activate Grok Imagine Cinematic Studio v3.8.7
+Activate Grok Imagine Cinematic Studio v3.8.9
 ```
 
 Or use the powerful new mode:
@@ -192,7 +192,7 @@ Free-text logline/characters/world/tech notes roll into `notes`. Stages live in 
 
 ## Recommended New Workflow (v3.7.1)
 
-1. **Primary Activation** — `Activate Grok Imagine Cinematic Studio v3.8.7` or `ACTIVATE IMAGINE_VIDEO_1.5_FULL`
+1. **Primary Activation** — `Activate Grok Imagine Cinematic Studio v3.8.9` or `ACTIVATE IMAGINE_VIDEO_1.5_FULL`
 2. **Production Bible** — `create-bible "Title"` (scripts) or `create-bible --wizard` (guided TTY) / Web Guided Bible Creator
 3. **Use VIDEO_PIPELINE_SPEC** — 1.0 cost default; 1.5 when native audio is required
 4. **Activate Sonic Architect early** when native audio is important

--- a/docs/guides/installation_guide.md
+++ b/docs/guides/installation_guide.md
@@ -1,6 +1,6 @@
-# Grok Imagine Cinematic Studio v3.8.7 — Installation Guide
+# Grok Imagine Cinematic Studio v3.8.9 — Installation Guide
 
-Two supported install paths. Both can ship the same **54 skills**; choose based on how you use Grok. As of **v3.8.0**, Method B also exposes **modular packs** (full suite recommended + 5 satellites).
+Two supported install paths. Both can ship the same **62 skills**; choose based on how you use Grok. As of **v3.8.0**, Method B also exposes **modular packs** (full suite recommended + 5 satellites).
 
 > [!NOTE]
 > **Grok Imagine Cinematic Studio** is an **independent community project**. It is **not affiliated with, endorsed by, sponsored by, or officially connected to xAI**. Installing this suite installs community skills and tooling only — it does not provision xAI models or API access. Full notice: [DISCLAIMER.md](../../DISCLAIMER.md).
@@ -11,11 +11,11 @@ Two supported install paths. Both can ship the same **54 skills**; choose based 
 |---|-------------------------------------|----------------------------|
 | **Best for** | Grok chat, agent sessions, CLI tools, scripted verify | Grok Build CLI, marketplace updates, slash commands |
 | **Skills location** | `~/.grok/skills/` | `~/.grok/installed-plugins/` (plugin-managed) |
-| **Also installs** | `~/Grok-Cinematic-Projects/` — references, `tools/`, `config/`, scripts | Full suite: **54 skills** + 11 slash commands; or modular packs (see matrix) |
+| **Also installs** | `~/Grok-Cinematic-Projects/` — references, `tools/`, `config/`, scripts | Full suite: **62 skills** + 11 slash commands; or modular packs (see matrix) |
 | **Verify** | `cinematic_studio.sh verify` / `verify --all` | `cinematic_studio.sh verify --plugin` or `grok plugin details grok-imagine-cinematic-studio` |
 | **Update** | `cinematic_studio.sh update` | `grok plugin update grok-imagine-cinematic-studio` (or reinstall from a local clone — see below) |
 
-You can use **both**, but **do not dual-load the 54 studio skills**:
+You can use **both**, but **do not dual-load the 62 studio skills**:
 
 | Goal | Use |
 |------|-----|
@@ -30,11 +30,11 @@ bash scripts/cinematic_studio.sh declutter --dry-run
 bash scripts/cinematic_studio.sh declutter --apply --keep-backups 1
 ```
 
-That removes Method A copies of the 54 studio skills (plugin keeps them) and prunes old `~/.grok/skills-backup-*` folders. User-global skills (`help`, `create-skill`, `docx`, …) stay in `~/.grok/skills/`.
+That removes Method A copies of the 62 studio skills (plugin keeps them) and prunes old `~/.grok/skills-backup-*` folders. User-global skills (`help`, `create-skill`, `docx`, …) stay in `~/.grok/skills/`.
 
 **Pack overlap (`full_suite_wins`):** if both the **full suite** plugin and one or more **satellite packs** are installed, declutter prefers the full suite and removes satellite skill duplicates (`config/plugin_packs.yaml` → `declutter.policy: full_suite_wins`).
 
-**Skill parity:** `scripts/required_skills.manifest` lists the same **54** skills as `.grok-plugin/plugin.json` / catalog generation.  
+**Skill parity:** `scripts/required_skills.manifest` lists the same **62** skills as `.grok-plugin/plugin.json` / catalog generation.  
 **Taxonomy (browse groups):** `references/SKILLS_TAXONOMY.md` · `cinematic-studio plugin list --grouped` · `cinematic-studio plugin packs`
 
 ### Path overrides (Method A)
@@ -172,7 +172,7 @@ Creates a timestamped backup at `~/.grok/skills-backup-*` before replacing skill
 
 ```bash
 ./scripts/cinematic_studio.sh verify          # core skills (7) + model registry
-./scripts/cinematic_studio.sh verify --all    # full manifest (54 skills)
+./scripts/cinematic_studio.sh verify --all    # full manifest (62 skills)
 ```
 
 Legacy wrapper: `./scripts/verify_cinematic_studio.sh`
@@ -193,12 +193,12 @@ Legacy wrapper: `./scripts/verify_cinematic_studio.sh`
 
 | Plugin name | Pack id | Skills | Soft requires | Role |
 |-------------|---------|--------|---------------|------|
-| **`grok-imagine-cinematic-studio`** | *(full suite)* | **54** | — | **Recommended** one-click install |
-| `grok-imagine-cinematic-core` | `core` | **20** | — | Orchestration / DNA / wardrobe / Imagine / QA / quota / meta |
-| `grok-imagine-camera-image` | `camera-image` | 9 | `core` | DoP, design, i2i, key art, i2v |
-| `grok-imagine-sequence-narrative` | `sequence-narrative` | 16 | `core` | Sequence, continuity, performance, audio, action/VFX, SFW |
-| `grok-imagine-nsfw` | `nsfw` | 4 | `core` | Opt-in NSFW (ErosForge + NSFW QA/quota) |
-| `grok-imagine-delivery-post` | `delivery-post` | 5 | `core` | Assembly, color, polish, upscale, ffmpeg |
+| **`grok-imagine-cinematic-studio`** | *(full suite)* | **62** | — | **Recommended** one-click install |
+| `grok-imagine-cinematic-core` | `core` | **21** | — | Orchestration / DNA / wardrobe / Imagine / QA / quota / meta |
+| `grok-imagine-camera-image` | `camera-image` | **11** | `core` | DoP, design, i2i, key art, i2v, plate/contact |
+| `grok-imagine-sequence-narrative` | `sequence-narrative` | **19** | `core` | Sequence, continuity, performance, audio, action/VFX, SFW |
+| `grok-imagine-nsfw` | `nsfw` | **4** | `core` | Opt-in NSFW (ErosForge + NSFW QA/quota) |
+| `grok-imagine-delivery-post` | `delivery-post` | **7** | `core` | Assembly, color, polish, upscale, ffmpeg, title/crop |
 
 Source of truth: `config/plugin_packs.yaml`. List from a checkout: `cinematic-studio plugin packs`.
 
@@ -241,7 +241,7 @@ Avoid dual installs of the same plugin name; uninstall until `grok plugin list` 
 bash scripts/cinematic_studio.sh verify --plugin
 ```
 
-Checks all **54** plugin skills, 11 slash commands (`/cinematic`, `/dna`, etc.), and model registry when CLI tools are present in the plugin checkout.
+Checks all **62** plugin skills, 11 slash commands (`/cinematic`, `/dna`, etc.), and model registry when CLI tools are present in the plugin checkout.
 
 Registry cross-check (optional):
 
@@ -315,8 +315,8 @@ catalog pin, skills layout, git, API key presence, and optional pytest.
 ## Verify tiers
 
 - **core** (default) — 7 manifest skills marked `# core` in `required_skills.manifest`, plus `models verify`
-- **all** — all **54** manifest skills in `~/.grok/skills/` (Method A)
-- **plugin** — all **54** skills + 11 commands in the Grok plugin checkout (Method B; `verify --plugin`)
+- **all** — all **62** manifest skills in `~/.grok/skills/` (Method A)
+- **plugin** — all **62** skills + 11 commands in the Grok plugin checkout (Method B; `verify --plugin`)
 
 Core skills: `grok-imagine-cinematic-studio`, `ai-video-upscaler`, `cinematic-sequence-extender`, `studio-director`, `quality-assurance-guardian`, `identity-lock-specialist`, `workflow-quota-optimizer`
 

--- a/references/SKILLS_TAXONOMY.md
+++ b/references/SKILLS_TAXONOMY.md
@@ -2,6 +2,21 @@
 
 Canonical **install layout** stays flat: `.grok/skills/<name>/SKILL.md` (required by Grok plugin format). This file is the **mental model** for browsing, declutter, and docs — not a second on-disk hierarchy.
 
+## Canonical suite headcounts (v3.8.9)
+
+Single source of truth for marketing and verify gates:
+
+| Metric | Count | Source |
+|--------|------:|--------|
+| **Skills (full suite)** | **62** | `.grok/skills/*/SKILL.md` ≡ `scripts/required_skills.manifest` ≡ `.grok-plugin/plugin.json` |
+| **Slash commands** | **11** | `commands/` ≡ `plugin.json` `commands` |
+| **Role-Card core agents** | **25** | `AGENTS.md` core table · `tools/cli/shared.py` `core_agent_count()` |
+| **Role cards (mapped)** | **44** | `AGENT_ROLE_CARDS` (core + pipeline + Wave A + i2i + NSFW) |
+| **Marketplace plugins** | **6** | full suite + 5 packs (`config/plugin_packs.yaml`) |
+| **Pack sizes** | 21 · 11 · 19 · 4 · 7 | core · camera-image · sequence-narrative · nsfw · delivery-post (exclusive; union = 62) |
+
+Do **not** invent skill counts in docs. After adding/removing a skill: update the manifest, regenerate the plugin catalog, and re-check this table.
+
 ## Install surfaces (do not dual-load studio skills)
 
 | Surface | Path | What belongs here |

--- a/scripts/required_skills.manifest
+++ b/scripts/required_skills.manifest
@@ -1,4 +1,4 @@
-# Grok Imagine Cinematic Studio v3.8.6 — skill manifest
+# Grok Imagine Cinematic Studio v3.8.9 — skill manifest (62 skills; matches .grok/skills + plugin.json)
 # One skill per line. Append " # core" for skills required by verify.
 
 grok-imagine-cinematic-studio # core

--- a/tests/test_control_plane_contract.py
+++ b/tests/test_control_plane_contract.py
@@ -23,7 +23,7 @@ def _snap(**overrides: object) -> dict:
             "total_agents": 34,
             "role_cards": 34,
             "role_cards_expected": 34,
-            "skills": 54,
+            "skills": 62,
             "models_compatible": True,
             "model_issues": [],
             "model_stack": {"xai_chat": "grok-4.5", "imagine_video": "grok-imagine-video"},

--- a/tests/test_handoff_schema.py
+++ b/tests/test_handoff_schema.py
@@ -19,6 +19,7 @@ from handoff_schema import (  # noqa: E402
     is_video_execution_mode,
     normalize_execution_mode,
     normalize_target_surface,
+    resolve_execution_mode,
 )
 from imagine_bridge import (  # noqa: E402
     EXECUTION_MODES as BRIDGE_MODES,
@@ -48,6 +49,20 @@ def test_normalize_execution_mode_aliases() -> None:
     assert normalize_execution_mode("still") == "image_prompt"
     assert normalize_execution_mode("video") == "video_prompt"
     assert normalize_execution_mode(None) == "video_prompt"
+
+
+def test_resolve_execution_mode_aliases_for_spend_gates() -> None:
+    """Batch shorthand must map so plate/motion gates do not silently skip."""
+    assert resolve_execution_mode({"recommended_mode": "i2v"}) == "image_to_video"
+    assert resolve_execution_mode({"recommended_mode": "I2V"}) == "image_to_video"
+    assert resolve_execution_mode({"decision": {"mode": "still"}}) == "image_prompt"
+    assert resolve_execution_mode({"execution_mode": "video"}) == "video_prompt"
+    assert resolve_execution_mode({}, execution_mode="image") == "image_prompt"
+    # Empty must not invent video_prompt (would false-trigger motion gates).
+    assert resolve_execution_mode({}) == ""
+    assert resolve_execution_mode({"recommended_mode": ""}) == ""
+    # Unknown kept as-is (soft).
+    assert resolve_execution_mode({"recommended_mode": "not-a-mode"}) == "not-a-mode"
 
 
 def test_normalize_execution_mode_strict() -> None:

--- a/tests/test_plate_readiness.py
+++ b/tests/test_plate_readiness.py
@@ -92,3 +92,14 @@ def test_mode_from_subject_recommended_mode() -> None:
     )
     assert r["pass"] is True
     assert "locked" in PLATE_OK
+
+
+def test_mode_alias_i2v_from_recommended_mode_blocks_draft() -> None:
+    """Shorthand recommended_mode=i2v must not skip still→video plate gates."""
+    r = evaluate_plate_lock_readiness(
+        {"recommended_mode": "i2v", "plate_status": "draft"},
+        execution_mode=None,
+    )
+    assert r["pass"] is False
+    assert r.get("execution_mode") == "image_to_video"
+    assert any("PL-02" in b for b in r["blockers"])

--- a/tests/test_spend_readiness.py
+++ b/tests/test_spend_readiness.py
@@ -29,6 +29,18 @@ def test_i2v_missing_plate_and_motion_fails_children() -> None:
     assert "motion" in spend_hard_fail_reasons(r, strict_plate=False, strict_motion=True)
 
 
+def test_alias_i2v_strict_spend_gates_hard_fail() -> None:
+    """recommended_mode=i2v must hard-fail under --strict-plate/--strict-motion."""
+    gates = evaluate_spend_gates(
+        {"recommended_mode": "i2v", "prompt": "static person"},
+        strict_plate=True,
+        strict_motion=True,
+    )
+    assert gates["plate"].get("execution_mode") == "image_to_video"
+    assert "plate" in gates["hard_fail"]
+    assert "motion" in gates["hard_fail"]
+
+
 def test_ready_shot_passes() -> None:
     r = evaluate_generation_spend_readiness(
         {

--- a/tests/test_tui_widgets.py
+++ b/tests/test_tui_widgets.py
@@ -39,7 +39,7 @@ def _sample_snap(**overrides: object) -> dict:
             "total_agents": 34,
             "role_cards": 34,
             "role_cards_expected": 34,
-            "skills": 54,
+            "skills": 62,
             "models_compatible": True,
             "model_issues": [],
             "model_stack": {

--- a/tools/cinematic_studio_cli.py
+++ b/tools/cinematic_studio_cli.py
@@ -33,7 +33,7 @@ app = typer.Typer(
     name="cinematic-studio",
     help=(
         f"🎥 Grok Imagine Cinematic Studio v{STUDIO_VERSION} — "
-        "Grok 4.5 cinematic+Build · optional 4.3 1M · Imagine 1.0/1.5 · 23-agent CLI"
+        "Grok 4.5 cinematic+Build · optional 4.3 1M · Imagine 1.0/1.5 · 25-agent core CLI"
     ),
     add_completion=False,
     rich_markup_mode="rich",

--- a/tools/cli/production.py
+++ b/tools/cli/production.py
@@ -14,7 +14,7 @@ from models import (
     resolve_video_model,
 )
 
-from cli.shared import AGENTS_DIR, DIRECTOR_SIGNATURES, STUDIO_VERSION
+from cli.shared import AGENTS_DIR, DIRECTOR_SIGNATURES, STUDIO_VERSION, core_agent_count
 
 
 def production_context(
@@ -79,7 +79,7 @@ def build_activation_prompt(
 
 {chr(10).join(meta_lines)}
 
-You are now running the full **23-agent** Grok Imagine Cinematic Studio **v{STUDIO_VERSION}** with complete Role Cards from `references/agents/`.
+You are now running the full **25-agent core** Grok Imagine Cinematic Studio **v{STUDIO_VERSION}** with complete Role Cards from `references/agents/`.
 
 **Model Layer (Grok 4.5):** orchestration + Build default **`grok-4.5`**; optional **`grok-4.3`** only for 1M-context Bibles/memory banks. Imagine video **1.0** cost default; **1.5** when native audio is required. Prefer stable `prompt_cache_key` (project slug). Reasoning **high** for Bibles, QA, Identity Lock, and Sequence Director.
 
@@ -121,7 +121,7 @@ def build_production_bible(
         "director_signature": director,
         "target_duration_seconds": target_duration_seconds,
         "complexity": complexity,
-        "total_agents": 23,
+        "total_agents": core_agent_count(),
         "version": STUDIO_VERSION,
         "role_cards_source": str(cards_dir) if cards_dir.exists() else "references/agents/",
         "model_stack": ctx["stack"],

--- a/tools/cli/report_commands.py
+++ b/tools/cli/report_commands.py
@@ -52,7 +52,7 @@ def register(app: typer.Typer) -> None:
         pdf.cell(
             0,
             8,
-            f"Status: Production in progress — studio v{STUDIO_VERSION} · Grok 4.5 · 23-agent core",
+            f"Status: Production in progress — studio v{STUDIO_VERSION} · Grok 4.5 · 25-agent core",
             ln=True,
         )
 

--- a/tools/handoff_schema.py
+++ b/tools/handoff_schema.py
@@ -95,7 +95,12 @@ def resolve_execution_mode(
     *,
     execution_mode: str | None = None,
 ) -> str:
-    """Resolve execution mode from explicit override or subject fields (batch/shot)."""
+    """Resolve execution mode from explicit override or subject fields (batch/shot).
+
+    Applies ``EXECUTION_MODE_ALIASES`` (e.g. ``i2v`` → ``image_to_video``) so
+    plate/motion spend gates fire for shorthand batch modes. Empty stays empty
+    — do not invent a default (unlike ``normalize_execution_mode`` for builders).
+    """
     subj = subject if isinstance(subject, dict) else {}
     mode = (
         execution_mode
@@ -104,7 +109,18 @@ def resolve_execution_mode(
         or (subj.get("decision") or {}).get("mode")
         or ""
     )
-    return str(mode).strip()
+    raw = str(mode).strip()
+    if not raw:
+        return ""
+    # Prefer exact alias, then lowercased alias (batch UIs often use "I2V").
+    mapped = EXECUTION_MODE_ALIASES.get(raw, EXECUTION_MODE_ALIASES.get(raw.lower(), raw))
+    if mapped in EXECUTION_MODES:
+        return mapped
+    low = raw.lower()
+    for official in EXECUTION_MODES:
+        if official.lower() == low:
+            return official
+    return raw
 
 
 def normalize_execution_mode(


### PR DESCRIPTION
## Summary
- `resolve_execution_mode` now applies `EXECUTION_MODE_ALIASES` (`i2v` → `image_to_video`, `still` → `image_prompt`, `video`/`t2v` → `video_prompt`, etc.).
- Fixes silent skip of plate/motion spend gates when batch shots only set `recommended_mode: "i2v"`.
- Empty mode still returns empty (does not invent `video_prompt`).
- Tests for schema resolve, plate draft+i2v alias, and strict spend hard-fail.

## Test plan
- [x] `pytest tests/test_handoff_schema.py tests/test_plate_readiness.py tests/test_spend_readiness.py tests/test_motion_readiness.py tests/test_handoff_readiness.py` (45 passed)
- [ ] Manual: shot with `recommended_mode: i2v` + draft plate → `sfw run --strict-plate` exits 1