### PR TITLE
PR3: add studio_core execute_action (inprocess + subprocess)

### DIFF
--- a/docs/PR3_STUDIO_CORE_EXECUTE.md
+++ b/docs/PR3_STUDIO_CORE_EXECUTE.md
@@ -1,0 +1,41 @@
+# PR3 — `studio_core.services.execute`
+
+## Goal
+
+One safe entrypoint for running registered ActionSpec actions from any shell:
+
+| Mode | Who uses it | Mechanism |
+|------|-------------|-----------|
+| `subprocess` | Textual TUI | `python tools/cinematic_studio_cli.py …` |
+| `inprocess` | Web / API (default) | Typer `CliRunner` invoke (no process spawn) |
+
+Both paths share `validate_answers` → `answers_to_argv` → forbidden-token checks.
+
+## API
+
+```python
+from studio_core.services.execute import execute_action, ActionResult
+
+r: ActionResult = execute_action("status", mode="inprocess")
+r = execute_action("dna_lock", {"name": "Hero"}, mode="subprocess", timeout=60)
+assert r.ok and r.returncode == 0
+print(r.stdout)
+```
+
+## Compatibility
+
+- `cli.tui.runner.run_action` / `run_cli_command` still return `CommandResult`
+- They now delegate to `execute_*` with `mode="subprocess"`
+- Existing TUI tests should pass unchanged
+
+## Verify
+
+```bash
+pytest tests/test_studio_core_execute.py tests/test_tui_runner.py -q
+```
+
+## Out of scope
+
+- Direct domain-function dispatch (bypass Typer) — later optimization
+- FastAPI route wrappers
+- Streamlit wiring

--- a/studio_core/services/__init__.py
+++ b/studio_core/services/__init__.py
@@ -9,11 +9,15 @@ from studio_core.services.actions import (
     validate_answers,
 )
 from studio_core.services.dashboard import build_studio_dashboard
+from studio_core.services.execute import ActionResult, execute_action, execute_argv
 
 __all__ = [
     "ACTIONS",
+    "ActionResult",
     "ActionSpec",
     "answers_to_argv",
     "build_studio_dashboard",
+    "execute_action",
+    "execute_argv",
     "validate_answers",
 ]

