### PR TITLE
PR1: extract studio_core.services.dashboard + CLI shims

### DIFF
--- a/docs/PR1_STUDIO_CORE_DASHBOARD.md
+++ b/docs/PR1_STUDIO_CORE_DASHBOARD.md
@@ -1,0 +1,46 @@
+# PR1 — Extract `studio_core.services.dashboard`
+
+## Goal
+
+Move **UI-agnostic** studio dashboard snapshot aggregation out of
+`tools/cli/dashboard.py` so CLI (Rich), TUI (Textual), Streamlit, and future
+NiceGUI/API shells share one contract.
+
+## What changed
+
+| Path | Change |
+|------|--------|
+| `studio_core/` | New package (path helpers + services) |
+| `studio_core/services/dashboard.py` | `build_studio_dashboard()` (pure dict) |
+| `tools/cli/dashboard.py` | Re-exports builder; keeps Rich renderers |
+| `tools/cinematic_studio_cli.py` | Adds repo root to `sys.path` for `studio_core` |
+| `tests/test_studio_core_dashboard.py` | Shape + shim identity + no-UI-import guard |
+
+## Compatibility
+
+Existing imports keep working:
+
+```python
+from cli.dashboard import build_studio_dashboard  # shim → studio_core
+```
+
+Preferred for new code:
+
+```python
+from studio_core.services.dashboard import build_studio_dashboard
+```
+
+## Out of scope (later PRs)
+
+- Move `ActionSpec` registry (`cli.tui.actions`) → `studio_core.services.actions`
+- Move agent/version helpers out of `cli.shared`
+- Streamlit → NiceGUI page port
+- FastAPI control plane
+
+## Verify
+
+```bash
+pytest tests/test_studio_core_dashboard.py tests/test_cli_dashboard.py -q
+python tools/cinematic_studio_cli.py dashboard --compact
+python tools/cinematic_studio_cli.py ui --print
+```

--- a/studio_core/__init__.py
+++ b/studio_core/__init__.py
@@ -1,0 +1,12 @@
+"""UI-agnostic studio core shared by CLI, TUI, Web, and future API shells.
+
+PR1 introduces ``studio_core.services.dashboard`` (snapshot aggregation only).
+Rich/Textual/Streamlit rendering stays in their respective UI packages.
+"""
+
+from __future__ import annotations
+
+__all__ = ["__version__"]
+
+# Keep in sync with repo VERSION when packaging; runtime prefers VERSION file.
+__version__ = "3.8.9"

