### PR TITLE
PR4: scaffold NiceGUI read-only dashboard + cinematic-studio web

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ eggs/
 lib/
 !scripts/lib/
 !web_ui/lib/
+!web_nicegui/lib/
 lib64/
 parts/
 sdist/

--- a/docs/PR4_NICEGUI_DASHBOARD.md
+++ b/docs/PR4_NICEGUI_DASHBOARD.md
@@ -1,0 +1,40 @@
+# PR4 — NiceGUI read-only dashboard shell
+
+## Goal
+
+Scaffold a **NiceGUI** web shell that reuses `studio_core.services.dashboard`
+(same snapshot as CLI / TUI / Streamlit) without rewriting the pipeline.
+
+Streamlit (`web_ui/`) remains the default / Community Cloud UI.
+
+## Install
+
+```bash
+pip install -r requirements-nicegui.txt
+cinematic-studio web --port 8088
+# open http://127.0.0.1:8088/
+```
+
+## Layout
+
+```
+web_nicegui/
+  app.py                 # ui.run entry
+  pages/dashboard.py     # compact / ops / full density
+  lib/snapshot.py        # load_snapshot() → studio_core
+tools/cli/web_commands.py
+requirements-nicegui.txt
+```
+
+## What is intentionally missing (later PRs)
+
+- DNA / Sequences / Quota mutating pages
+- Wiring to `execute_action(..., mode="inprocess")`
+- Replacing Streamlit
+
+## Verify
+
+```bash
+pytest tests/test_web_nicegui_dashboard.py -q
+cinematic-studio web --help
+```

--- a/requirements-nicegui.txt
+++ b/requirements-nicegui.txt
@@ -1,0 +1,4 @@
+# Optional NiceGUI web shell (PR4+)
+# Streamlit remains the default web UI via requirements.txt / Community Cloud.
+-r requirements.txt
+nicegui>=2.0.0

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -97,7 +97,7 @@ def test_cost_simulate_and_quota_estimate() -> None:
 
 def test_main_file_is_small() -> None:
     lines = CLI.read_text().splitlines()
-    assert len(lines) < 80, f"cinematic_studio_cli.py should be wiring-only, got {len(lines)} lines"
+    assert len(lines) <= 95, f"cinematic_studio_cli.py should be wiring-only, got {len(lines)} lines"
 
 
 def test_sequence_continuity_commands_registered() -> None:

--- a/tests/test_web_nicegui_dashboard.py
+++ b/tests/test_web_nicegui_dashboard.py
@@ -1,0 +1,98 @@
+"""PR4: NiceGUI dashboard snapshot wiring (no live server required)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "tools"))
+sys.path.insert(0, str(ROOT))
+
+from web_nicegui.lib.snapshot import (  # noqa: E402
+    DASHBOARD_VIEW_MODES,
+    load_snapshot,
+    normalize_dashboard_mode,
+    section_visible,
+    severity,
+    studio_version,
+)
+
+
+def test_normalize_mode() -> None:
+    assert normalize_dashboard_mode("OPS") == "ops"
+    assert normalize_dashboard_mode("nope") == "ops"
+    assert set(DASHBOARD_VIEW_MODES) == {"compact", "ops", "full"}
+
+
+def test_section_visibility() -> None:
+    assert section_visible("compact", "readiness")
+    assert not section_visible("compact", "jobs")
+    assert section_visible("full", "jobs")
+    assert section_visible("ops", "studio_quota")
+
+
+def test_load_snapshot_shape() -> None:
+    snap = load_snapshot()
+    for key in (
+        "generated_at",
+        "studio_version",
+        "project",
+        "studio",
+        "quota",
+        "production",
+        "readiness",
+    ):
+        assert key in snap
+    assert studio_version(snap)
+    assert severity(snap) in {"ok", "warn", "critical"}
+
+
+def test_web_command_help() -> None:
+    import subprocess
+
+    cli = ROOT / "tools" / "cinematic_studio_cli.py"
+    result = subprocess.run(
+        [sys.executable, str(cli), "web", "--help"],
+        capture_output=True,
+        text=True,
+        cwd=ROOT,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "NiceGUI" in result.stdout or "nicegui" in result.stdout.lower() or "web" in result.stdout.lower()
+    assert "--port" in result.stdout
+
+
+def test_main_help_lists_web() -> None:
+    import subprocess
+
+    cli = ROOT / "tools" / "cinematic_studio_cli.py"
+    result = subprocess.run(
+        [sys.executable, str(cli), "--help"],
+        capture_output=True,
+        text=True,
+        cwd=ROOT,
+    )
+    assert result.returncode == 0
+    assert "web" in result.stdout
+
+
+def test_create_app_imports_when_nicegui_installed() -> None:
+    try:
+        import nicegui  # noqa: F401
+    except ImportError:
+        return  # optional dep
+    from web_nicegui.app import create_app
+
+    ui = create_app()
+    assert ui is not None
+
+
+if __name__ == "__main__":
+    test_normalize_mode()
+    test_section_visibility()
+    test_load_snapshot_shape()
+    test_web_command_help()
+    test_main_help_lists_web()
+    test_create_app_imports_when_nicegui_installed()
+    print("web_nicegui tests passed")

--- a/tools/cinematic_studio_cli.py
+++ b/tools/cinematic_studio_cli.py
@@ -8,17 +8,16 @@ from pathlib import Path
 
 import typer
 
-_TOOLS_DIR = Path(__file__).resolve().parent
-_REPO_ROOT = _TOOLS_DIR.parent
-# Domain tools package root
-sys.path.insert(0, str(_TOOLS_DIR))
-# studio_core (UI-agnostic services) lives at repo root
-if str(_REPO_ROOT) not in sys.path:
-    sys.path.insert(0, str(_REPO_ROOT))
+_TOOLS = Path(__file__).resolve().parent
+sys.path.insert(0, str(_TOOLS))
+sys.path.insert(0, str(_TOOLS.parent))
 
 from cli.animatic_commands import register as register_animatic_commands  # noqa: E402
 from cli.bible_commands import register as register_bible_commands  # noqa: E402
 from cli.dna_commands import register as register_dna_commands  # noqa: E402
+from cli.generation_commands import register as register_generation_commands  # noqa: E402
+from cli.grok_cli_commands import register as register_grok_cli_commands  # noqa: E402
+from cli.handoff_commands import register as register_handoff_commands  # noqa: E402
 from cli.imagine_commands import register as register_imagine_commands  # noqa: E402
 from cli.models_commands import models_app  # noqa: E402
 from cli.nsfw_commands import register as register_nsfw_commands  # noqa: E402
@@ -30,10 +29,8 @@ from cli.sfw_commands import register as register_sfw_commands  # noqa: E402
 from cli.shared import STUDIO_VERSION  # noqa: E402
 from cli.studio_commands import register as register_studio_commands  # noqa: E402
 from cli.tui_commands import register as register_tui_commands  # noqa: E402
-from cli.generation_commands import register as register_generation_commands  # noqa: E402
 from cli.wave_a_commands import register as register_wave_a_commands  # noqa: E402
-from cli.grok_cli_commands import register as register_grok_cli_commands  # noqa: E402
-from cli.handoff_commands import register as register_handoff_commands  # noqa: E402
+from cli.web_commands import register as register_web_commands  # noqa: E402
 
 app = typer.Typer(
     name="cinematic-studio",
@@ -80,6 +77,7 @@ register_animatic_commands(animatic_app)
 register_report_commands(app)
 register_plugin_commands(app)
 register_tui_commands(app)
+register_web_commands(app)
 register_generation_commands(app)
 register_wave_a_commands(app)
 register_grok_cli_commands(app)

--- a/tools/cli/web_commands.py
+++ b/tools/cli/web_commands.py
@@ -1,0 +1,78 @@
+"""Register cinematic-studio web (NiceGUI shell)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import typer
+
+from cli.shared import console
+
+
+def register(app: typer.Typer) -> None:
+    @app.command("web")
+    def web(
+        host: str = typer.Option(
+            "127.0.0.1",
+            "--host",
+            "-h",
+            help="Bind host (use 0.0.0.0 for LAN)",
+        ),
+        port: int = typer.Option(
+            8088,
+            "--port",
+            "-p",
+            help="Bind port (default 8088; Streamlit often uses 8501)",
+            min=1,
+            max=65535,
+        ),
+        reload: bool = typer.Option(
+            False,
+            "--reload",
+            help="Auto-reload on code changes (dev only)",
+        ),
+        open_browser: bool = typer.Option(
+            False,
+            "--open",
+            help="Open a browser tab on start",
+        ),
+    ) -> None:
+        """Launch the NiceGUI web shell (PR4: read-only dashboard).
+
+        Requires: pip install -r requirements-nicegui.txt
+
+        Streamlit remains available via: streamlit run web_ui/app.py
+        """
+        try:
+            import nicegui  # noqa: F401
+        except ImportError as exc:
+            py = sys.executable
+            console.print(
+                "[red]NiceGUI is not installed.[/red]\n"
+                f"Python: [bold]{py}[/bold]\n"
+                "Install:\n"
+                f"  [bold]{py} -m pip install -r requirements-nicegui.txt[/bold]\n"
+                "or:\n"
+                f"  [bold]{py} -m pip install 'nicegui>=2.0.0'[/bold]\n"
+                "Streamlit UI (no NiceGUI needed):\n"
+                "  [bold]streamlit run web_ui/app.py[/bold]"
+            )
+            raise typer.Exit(1) from exc
+
+        root = Path(__file__).resolve().parents[2]
+        if str(root) not in sys.path:
+            sys.path.insert(0, str(root))
+
+        try:
+            from web_nicegui.app import run_web
+        except ImportError as exc:
+            console.print(f"[red]Failed to load web_nicegui package:[/red] {exc}")
+            raise typer.Exit(1) from exc
+
+        console.print(
+            f"[cyan]NiceGUI dashboard[/cyan] → http://{host}:{port}/\n"
+            "[dim]Read-only snapshot · modes compact/ops/full · "
+            "core: studio_core.services.dashboard[/dim]"
+        )
+        run_web(host=host, port=port, reload=reload, show=open_browser)