--- a/studio_core/services/execute.py
+++ b/studio_core/services/execute.py
@@ -1,0 +1,351 @@
+"""Safe action execution for CLI/TUI/Web/API shells.
+
+Validates ActionSpec answers, builds argv, then runs either:
+  - ``subprocess`` — isolated process (default for Textual TUI)
+  - ``inprocess``  — Typer app invoke in-process (Web/API; no process spawn)
+
+Forbidden argv tokens are always rejected. Free-form argv is never accepted
+via :func:`execute_action` (only registered action ids).
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import TimeoutError as FuturesTimeout
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Literal
+
+from studio_core.pathutil import STUDIO_ROOT, ensure_import_paths
+from studio_core.services.actions import (
+    answers_to_argv,
+    reject_forbidden_argv,
+    static_allowed_argvs,
+    validate_answers,
+)
+
+ExecuteMode = Literal["inprocess", "subprocess"]
+
+
+@dataclass(frozen=True)
+class ActionResult:
+    """Result of :func:`execute_action` / :func:`execute_argv`."""
+
+    ok: bool
+    argv: list[str]
+    returncode: int
+    stdout: str = ""
+    stderr: str = ""
+    errors: list[str] = field(default_factory=list)
+    timed_out: bool = False
+    action_id: str | None = None
+    mode: str = "inprocess"
+
+    @property
+    def output(self) -> str:
+        """Combined stdout+stderr for simple UI display."""
+        if self.stdout and self.stderr:
+            return self.stdout.rstrip() + "\n" + self.stderr
+        return self.stdout or self.stderr
+
+
+def resolve_repo_root(cwd: Path | None = None) -> Path:
+    """Project root containing tools/cinematic_studio_cli.py."""
+    env = os.environ.get("CINEMATIC_PROJECT_DIR")
+    if env:
+        candidate = Path(env).expanduser().resolve()
+        if (candidate / "tools" / "cinematic_studio_cli.py").is_file():
+            return candidate
+    if cwd is not None:
+        c = Path(cwd).resolve()
+        if (c / "tools" / "cinematic_studio_cli.py").is_file():
+            return c
+    # Prefer pathutil root when it looks like a checkout
+    if (STUDIO_ROOT / "tools" / "cinematic_studio_cli.py").is_file():
+        return STUDIO_ROOT
+    here = Path(__file__).resolve()
+    for parent in here.parents:
+        if (parent / "tools" / "cinematic_studio_cli.py").is_file():
+            return parent
+    return STUDIO_ROOT
+
+
+def cli_script_path(cwd: Path | None = None) -> Path:
+    return resolve_repo_root(cwd) / "tools" / "cinematic_studio_cli.py"
+
+
+def _deny(
+    argv: list[str],
+    message: str,
+    *,
+    action_id: str | None = None,
+    mode: str = "inprocess",
+    errors: list[str] | None = None,
+) -> ActionResult:
+    errs = list(errors) if errors is not None else [message]
+    return ActionResult(
+        ok=False,
+        argv=list(argv),
+        returncode=2,
+        stdout="",
+        stderr=message,
+        errors=errs,
+        timed_out=False,
+        action_id=action_id,
+        mode=mode,
+    )
+
+
+def _subprocess_run(
+    argv: list[str],
+    *,
+    timeout: float,
+    cwd: Path | None,
+    action_id: str | None,
+) -> ActionResult:
+    if not argv:
+        return _deny([], "No command argv provided.", action_id=action_id, mode="subprocess")
+
+    try:
+        reject_forbidden_argv(argv)
+    except ValueError as exc:
+        return _deny(argv, str(exc), action_id=action_id, mode="subprocess", errors=[str(exc)])
+
+    script = cli_script_path(cwd)
+    if not script.is_file():
+        msg = f"CLI script not found: {script}"
+        return _deny(argv, msg, action_id=action_id, mode="subprocess", errors=[msg])
+
+    workdir = cwd or resolve_repo_root(cwd)
+    cmd = [sys.executable, str(script), *argv]
+    try:
+        completed = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            cwd=str(workdir),
+            timeout=max(1.0, float(timeout)),
+        )
+        code = int(completed.returncode)
+        return ActionResult(
+            ok=code == 0,
+            argv=list(argv),
+            returncode=code,
+            stdout=completed.stdout or "",
+            stderr=completed.stderr or "",
+            errors=[] if code == 0 else [f"exit {code}"],
+            timed_out=False,
+            action_id=action_id,
+            mode="subprocess",
+        )
+    except subprocess.TimeoutExpired as exc:
+        out = (exc.stdout or "") if isinstance(exc.stdout, str) else ""
+        err = (exc.stderr or "") if isinstance(exc.stderr, str) else ""
+        msg = f"Command timed out after {timeout}s: {' '.join(argv)}"
+        return ActionResult(
+            ok=False,
+            argv=list(argv),
+            returncode=124,
+            stdout=out,
+            stderr=(err + "\n" + msg).strip(),
+            errors=[msg],
+            timed_out=True,
+            action_id=action_id,
+            mode="subprocess",
+        )
+
+
+_CLI_APP: Any = None
+
+
+def _load_cli_app() -> Any:
+    """Load the Typer app from tools/cinematic_studio_cli.py (cached)."""
+    global _CLI_APP
+    if _CLI_APP is not None:
+        return _CLI_APP
+
+    ensure_import_paths()
+    import importlib.util
+
+    path = cli_script_path()
+    if not path.is_file():
+        raise FileNotFoundError(f"CLI script not found: {path}")
+
+    spec = importlib.util.spec_from_file_location("cinematic_studio_cli_mod", path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load CLI from {path}")
+    mod = importlib.util.module_from_spec(spec)
+    # Register under a stable name so relative imports inside behave
+    sys.modules.setdefault("cinematic_studio_cli_mod", mod)
+    spec.loader.exec_module(mod)
+    app = getattr(mod, "app", None)
+    if app is None:
+        raise ImportError("cinematic_studio_cli.py has no 'app' Typer instance")
+    _CLI_APP = app
+    return _CLI_APP
+
+
+def _invoke_typer(argv: list[str], *, cwd: Path) -> tuple[int, str, str]:
+    """Invoke Typer app in-process; return (code, stdout, stderr)."""
+    from typer.testing import CliRunner
+
+    app = _load_cli_app()
+    runner = CliRunner()
+    # Click 8+: stderr captured separately when mix_stderr not used
+    prev = os.getcwd()
+    try:
+        os.chdir(str(cwd))
+        result = runner.invoke(app, argv, catch_exceptions=True)
+    finally:
+        os.chdir(prev)
+
+    code = int(result.exit_code if result.exit_code is not None else 1)
+    out = result.stdout or ""
+    err = getattr(result, "stderr", None) or ""
+    if result.exception is not None and not err:
+        err = f"{type(result.exception).__name__}: {result.exception}"
+    return code, out, err
+
+
+def _inprocess_run(
+    argv: list[str],
+    *,
+    timeout: float,
+    cwd: Path | None,
+    action_id: str | None,
+) -> ActionResult:
+    if not argv:
+        return _deny([], "No command argv provided.", action_id=action_id, mode="inprocess")
+
+    try:
+        reject_forbidden_argv(argv)
+    except ValueError as exc:
+        return _deny(argv, str(exc), action_id=action_id, mode="inprocess", errors=[str(exc)])
+
+    workdir = cwd or resolve_repo_root(cwd)
+    timeout = max(1.0, float(timeout))
+
+    def _call() -> tuple[int, str, str]:
+        return _invoke_typer(argv, cwd=workdir)
+
+    try:
+        with ThreadPoolExecutor(max_workers=1) as pool:
+            fut = pool.submit(_call)
+            code, out, err = fut.result(timeout=timeout)
+    except FuturesTimeout:
+        msg = f"Command timed out after {timeout}s: {' '.join(argv)}"
+        return ActionResult(
+            ok=False,
+            argv=list(argv),
+            returncode=124,
+            stdout="",
+            stderr=msg,
+            errors=[msg],
+            timed_out=True,
+            action_id=action_id,
+            mode="inprocess",
+        )
+    except Exception as exc:  # noqa: BLE001
+        msg = f"In-process invoke failed: {exc}"
+        return ActionResult(
+            ok=False,
+            argv=list(argv),
+            returncode=1,
+            stdout="",
+            stderr=msg,
+            errors=[msg],
+            timed_out=False,
+            action_id=action_id,
+            mode="inprocess",
+        )
+
+    return ActionResult(
+        ok=code == 0,
+        argv=list(argv),
+        returncode=code,
+        stdout=out,
+        stderr=err,
+        errors=[] if code == 0 else [f"exit {code}"],
+        timed_out=False,
+        action_id=action_id,
+        mode="inprocess",
+    )
+
+
+def execute_argv(
+    argv: list[str],
+    *,
+    mode: ExecuteMode = "inprocess",
+    timeout: float = 60.0,
+    cwd: Path | None = None,
+    action_id: str | None = None,
+    require_static_allowlist: bool = False,
+) -> ActionResult:
+    """Execute a fully-built argv with forbidden-token checks.
+
+    When ``require_static_allowlist`` is True (TUI static launcher path),
+    only field-less registered argvs are allowed.
+    """
+    if require_static_allowlist:
+        key = tuple(argv)
+        if key not in static_allowed_argvs():
+            msg = "argv not in TUI static allowlist; use execute_action(action_id, answers)."
+            return _deny(argv, msg, action_id=action_id, mode=mode, errors=[msg])
+
+    if mode == "subprocess":
+        return _subprocess_run(argv, timeout=timeout, cwd=cwd, action_id=action_id)
+    if mode == "inprocess":
+        return _inprocess_run(argv, timeout=timeout, cwd=cwd, action_id=action_id)
+    return _deny(
+        argv,
+        f"Unknown execute mode: {mode!r} (use 'inprocess' or 'subprocess')",
+        action_id=action_id,
+        mode=str(mode),
+    )
+
+
+def execute_action(
+    action_id: str,
+    answers: dict[str, str] | None = None,
+    *,
+    mode: ExecuteMode = "inprocess",
+    timeout: float = 60.0,
+    cwd: Path | None = None,
+) -> ActionResult:
+    """Validate answers, build argv from ActionSpec, and execute.
+
+    Parameters
+    ----------
+    action_id:
+        Registered id from ``studio_core.services.actions.ACTIONS``.
+    answers:
+        Form field values (stringly-typed, same as TUI forms).
+    mode:
+        ``inprocess`` (Web/API default) or ``subprocess`` (TUI isolation).
+    timeout:
+        Seconds before the run is aborted (both modes).
+    cwd:
+        Working directory; defaults to studio repo root.
+    """
+    ans = answers or {}
+    errors = validate_answers(action_id, ans)
+    if errors:
+        msg = "Validation failed: " + "; ".join(errors)
+        return _deny([], msg, action_id=action_id, mode=mode, errors=errors)
+
+    try:
+        argv = answers_to_argv(action_id, ans)
+    except (ValueError, KeyError) as exc:
+        return _deny([], str(exc), action_id=action_id, mode=mode, errors=[str(exc)])
+
+    return execute_argv(
+        argv,
+        mode=mode,
+        timeout=timeout,
+        cwd=cwd,
+        action_id=action_id,
+        require_static_allowlist=False,
+    )

--- a/tests/test_studio_core_execute.py
+++ b/tests/test_studio_core_execute.py
@@ -1,0 +1,88 @@
+"""PR3: studio_core execute_action (inprocess + subprocess)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "tools"))
+sys.path.insert(0, str(ROOT))
+
+from studio_core.services.execute import (  # noqa: E402
+    ActionResult,
+    execute_action,
+    execute_argv,
+)
+
+
+def test_execute_action_status_inprocess() -> None:
+    result = execute_action("status", mode="inprocess", timeout=60.0)
+    assert isinstance(result, ActionResult)
+    assert result.mode == "inprocess"
+    assert result.timed_out is False
+    assert result.returncode == 0
+    assert result.ok is True
+    assert result.action_id == "status"
+    assert result.argv == ["status"]
+    assert result.stdout
+    assert "4.5" in result.stdout or "Studio" in result.stdout or "Grok" in result.stdout
+
+
+def test_execute_action_status_subprocess() -> None:
+    result = execute_action("status", mode="subprocess", timeout=60.0)
+    assert result.mode == "subprocess"
+    assert result.returncode == 0
+    assert result.ok is True
+    assert result.argv == ["status"]
+    assert result.stdout
+
+
+def test_execute_action_validation_failure() -> None:
+    result = execute_action("bible_create", {"title": ""}, mode="inprocess")
+    assert result.ok is False
+    assert result.returncode != 0
+    assert result.errors
+    assert "required" in result.stderr.lower() or "validation" in result.stderr.lower()
+
+
+def test_execute_action_stack_inprocess() -> None:
+    result = execute_action("stack", mode="inprocess", timeout=60.0)
+    assert result.returncode == 0
+    assert "grok-4.5" in result.stdout or "VIDEO_PIPELINE" in result.stdout or "Model" in result.stdout
+
+
+def test_execute_argv_static_allowlist_rejects_freeform() -> None:
+    result = execute_argv(
+        ["create-bible", "Hacked", "--wizard"],
+        mode="subprocess",
+        require_static_allowlist=True,
+    )
+    assert result.ok is False
+    assert "allowlist" in result.stderr.lower() or "forbidden" in result.stderr.lower()
+
+
+def test_execute_argv_forbidden_token_without_allowlist() -> None:
+    result = execute_argv(["create-bible", "X", "--wizard"], mode="inprocess")
+    assert result.ok is False
+    assert "forbidden" in result.stderr.lower() or "wizard" in result.stderr.lower()
+
+
+def test_tui_runner_delegates_to_execute() -> None:
+    from cli.tui.runner import run_action
+
+    r = run_action("status", timeout=30.0)
+    assert r.returncode == 0
+    assert r.action_id == "status"
+    assert r.argv == ["status"]
+
+
+if __name__ == "__main__":
+    test_execute_action_status_inprocess()
+    test_execute_action_status_subprocess()
+    test_execute_action_validation_failure()
+    test_execute_action_stack_inprocess()
+    test_execute_argv_static_allowlist_rejects_freeform()
+    test_execute_argv_forbidden_token_without_allowlist()
+    test_tui_runner_delegates_to_execute()
+    print("studio_core execute tests passed")