--- a/studio_core/pathutil.py
+++ b/studio_core/pathutil.py
@@ -1,0 +1,23 @@
+"""Ensure repo-root and tools/ are importable for studio_core consumers."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parent.parent
+_TOOLS = _ROOT / "tools"
+
+
+def ensure_import_paths() -> Path:
+    """Insert repo root + tools/ on sys.path (idempotent). Return studio root."""
+    tools_s = str(_TOOLS)
+    root_s = str(_ROOT)
+    if tools_s not in sys.path:
+        sys.path.insert(0, tools_s)
+    if root_s not in sys.path:
+        sys.path.insert(0, root_s)
+    return _ROOT
+
+
+STUDIO_ROOT = _ROOT

--- a/studio_core/services/__init__.py
+++ b/studio_core/services/__init__.py
@@ -1,0 +1,7 @@
+"""Service-layer facades over domain tools (no UI framework imports)."""
+
+from __future__ import annotations
+
+from studio_core.services.dashboard import build_studio_dashboard
+
+__all__ = ["build_studio_dashboard"]

--- a/studio_core/services/dashboard.py
+++ b/studio_core/services/dashboard.py
@@ -1,0 +1,166 @@
+"""UI-agnostic studio dashboard snapshot aggregation.
+
+Pure data: returns a JSON-serializable dict used by CLI (Rich), TUI (Textual),
+Streamlit, and future NiceGUI/API shells. No Rich/Streamlit/Textual imports.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+from studio_core.pathutil import ensure_import_paths
+
+ensure_import_paths()
+
+from artifact_pipeline import artifacts_summary  # noqa: E402
+from character_dna import list_characters  # noqa: E402
+from chain_qa_assist import summarize_sequence_qa  # noqa: E402
+from imagine_jobs import job_summary, list_jobs  # noqa: E402
+from models import model_stack_summary, verify_model_compatibility  # noqa: E402
+from nsfw_orchestrator import list_batches  # noqa: E402
+from production_report import build_production_report  # noqa: E402
+from project_state import load_project_state  # noqa: E402
+from quota_optimizer import assess_budget_risk, quota_dashboard  # noqa: E402
+from sequence_chain import find_sequence, list_sequences, load_sequence  # noqa: E402
+from sfw_orchestrator import list_batches as list_sfw_batches  # noqa: E402
+from studio_health import count_skills  # noqa: E402
+
+# Agent/version metadata still lives in cli.shared (PR later can move to studio_core).
+from cli.shared import (  # noqa: E402
+    EXPECTED_ROLE_CARD_COUNT,
+    STUDIO_VERSION,
+    core_agent_count,
+    list_role_card_files,
+    total_agent_count,
+)
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def build_studio_dashboard() -> dict[str, Any]:
+    """Aggregate studio snapshot for CLI / TUI / Web / JSON export.
+
+    Contract (stable keys for UI shells):
+      generated_at, studio_version, project, studio, quota, production,
+      readiness, imagine_jobs, sequences, characters, nsfw_batches,
+      sfw_batches, recent_jobs, chain_qa, production_report, artifacts,
+      plus phase-3 fields when available (parallel_briefs, convergence, delivery).
+    """
+    state = load_project_state()
+    project = state.get("project") or {}
+    dash = quota_dashboard(state)
+    model_check = verify_model_compatibility()
+    sequences = list_sequences()
+    characters = list_characters()
+    batches = list_batches()
+    sfw_batches = list_sfw_batches()
+    imagine_summary = job_summary()
+    recent_jobs = list_jobs(limit=8)
+    chain_qa_summaries: list[dict[str, Any]] = []
+    for s in sequences[:6]:
+        seq_path = find_sequence(s["slug"])
+        if seq_path:
+            try:
+                chain_qa_summaries.append(summarize_sequence_qa(load_sequence(seq_path)))
+            except (ValueError, OSError):
+                pass
+    role_cards = list_role_card_files()
+    identity_locked = sum(1 for c in characters if c.get("status") == "locked")
+
+    remaining = dash.get("budget_remaining")
+    spent = dash.get("session_spent", 0)
+    risk = assess_budget_risk(
+        {"credits_low": spent, "credits_high": spent},
+        tier=dash.get("tier", "supergrok_pro"),
+        budget_remaining=remaining,
+    )
+
+    production = {
+        "sequences": len(sequences),
+        "characters": len(characters),
+        "identity_locked": identity_locked,
+        "nsfw_batches": len(batches),
+        "sfw_batches": len(sfw_batches),
+        "imagine_jobs": imagine_summary["total"],
+        "reference_assets": imagine_summary["reference_assets"],
+    }
+    try:
+        from control_plane_readiness import build_readiness_rollup
+
+        readiness = build_readiness_rollup(
+            characters=characters,
+            chain_qa=chain_qa_summaries,
+            production=production,
+            scan_sfw=True,
+        )
+    except Exception:
+        readiness = {
+            "overall": "unknown",
+            "identity": {
+                "total": len(characters),
+                "locked": identity_locked,
+                "pending": max(0, len(characters) - identity_locked),
+                "ready": identity_locked == len(characters),
+                "label": f"{identity_locked}/{len(characters)} locked",
+            },
+            "plate_motion": {"available": False, "scanned_shots": 0},
+            "chain_qa": {"go": 0, "no_go": 0, "ready": True, "label": "—"},
+            "next_actions": [],
+        }
+
+    title = project.get("project_title") or project.get("title") or "Untitled"
+    snap: dict[str, Any] = {
+        "generated_at": _now_iso(),
+        "studio_version": STUDIO_VERSION,
+        "project": {
+            "title": title,
+            "genre": project.get("genre"),
+            "has_bible": bool(project),
+        },
+        "studio": {
+            "core_agents": core_agent_count(),
+            "total_agents": total_agent_count(),
+            "role_cards": len(role_cards),
+            "role_cards_expected": EXPECTED_ROLE_CARD_COUNT,
+            "skills": count_skills(),
+            "models_compatible": model_check["compatible"],
+            "model_issues": model_check.get("issues", []),
+            "model_stack": model_check.get("model_stack", model_stack_summary()),
+        },
+        "quota": {**dash, "risk_level": risk.get("risk_level", "unknown")},
+        "production": production,
+        "readiness": readiness,
+        "imagine_jobs": imagine_summary,
+        "sequences": sequences[:8],
+        "characters": characters[:8],
+        "nsfw_batches": batches[:5],
+        "sfw_batches": sfw_batches[:5],
+        "recent_jobs": recent_jobs,
+        "chain_qa": chain_qa_summaries,
+        "production_report": build_production_report(state),
+        "artifacts": artifacts_summary(),
+    }
+    try:
+        from control_plane_phase3 import build_phase3_snapshot_fields
+
+        snap.update(build_phase3_snapshot_fields(snap))
+    except Exception:
+        snap["parallel_briefs"] = {"logs": [], "count": 0, "label": "unavailable"}
+        snap["convergence"] = {
+            "checklist": [],
+            "ready": False,
+            "ok": 0,
+            "fail": 0,
+            "label": "unavailable",
+        }
+        snap["delivery"] = {
+            "sequences": [],
+            "polish_ready": 0,
+            "deliver_ready": 0,
+            "total": 0,
+            "label": "unavailable",
+        }
+    return snap