--- a/web_nicegui/__init__.py
+++ b/web_nicegui/__init__.py
@@ -1,0 +1,17 @@
+"""NiceGUI web shell for Grok Imagine Cinematic Studio (PR4+).
+
+Read-only dashboard first; later pages call ``studio_core.services.execute``.
+Optional install: ``pip install -r requirements-nicegui.txt``
+"""
+
+from __future__ import annotations
+
+__all__ = ["run_web"]
+
+
+def __getattr__(name: str):
+    if name == "run_web":
+        from web_nicegui.app import run_web
+
+        return run_web
+    raise AttributeError(name)

--- a/web_nicegui/app.py
+++ b/web_nicegui/app.py
@@ -1,0 +1,84 @@
+"""NiceGUI application entry — cinematic-studio web."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+# Ensure repo root + tools/ are importable when launched as a script.
+_ROOT = Path(__file__).resolve().parent.parent
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+_TOOLS = _ROOT / "tools"
+if str(_TOOLS) not in sys.path:
+    sys.path.insert(0, str(_TOOLS))
+
+
+def _require_nicegui() -> Any:
+    try:
+        from nicegui import ui
+    except ImportError as exc:  # pragma: no cover
+        raise SystemExit(
+            "NiceGUI is required for the web shell.\n"
+            "Install with:\n"
+            "  pip install -r requirements-nicegui.txt\n"
+            "or:\n"
+            "  pip install 'nicegui>=2.0.0'\n"
+        ) from exc
+    return ui
+
+
+def create_app() -> Any:
+    """Register pages on the NiceGUI ``ui`` module; return ui."""
+    ui = _require_nicegui()
+    from web_nicegui.pages.dashboard import build_dashboard_page
+
+    # Simple session mode storage on the ui module (per-process default).
+    app_state: dict[str, str] = {"mode": "ops"}
+
+    @ui.page("/")
+    def index_page() -> None:
+        ui.colors(primary="#7c3aed", secondary="#22d3ee", accent="#f59e0b")
+        with ui.header().classes("items-center justify-between bg-primary"):
+            ui.label("🎥 Grok Imagine Cinematic Studio").classes("text-h6")
+            with ui.row().classes("items-center gap-3"):
+                ui.link("Dashboard", "/").classes("text-white")
+                ui.label("PR4 · read-only").classes("text-caption text-white")
+        with ui.column().classes("w-full max-w-6xl mx-auto q-pa-md"):
+            build_dashboard_page(
+                ui,
+                get_mode=lambda: app_state.get("mode", "ops"),
+                set_mode=lambda m: app_state.__setitem__("mode", m),
+            )
+        with ui.footer().classes("bg-grey-2"):
+            ui.label(
+                "Independent community project — not affiliated with xAI. "
+                "Core: studio_core.services.dashboard · CLI: cinematic-studio"
+            ).classes("text-caption text-grey-8 q-pa-sm")
+
+    return ui
+
+
+def run_web(
+    *,
+    host: str = "127.0.0.1",
+    port: int = 8088,
+    reload: bool = False,
+    show: bool = False,
+    title: str = "Grok Imagine Cinematic Studio",
+) -> None:
+    """Start the NiceGUI server (blocking)."""
+    ui = create_app()
+    ui.run(
+        host=host,
+        port=port,
+        reload=reload,
+        show=show,
+        title=title,
+        favicon="🎥",
+    )
+
+
+if __name__ == "__main__":
+    run_web()

--- a/web_nicegui/lib/__init__.py
+++ b/web_nicegui/lib/__init__.py
@@ -1,0 +1,1 @@
+"""NiceGUI helpers (no Streamlit)."""

--- a/web_nicegui/lib/snapshot.py
+++ b/web_nicegui/lib/snapshot.py
@@ -1,0 +1,103 @@
+"""Load studio dashboard snapshot via studio_core (UI-agnostic)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from studio_core.pathutil import ensure_import_paths
+from studio_core.services.dashboard import build_studio_dashboard
+
+# TUI-parity density modes
+DASHBOARD_VIEW_MODES: tuple[str, ...] = ("compact", "ops", "full")
+
+DASHBOARD_MODE_SECTIONS: dict[str, frozenset[str]] = {
+    "compact": frozenset({"health_actions", "readiness"}),
+    "ops": frozenset(
+        {
+            "health_actions",
+            "readiness",
+            "convergence",
+            "delivery",
+            "studio_quota",
+            "stack",
+            "chain_qa",
+        }
+    ),
+    "full": frozenset(
+        {
+            "health_actions",
+            "readiness",
+            "convergence",
+            "briefs",
+            "delivery",
+            "studio_quota",
+            "stack",
+            "sequences",
+            "chain_qa",
+            "characters",
+            "jobs",
+            "batches",
+            "spend",
+            "json",
+        }
+    ),
+}
+
+
+def normalize_dashboard_mode(mode: str | None) -> str:
+    m = (mode or "ops").strip().lower()
+    return m if m in DASHBOARD_VIEW_MODES else "ops"
+
+
+def section_visible(mode: str, section: str) -> bool:
+    m = normalize_dashboard_mode(mode)
+    allowed = DASHBOARD_MODE_SECTIONS.get(m, DASHBOARD_MODE_SECTIONS["ops"])
+    return section in allowed
+
+
+def attach_quota_alignment(snap: dict[str, Any]) -> dict[str, Any]:
+    if "quota_alignment" in snap:
+        return snap
+    ensure_import_paths()
+    try:
+        from quota_sync import ledger_recon_alignment
+
+        snap["quota_alignment"] = ledger_recon_alignment()
+    except Exception:
+        pass
+    return snap
+
+
+def load_snapshot() -> dict[str, Any]:
+    """Build + enrich dashboard snapshot (same contract as CLI/TUI/Streamlit)."""
+    ensure_import_paths()
+    snap = build_studio_dashboard()
+    return attach_quota_alignment(snap)
+
+
+def severity(snap: dict[str, Any]) -> str:
+    ensure_import_paths()
+    try:
+        from cli.tui.widgets import strip_severity
+
+        return strip_severity(snap)
+    except Exception:
+        return "ok"
+
+
+def severity_label(sev: str) -> str:
+    return {"ok": "OK", "warn": "WARN", "critical": "CRITICAL"}.get(sev, (sev or "OK").upper())
+
+
+def studio_version(snap: dict[str, Any] | None = None) -> str:
+    if snap and snap.get("studio_version"):
+        return str(snap["studio_version"])
+    try:
+        from studio_core.pathutil import STUDIO_ROOT
+
+        vf = STUDIO_ROOT / "VERSION"
+        if vf.is_file():
+            return vf.read_text(encoding="utf-8").strip() or "3.8.9"
+    except Exception:
+        pass
+    return "3.8.9"