--- a/tests/test_tui_runner.py
+++ b/tests/test_tui_runner.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 
 ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(ROOT / "tools"))
+sys.path.insert(0, str(ROOT))
 
 from cli.tui.runner import (  # noqa: E402
     cli_script_path,
@@ -36,7 +37,7 @@ def test_run_cli_command_timeout_sets_flag() -> None:
     import subprocess as sp
 
     with patch(
-        "cli.tui.runner.subprocess.run",
+        "studio_core.services.execute.subprocess.run",
         side_effect=sp.TimeoutExpired(cmd=["x"], timeout=0.01),
     ):
         result = run_cli_command(["status"], timeout=0.01)

--- a/tools/cli/tui/runner.py
+++ b/tools/cli/tui/runner.py
@@ -2,20 +2,28 @@
 
 Screens should call ``run_action(action_id, answers)`` only.
 ``run_cli_command`` is reserved for static allowlisted argv (no free-form).
+
+PR3: execution is delegated to ``studio_core.services.execute`` (subprocess mode)
+so Web/API can share validation + argv building with ``mode="inprocess"``.
 """
 
 from __future__ import annotations
 
-import subprocess
-import sys
 from dataclasses import dataclass
 from pathlib import Path
+import sys
 
-from cli.tui.actions import (
-    answers_to_argv,
-    reject_forbidden_argv,
-    static_allowed_argvs,
-    validate_answers,
+# Repo root for studio_core (tools/cli/tui → parents[3])
+_ROOT = Path(__file__).resolve().parents[3]
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+from studio_core.services.execute import (
+    ActionResult,
+    cli_script_path as _core_cli_script_path,
+    execute_action,
+    execute_argv,
+    resolve_repo_root,
 )
 
 
@@ -30,95 +38,23 @@ class CommandResult:
 
 
 def repo_root() -> Path:
-    """Project root containing tools/cinematic_studio_cli.py.
-
-    Walks up from this file; falls back to parents[3] (tools/cli/tui → root).
-    Honors CINEMATIC_PROJECT_DIR when set and valid.
-    """
-    import os
-
-    env = os.environ.get("CINEMATIC_PROJECT_DIR")
-    if env:
-        candidate = Path(env).expanduser().resolve()
-        if (candidate / "tools" / "cinematic_studio_cli.py").is_file():
-            return candidate
-
-    here = Path(__file__).resolve()
-    for parent in here.parents:
-        if (parent / "tools" / "cinematic_studio_cli.py").is_file():
-            return parent
-    # tools/cli/tui/runner.py → parents[3] == project root in normal layout
-    return here.parents[3]
+    """Project root containing tools/cinematic_studio_cli.py."""
+    return resolve_repo_root()
 
 
 def cli_script_path() -> Path:
-    return repo_root() / "tools" / "cinematic_studio_cli.py"
+    return _core_cli_script_path()
 
 
-def _deny_result(argv: list[str], message: str, *, action_id: str | None = None) -> CommandResult:
+def _from_action_result(result: ActionResult) -> CommandResult:
     return CommandResult(
-        argv=list(argv),
-        returncode=2,
-        stdout="",
-        stderr=message,
-        timed_out=False,
-        action_id=action_id,
+        argv=list(result.argv),
+        returncode=int(result.returncode),
+        stdout=result.stdout or "",
+        stderr=result.stderr or "",
+        timed_out=bool(result.timed_out),
+        action_id=result.action_id,
     )
-
-
-def _subprocess_run(
-    argv: list[str],
-    *,
-    timeout: float,
-    cwd: Path | None,
-    action_id: str | None = None,
-) -> CommandResult:
-    if not argv:
-        return _deny_result([], "No command argv provided.", action_id=action_id)
-
-    try:
-        reject_forbidden_argv(argv)
-    except ValueError as exc:
-        return _deny_result(argv, str(exc), action_id=action_id)
-
-    script = cli_script_path()
-    if not script.is_file():
-        return _deny_result(
-            argv,
-            f"CLI script not found: {script}",
-            action_id=action_id,
-        )
-
-    cmd = [sys.executable, str(script), *argv]
-    workdir = cwd or repo_root()
-    try:
-        completed = subprocess.run(
-            cmd,
-            capture_output=True,
-            text=True,
-            cwd=str(workdir),
-            timeout=max(1.0, float(timeout)),
-        )
-        return CommandResult(
-            argv=list(argv),
-            returncode=int(completed.returncode),
-            stdout=completed.stdout or "",
-            stderr=completed.stderr or "",
-            timed_out=False,
-            action_id=action_id,
-        )
-    except subprocess.TimeoutExpired as exc:
-        out = (exc.stdout or "") if isinstance(exc.stdout, str) else ""
-        err = (exc.stderr or "") if isinstance(exc.stderr, str) else ""
-        msg = f"Command timed out after {timeout}s: {' '.join(argv)}"
-        return CommandResult(
-            argv=list(argv),
-            returncode=124,
-            stdout=out,
-            stderr=(err + "\n" + msg).strip(),
-            timed_out=True,
-            action_id=action_id,
-        )
 
 
 def run_cli_command(
@@ -131,16 +67,14 @@ def run_cli_command(
 
     For form-built commands use :func:`run_action`. Free-form argv is rejected.
     """
-    if not argv:
-        return _deny_result([], "No command argv provided.")
-
-    key = tuple(argv)
-    if key not in static_allowed_argvs():
-        return _deny_result(
-            argv,
-            "argv not in TUI static allowlist; use run_action(action_id, answers).",
-        )
-    return _subprocess_run(argv, timeout=timeout, cwd=cwd)
+    result = execute_argv(
+        list(argv),
+        mode="subprocess",
+        timeout=timeout,
+        cwd=cwd,
+        require_static_allowlist=True,
+    )
+    return _from_action_result(result)
 
 
 def run_action(
@@ -150,17 +84,12 @@ def run_action(
     timeout: float = 60.0,
     cwd: Path | None = None,
 ) -> CommandResult:
-    """Build argv from a registered action and execute (only safe entrypoint)."""
-    ans = answers or {}
-    errors = validate_answers(action_id, ans)
-    if errors:
-        return _deny_result(
-            [],
-            "Validation failed: " + "; ".join(errors),
-            action_id=action_id,
-        )
-    try:
-        argv = answers_to_argv(action_id, ans)
-    except (ValueError, KeyError) as exc:
-        return _deny_result([], str(exc), action_id=action_id)
-    return _subprocess_run(argv, timeout=timeout, cwd=cwd, action_id=action_id)
+    """Build argv from a registered action and execute via subprocess (TUI safe)."""
+    result = execute_action(
+        action_id,
+        answers,
+        mode="subprocess",
+        timeout=timeout,
+        cwd=cwd,
+    )
+    return _from_action_result(result)


### PR DESCRIPTION
## Summary

Adds a shared execution layer on top of the ActionSpec registry:

```python
from studio_core.services.execute import execute_action

execute_action("status", mode="inprocess")   # Web/API default
execute_action("dna_lock", {"name": "Hero"}, mode="subprocess")  # TUI isolation
```

| Piece | Change |
|-------|--------|
| `studio_core/services/execute.py` | `ActionResult`, `execute_action`, `execute_argv` |
| `tools/cli/tui/runner.py` | Thin adapter → `mode="subprocess"` (same `CommandResult` API) |
| `tests/test_studio_core_execute.py` | inprocess/subprocess/validation/allowlist |
| `tests/test_tui_runner.py` | Patch path updated for moved subprocess |
| `docs/PR3_STUDIO_CORE_EXECUTE.md` | Notes |

## Safety

- Still requires registered `action_id` + `validate_answers`
- Forbidden tokens rejected in both modes
- Static allowlist still enforced for `run_cli_command` / `execute_argv(..., require_static_allowlist=True)`

## Test plan

- [x] 51 related tests passed
- [ ] TUI cockpit on real TTY
- [ ] Optional: call `execute_action` from Streamlit Tools page later

## Out of scope

- Direct domain-function dispatch (bypass Typer)
- FastAPI routes
- Streamlit wiring