--- a/tests/test_studio_core_dashboard.py
+++ b/tests/test_studio_core_dashboard.py
@@ -1,0 +1,63 @@
+"""PR1: studio_core dashboard service is UI-agnostic and shims cleanly."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "tools"))
+sys.path.insert(0, str(ROOT))
+
+from studio_core.services.dashboard import build_studio_dashboard as core_build  # noqa: E402
+from cli.dashboard import build_studio_dashboard as cli_build  # noqa: E402
+
+
+REQUIRED_TOP_KEYS = {
+    "generated_at",
+    "studio_version",
+    "project",
+    "studio",
+    "quota",
+    "production",
+    "readiness",
+    "imagine_jobs",
+    "sequences",
+    "characters",
+    "nsfw_batches",
+    "sfw_batches",
+    "recent_jobs",
+    "chain_qa",
+    "production_report",
+    "artifacts",
+}
+
+
+def test_core_build_studio_dashboard_shape() -> None:
+    snap = core_build()
+    missing = REQUIRED_TOP_KEYS - set(snap)
+    assert not missing, f"missing keys: {missing}"
+    assert snap["studio_version"]
+    assert snap["studio"]["core_agents"] >= 23
+    recon = snap["quota"].get("reconciliation") or {}
+    assert "cascade_source" in recon
+    assert "entry_count" in recon
+
+
+def test_cli_shim_is_same_function() -> None:
+    """cli.dashboard re-exports the core builder (identity, not just shape)."""
+    assert cli_build is core_build
+
+
+def test_core_module_has_no_rich_dependency_at_import() -> None:
+    """dashboard service module source must not import rich/streamlit/textual."""
+    src = (ROOT / "studio_core" / "services" / "dashboard.py").read_text(encoding="utf-8")
+    for ban in ("import rich", "from rich", "import streamlit", "import textual", "from textual"):
+        assert ban not in src, f"forbidden import pattern: {ban}"
+
+
+if __name__ == "__main__":
+    test_core_build_studio_dashboard_shape()
+    test_cli_shim_is_same_function()
+    test_core_module_has_no_rich_dependency_at_import()
+    print("studio_core dashboard tests passed")

--- a/tools/cinematic_studio_cli.py
+++ b/tools/cinematic_studio_cli.py
@@ -8,7 +8,13 @@ from pathlib import Path
 
 import typer
 
-sys.path.insert(0, str(Path(__file__).resolve().parent))
+_TOOLS_DIR = Path(__file__).resolve().parent
+_REPO_ROOT = _TOOLS_DIR.parent
+# Domain tools package root
+sys.path.insert(0, str(_TOOLS_DIR))
+# studio_core (UI-agnostic services) lives at repo root
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
 
 from cli.animatic_commands import register as register_animatic_commands  # noqa: E402
 from cli.bible_commands import register as register_bible_commands  # noqa: E402

--- a/tools/cli/dashboard.py
+++ b/tools/cli/dashboard.py
@@ -1,8 +1,14 @@
-"""Studio dashboard data aggregation and Rich rendering."""
+"""Studio dashboard: Rich rendering + re-export of UI-agnostic snapshot builder.
+
+Snapshot aggregation lives in ``studio_core.services.dashboard`` so Web/TUI/API
+shells can share one contract without importing Rich. This module keeps CLI
+presentation (panels, tables) and re-exports ``build_studio_dashboard`` for
+backward compatibility.
+"""
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any
 
 from rich import box
@@ -12,29 +18,24 @@ from rich.panel import Panel
 from rich.table import Table
 from rich.text import Text
 
-from character_dna import list_characters
-from models import model_stack_summary, verify_model_compatibility
-from chain_qa_assist import summarize_sequence_qa
-from imagine_jobs import job_summary, list_jobs
-from sequence_chain import find_sequence, load_sequence
-from nsfw_orchestrator import list_batches
-from project_state import load_project_state
-from sfw_orchestrator import list_batches as list_sfw_batches
-from artifact_pipeline import artifacts_summary
-from production_report import build_production_report
-from quota_optimizer import assess_budget_risk, quota_dashboard
-from sequence_chain import list_sequences
-from studio_health import count_skills
-
 from cli.quota_display import RISK_COLORS
-from cli.shared import (
-    EXPECTED_ROLE_CARD_COUNT,
-    STUDIO_VERSION,
-    console,
-    core_agent_count,
-    list_role_card_files,
-    total_agent_count,
-)
+from cli.shared import console
+
+# Repo root on path so studio_core imports work when only tools/ was inserted.
+_ROOT = Path(__file__).resolve().parents[2]
+import sys
+
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+from studio_core.services.dashboard import build_studio_dashboard  # noqa: E402
+
+__all__ = [
+    "build_studio_dashboard",
+    "dashboard_renderables",
+    "render_dashboard_json",
+    "render_studio_dashboard",
+]
 
 CHAIN_QA_COLORS = {
     "go": "green",
@@ -44,129 +45,6 @@ CHAIN_QA_COLORS = {
     "pending": "dim",
 }
 LOCK_COLORS = {"locked": "green", "pending": "yellow"}
-
-
-def _now_iso() -> str:
-    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
-
-
-def build_studio_dashboard() -> dict[str, Any]:
-    """Aggregate studio snapshot for CLI dashboard or JSON export."""
-    state = load_project_state()
-    project = state.get("project") or {}
-    dash = quota_dashboard(state)
-    model_check = verify_model_compatibility()
-    sequences = list_sequences()
-    characters = list_characters()
-    batches = list_batches()
-    sfw_batches = list_sfw_batches()
-    imagine_summary = job_summary()
-    recent_jobs = list_jobs(limit=8)
-    chain_qa_summaries: list[dict[str, Any]] = []
-    for s in sequences[:6]:
-        seq_path = find_sequence(s["slug"])
-        if seq_path:
-            try:
-                chain_qa_summaries.append(summarize_sequence_qa(load_sequence(seq_path)))
-            except (ValueError, OSError):
-                pass
-    role_cards = list_role_card_files()
-    identity_locked = sum(1 for c in characters if c.get("status") == "locked")
-
-    remaining = dash.get("budget_remaining")
-    spent = dash.get("session_spent", 0)
-    risk = assess_budget_risk(
-        {"credits_low": spent, "credits_high": spent},
-        tier=dash.get("tier", "supergrok_pro"),
-        budget_remaining=remaining,
-    )
-
-    production = {
-        "sequences": len(sequences),
-        "characters": len(characters),
-        "identity_locked": identity_locked,
-        "nsfw_batches": len(batches),
-        "sfw_batches": len(sfw_batches),
-        "imagine_jobs": imagine_summary["total"],
-        "reference_assets": imagine_summary["reference_assets"],
-    }
-    try:
-        from control_plane_readiness import build_readiness_rollup
-
-        readiness = build_readiness_rollup(
-            characters=characters,
-            chain_qa=chain_qa_summaries,
-            production=production,
-            scan_sfw=True,
-        )
-    except Exception:
-        readiness = {
-            "overall": "unknown",
-            "identity": {
-                "total": len(characters),
-                "locked": identity_locked,
-                "pending": max(0, len(characters) - identity_locked),
-                "ready": identity_locked == len(characters),
-                "label": f"{identity_locked}/{len(characters)} locked",
-            },
-            "plate_motion": {"available": False, "scanned_shots": 0},
-            "chain_qa": {"go": 0, "no_go": 0, "ready": True, "label": "—"},
-            "next_actions": [],
-        }
-
-    title = project.get("project_title") or project.get("title") or "Untitled"
-    snap: dict[str, Any] = {
-        "generated_at": _now_iso(),
-        "studio_version": STUDIO_VERSION,
-        "project": {
-            "title": title,
-            "genre": project.get("genre"),
-            "has_bible": bool(project),
-        },
-        "studio": {
-            "core_agents": core_agent_count(),
-            "total_agents": total_agent_count(),
-            "role_cards": len(role_cards),
-            "role_cards_expected": EXPECTED_ROLE_CARD_COUNT,
-            "skills": count_skills(),
-            "models_compatible": model_check["compatible"],
-            "model_issues": model_check.get("issues", []),
-            "model_stack": model_check.get("model_stack", model_stack_summary()),
-        },
-        "quota": {**dash, "risk_level": risk.get("risk_level", "unknown")},
-        "production": production,
-        "readiness": readiness,
-        "imagine_jobs": imagine_summary,
-        "sequences": sequences[:8],
-        "characters": characters[:8],
-        "nsfw_batches": batches[:5],
-        "sfw_batches": sfw_batches[:5],
-        "recent_jobs": recent_jobs,
-        "chain_qa": chain_qa_summaries,
-        "production_report": build_production_report(state),
-        "artifacts": artifacts_summary(),
-    }
-    try:
-        from control_plane_phase3 import build_phase3_snapshot_fields
-
-        snap.update(build_phase3_snapshot_fields(snap))
-    except Exception:
-        snap["parallel_briefs"] = {"logs": [], "count": 0, "label": "unavailable"}
-        snap["convergence"] = {
-            "checklist": [],
-            "ready": False,
-            "ok": 0,
-            "fail": 0,
-            "label": "unavailable",
-        }
-        snap["delivery"] = {
-            "sequences": [],
-            "polish_ready": 0,
-            "deliver_ready": 0,
-            "total": 0,
-            "label": "unavailable",
-        }
-    return snap
 
 
 def _risk_text(level: str) -> Text:


### PR DESCRIPTION
## Summary

Extracts UI-agnostic studio dashboard snapshot aggregation into a new `studio_core` package so CLI (Rich), TUI (Textual), Streamlit, and future NiceGUI/API shells share one contract — without rewriting the production pipeline.

- **New** `studio_core/services/dashboard.py` — pure `build_studio_dashboard()` (no Rich/Streamlit/Textual)
- **Shim** `tools/cli/dashboard.py` — re-exports builder; keeps Rich panels/tables
- **Path** `tools/cinematic_studio_cli.py` — adds repo root to `sys.path` for `studio_core`
- **Tests** `tests/test_studio_core_dashboard.py` — shape, shim identity, no-UI-import guard
- **Docs** `docs/PR1_STUDIO_CORE_DASHBOARD.md`

## Compatibility

```python
from cli.dashboard import build_studio_dashboard  # still works (shim)
from studio_core.services.dashboard import build_studio_dashboard  # preferred
```

Existing TUI / Streamlit / CLI callers unchanged.

## Test plan

- [x] `pytest tests/test_studio_core_dashboard.py tests/test_cli_dashboard.py` (and related control-plane/TUI tests) — 42 passed
- [x] `python tools/cinematic_studio_cli.py dashboard --compact`
- [ ] `cinematic-studio ui --print` on a real TTY checkout
- [ ] Streamlit dashboard still loads (`streamlit run web_ui/app.py`)

## Out of scope (follow-ups)

- PR2: move `ActionSpec` → `studio_core.services.actions`
- Streamlit → NiceGUI port
- FastAPI control plane