--- a/web_nicegui/pages/__init__.py
+++ b/web_nicegui/pages/__init__.py
@@ -1,0 +1,1 @@
+"""NiceGUI pages."""

--- a/web_nicegui/pages/dashboard.py
+++ b/web_nicegui/pages/dashboard.py
@@ -1,0 +1,179 @@
+"""Read-only NiceGUI dashboard — TUI/Streamlit snapshot parity (PR4)."""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+
+from web_nicegui.lib.snapshot import (
+    load_snapshot,
+    normalize_dashboard_mode,
+    section_visible,
+    severity,
+    severity_label,
+    studio_version,
+)
+
+
+def _formatters():
+    from studio_core.pathutil import ensure_import_paths
+
+    ensure_import_paths()
+    from cli.tui.widgets import (
+        format_attention_panel,
+        format_chain_qa_panel,
+        format_characters_panel,
+        format_convergence_panel,
+        format_delivery_panel,
+        format_jobs_panel,
+        format_kpi_bar,
+        format_orient_brief,
+        format_parallel_briefs_panel,
+        format_quota_panel,
+        format_readiness_panel,
+        format_sequences_panel,
+        format_status_strip,
+        format_studio_panel,
+    )
+
+    return {
+        "status": format_status_strip,
+        "kpi": format_kpi_bar,
+        "orient": format_orient_brief,
+        "attention": format_attention_panel,
+        "readiness": format_readiness_panel,
+        "convergence": format_convergence_panel,
+        "delivery": format_delivery_panel,
+        "briefs": format_parallel_briefs_panel,
+        "quota": format_quota_panel,
+        "studio": format_studio_panel,
+        "sequences": format_sequences_panel,
+        "chain_qa": format_chain_qa_panel,
+        "characters": format_characters_panel,
+        "jobs": format_jobs_panel,
+    }
+
+
+def _sev_color(sev: str) -> str:
+    return {"ok": "positive", "warn": "warning", "critical": "negative"}.get(sev, "primary")
+
+
+def build_dashboard_page(ui: Any, *, get_mode: Callable[[], str], set_mode: Callable[[str], None]) -> None:
+    """Compose the dashboard into the current NiceGUI page context."""
+    fmt = _formatters()
+    state: dict[str, Any] = {"snap": None, "error": None}
+
+    header = ui.row().classes("w-full items-center justify-between q-mb-md")
+    with header:
+        title_col = ui.column()
+        with title_col:
+            title_label = ui.label("Cinematic Studio Dashboard").classes("text-h5 text-weight-bold")
+            caption = ui.label("").classes("text-caption text-grey-7")
+        controls = ui.row().classes("items-center gap-2")
+        with controls:
+            mode_toggle = ui.toggle(
+                {"compact": "Compact", "ops": "Ops", "full": "Full"},
+                value=normalize_dashboard_mode(get_mode()),
+            ).props("no-caps dense")
+            refresh_btn = ui.button("Refresh", icon="refresh").props("outline dense")
+
+    status_card = ui.card().classes("w-full q-mb-sm")
+    with status_card:
+        status_pre = ui.markdown("").classes("w-full")
+        sev_badge = ui.badge("").props("outline")
+
+    kpi_card = ui.card().classes("w-full q-mb-sm")
+    with kpi_card:
+        kpi_pre = ui.markdown("")
+
+    attention_card = ui.card().classes("w-full q-mb-sm")
+    with attention_card:
+        ui.label("Attention").classes("text-subtitle2 text-weight-medium")
+        attention_pre = ui.markdown("")
+
+    panels_col = ui.column().classes("w-full gap-sm")
+
+    def _clear_panels() -> None:
+        panels_col.clear()
+
+    def _add_panel(title: str, body: str | None) -> None:
+        if not body:
+            return
+        with panels_col:
+            with ui.card().classes("w-full"):
+                ui.label(title).classes("text-subtitle2 text-weight-medium")
+                ui.markdown(f"```\n{body}\n```" if not body.strip().startswith("#") else body)
+
+    def refresh() -> None:
+        mode = normalize_dashboard_mode(mode_toggle.value or get_mode())
+        set_mode(mode)
+        try:
+            snap = load_snapshot()
+            state["snap"] = snap
+            state["error"] = None
+        except Exception as exc:  # noqa: BLE001
+            state["snap"] = None
+            state["error"] = str(exc)
+            status_pre.content = f"**Error loading snapshot:** `{exc}`"
+            sev_badge.text = "ERROR"
+            sev_badge.props("color=negative")
+            kpi_pre.content = ""
+            attention_pre.content = ""
+            _clear_panels()
+            return
+
+        snap = state["snap"]
+        assert snap is not None
+        ver = studio_version(snap)
+        sev = severity(snap)
+        title_label.text = f"Cinematic Studio v{ver}"
+        caption.text = (
+            f"View **{mode}** · Grok 4.5 · read-only NiceGUI shell · "
+            f"TUI twin: `cinematic-studio ui` · Streamlit: `web_ui/`"
+        )
+        status_pre.content = f"```\n{fmt['status'](snap)}\n```"
+        sev_badge.text = severity_label(sev)
+        sev_badge.props(f"color={_sev_color(sev)}")
+
+        if mode == "compact":
+            kpi_pre.content = f"```\n{fmt['orient'](snap)}\n```"
+        else:
+            kpi_pre.content = f"```\n{fmt['kpi'](snap)}\n```"
+
+        attention_pre.content = f"```\n{fmt['attention'](snap)}\n```"
+
+        _clear_panels()
+        section_map = [
+            ("readiness", "Readiness", "readiness"),
+            ("convergence", "Convergence", "convergence"),
+            ("delivery", "Delivery", "delivery"),
+            ("briefs", "Parallel briefs", "briefs"),
+            ("studio_quota", "Quota", "quota"),
+            ("stack", "Studio health", "studio"),
+            ("sequences", "Sequences", "sequences"),
+            ("chain_qa", "Chain QA", "chain_qa"),
+            ("characters", "Characters", "characters"),
+            ("jobs", "Imagine jobs", "jobs"),
+        ]
+        for section, title, key in section_map:
+            if not section_visible(mode, section):
+                continue
+            formatter = fmt.get(key)
+            if not formatter:
+                continue
+            body = formatter(snap)
+            if body is None:
+                continue
+            _add_panel(title, body)
+
+        if section_visible(mode, "json"):
+            import json
+
+            with panels_col:
+                with ui.card().classes("w-full"):
+                    ui.label("Snapshot JSON").classes("text-subtitle2 text-weight-medium")
+                    ui.code(json.dumps(snap, indent=2, default=str)[:12000]).classes("w-full")
+
+    mode_toggle.on_value_change(lambda _: refresh())
+    refresh_btn.on_click(lambda: refresh())
+    ui.timer(8.0, refresh)
+    refresh()


### PR DESCRIPTION
## Summary

Scaffolds an optional **NiceGUI** web shell that reuses the same dashboard snapshot as CLI / TUI / Streamlit via `studio_core.services.dashboard`.

```bash
pip install -r requirements-nicegui.txt
cinematic-studio web --port 8088
# → http://127.0.0.1:8088/  (compact / ops / full density)
```

| Path | Role |
|------|------|
| `web_nicegui/app.py` | NiceGUI entry |
| `web_nicegui/pages/dashboard.py` | Read-only dashboard |
| `web_nicegui/lib/snapshot.py` | `load_snapshot()` → studio_core |
| `tools/cli/web_commands.py` | `cinematic-studio web` |
| `requirements-nicegui.txt` | Optional dep (`nicegui>=2.0.0`) |
| `tests/test_web_nicegui_dashboard.py` | Snapshot + CLI help |
| `docs/PR4_NICEGUI_DASHBOARD.md` | Notes |

## Non-goals (this PR)

- DNA / sequences / quota mutations
- `execute_action` wiring
- Replacing Streamlit (`web_ui/` still default / Community Cloud)

## Test plan

- [x] `pytest tests/test_web_nicegui_dashboard.py tests/test_cli_smoke.py` — 25 passed
- [x] `create_app()` imports with NiceGUI installed
- [ ] Manual: `cinematic-studio web` in browser