### PR TITLE
PR6: NiceGUI Production + Imagine pages via execute_action

### DIFF
--- a/docs/PR6_NICEGUI_PRODUCTION_IMAGINE.md
+++ b/docs/PR6_NICEGUI_PRODUCTION_IMAGINE.md
@@ -1,0 +1,25 @@
+# PR6 — NiceGUI Production + Imagine
+
+## Routes
+
+| Path | Actions |
+|------|---------|
+| `/production` | `status`, `validate`, `stack`, `doctor_quick`, `models_*`, `bible_create`, `handoff_validate` |
+| `/imagine` | `imagine_list`, `imagine_bridge`, `sequence_handoff`, `dna_handoff` |
+
+All via `execute_action(..., mode="inprocess")`.
+
+Streamlit keeps the full multi-stage bible wizard and live xAI batch execute.
+
+## Run
+
+```bash
+pip install -r requirements-nicegui.txt
+cinematic-studio web --port 8088
+```
+
+## Verify
+
+```bash
+pytest tests/test_web_nicegui_production_imagine.py tests/test_web_nicegui_pages.py -q
+```

--- a/tests/test_web_nicegui_production_imagine.py
+++ b/tests/test_web_nicegui_production_imagine.py
@@ -1,0 +1,81 @@
+"""PR6: NiceGUI Production + Imagine pages via execute_action."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "tools"))
+sys.path.insert(0, str(ROOT))
+
+from web_nicegui.lib.actions_ui import run_registered  # noqa: E402
+from web_nicegui.pages import imagine, production  # noqa: E402
+
+
+def test_page_builders_exist() -> None:
+    assert callable(production.build_production_page)
+    assert callable(imagine.build_imagine_page)
+
+
+def test_run_status_and_imagine_list() -> None:
+    status = run_registered("status", timeout=60.0)
+    assert status.ok is True
+    assert status.argv == ["status"]
+
+    jobs = run_registered("imagine_list", timeout=60.0)
+    assert jobs.ok is True
+    assert jobs.argv == ["imagine", "list"]
+
+
+def test_models_verify_and_validate() -> None:
+    models = run_registered("models_verify", timeout=90.0)
+    assert models.ok is True
+    assert models.argv == ["models", "verify"]
+
+    val = run_registered("validate", timeout=90.0)
+    assert val.ok is True
+    assert val.argv == ["validate"]
+
+
+def test_bible_create_validation_failure() -> None:
+    result = run_registered("bible_create", {"title": ""}, timeout=30.0)
+    assert result.ok is False
+
+
+def test_nav_includes_production_and_imagine() -> None:
+    from web_nicegui.lib.layout import NAV
+
+    paths = {p for p, _ in NAV}
+    assert "/production" in paths
+    assert "/imagine" in paths
+    assert "/dna" in paths
+
+
+def test_create_app_registers_new_routes() -> None:
+    try:
+        import nicegui  # noqa: F401
+    except ImportError:
+        return
+    from web_nicegui.app import create_app
+
+    assert create_app() is not None
+
+
+def test_run_registered_error_path_no_crash() -> None:
+    with patch("web_nicegui.lib.actions_ui.execute_action", side_effect=RuntimeError("x")):
+        r = run_registered("status")
+    assert r.ok is False
+    assert "x" in r.stderr
+
+
+if __name__ == "__main__":
+    test_page_builders_exist()
+    test_run_status_and_imagine_list()
+    test_models_verify_and_validate()
+    test_bible_create_validation_failure()
+    test_nav_includes_production_and_imagine()
+    test_create_app_registers_new_routes()
+    test_run_registered_error_path_no_crash()
+    print("PR6 tests passed")

--- a/tools/cli/web_commands.py
+++ b/tools/cli/web_commands.py
@@ -38,7 +38,7 @@ def register(app: typer.Typer) -> None:
             help="Open a browser tab on start",
         ),
     ) -> None:
-        """Launch the NiceGUI web shell (PR5: dashboard + DNA + sequences + quota).
+        """Launch the NiceGUI web shell (PR6: full shell (dashboard/production/DNA/sequences/imagine/quota)).
 
         Requires: pip install -r requirements-nicegui.txt
 
@@ -72,7 +72,7 @@ def register(app: typer.Typer) -> None:
 
         console.print(
             f"[cyan]NiceGUI dashboard[/cyan] → http://{host}:{port}/\n"
-            "[dim]Dashboard + DNA/Sequences/Quota via execute_action · modes compact/ops/full · "
+            "[dim]Dashboard · Production · DNA · Sequences · Imagine · Quota via execute_action · modes compact/ops/full · "
             "core: studio_core.services.dashboard[/dim]"
         )
         run_web(host=host, port=port, reload=reload, show=open_browser)

--- a/web_nicegui/app.py
+++ b/web_nicegui/app.py
@@ -35,6 +35,8 @@ def create_app() -> Any:
     from web_nicegui.lib.layout import page_shell
     from web_nicegui.pages.dashboard import build_dashboard_page
     from web_nicegui.pages.dna import build_dna_page
+    from web_nicegui.pages.imagine import build_imagine_page
+    from web_nicegui.pages.production import build_production_page
     from web_nicegui.pages.quota import build_quota_page
     from web_nicegui.pages.sequences import build_sequences_page
 
@@ -50,6 +52,12 @@ def create_app() -> Any:
                 set_mode=lambda m: app_state.__setitem__("mode", m),
             )
 
+    @ui.page("/production")
+    def production_page() -> None:
+        page_shell(ui, active="/production")
+        with ui.column().classes("w-full max-w-6xl mx-auto q-pa-md"):
+            build_production_page(ui)
+
     @ui.page("/dna")
     def dna_page() -> None:
         page_shell(ui, active="/dna")
@@ -61,6 +69,12 @@ def create_app() -> Any:
         page_shell(ui, active="/sequences")
         with ui.column().classes("w-full max-w-6xl mx-auto q-pa-md"):
             build_sequences_page(ui)
+
+    @ui.page("/imagine")
+    def imagine_page() -> None:
+        page_shell(ui, active="/imagine")
+        with ui.column().classes("w-full max-w-6xl mx-auto q-pa-md"):
+            build_imagine_page(ui)
 
     @ui.page("/quota")
     def quota_page() -> None:

--- a/web_nicegui/lib/layout.py
+++ b/web_nicegui/lib/layout.py
@@ -6,18 +6,20 @@ from typing import Any
 
 NAV = (
     ("/", "Dashboard"),
+    ("/production", "Production"),
     ("/dna", "DNA"),
     ("/sequences", "Sequences"),
+    ("/imagine", "Imagine"),
     ("/quota", "Quota"),
 )
 
 
-def page_shell(ui: Any, *, active: str, badge: str = "PR5") -> None:
+def page_shell(ui: Any, *, active: str, badge: str = "PR6") -> None:
     """Apply colors, header nav, and footer once per page."""
     ui.colors(primary="#7c3aed", secondary="#22d3ee", accent="#f59e0b")
     with ui.header().classes("items-center justify-between bg-primary"):
         ui.label("Grok Imagine Cinematic Studio").classes("text-h6 text-white")
-        with ui.row().classes("items-center gap-3"):
+        with ui.row().classes("items-center gap-2 flex-wrap"):
             for path, label in NAV:
                 cls = "text-white text-weight-bold" if path == active else "text-white"
                 ui.link(label, path).classes(cls)

--- a/web_nicegui/pages/imagine.py
+++ b/web_nicegui/pages/imagine.py
@@ -1,0 +1,45 @@
+"""NiceGUI Imagine page — jobs list + bridge via execute_action."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from web_nicegui.lib.actions_ui import (
+    _format_result,
+    _set_md,
+    build_action_form,
+    run_registered,
+)
+
+
+def build_imagine_page(ui: Any) -> None:
+    ui.label("Imagine").classes("text-h5 text-weight-bold")
+    ui.label(
+        "Job queue + agent-handoff bridge via execute_action. "
+        "SFW batch execute / live xAI generation stay on Streamlit when an API key is set."
+    ).classes("text-caption text-grey-7 q-mb-md")
+
+    with ui.card().classes("w-full q-mb-md"):
+        ui.label("Imagine jobs").classes("text-subtitle1 text-weight-medium")
+        list_box = ui.markdown("_Loading imagine list…_")
+
+    def refresh() -> None:
+        result = run_registered("imagine_list")
+        _set_md(list_box, _format_result(result, limit=12000))
+
+    with ui.row().classes("q-mb-md gap-2"):
+        ui.button("Refresh jobs", icon="refresh", on_click=refresh).props("outline")
+
+    with ui.tabs().classes("w-full") as tabs:
+        tab_bridge = ui.tab("Bridge")
+        tab_seq_handoff = ui.tab("Sequence handoff")
+        tab_dna_handoff = ui.tab("DNA handoff")
+    with ui.tab_panels(tabs, value=tab_bridge).classes("w-full"):
+        with ui.tab_panel(tab_bridge):
+            build_action_form(ui, "imagine_bridge", force_confirm=False, on_done=lambda _r: refresh())
+        with ui.tab_panel(tab_seq_handoff):
+            build_action_form(ui, "sequence_handoff", on_done=lambda _r: refresh())
+        with ui.tab_panel(tab_dna_handoff):
+            build_action_form(ui, "dna_handoff", on_done=lambda _r: refresh())
+
+    ui.timer(0.05, refresh, once=True)

--- a/web_nicegui/pages/production.py
+++ b/web_nicegui/pages/production.py
@@ -1,0 +1,70 @@
+"""NiceGUI Production page — bible create + health checks via execute_action."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from web_nicegui.lib.actions_ui import (
+    _format_result,
+    _set_md,
+    build_action_form,
+    run_registered,
+)
+
+
+def build_production_page(ui: Any) -> None:
+    ui.label("Production").classes("text-h5 text-weight-bold")
+    ui.label(
+        "Production bible + studio health via ActionSpec / execute_action (in-process). "
+        "Full multi-stage Streamlit wizard remains in web_ui/pages/production.py."
+    ).classes("text-caption text-grey-7 q-mb-md")
+
+    with ui.card().classes("w-full q-mb-md"):
+        ui.label("Studio health").classes("text-subtitle1 text-weight-medium")
+        health_box = ui.markdown("_Run status / validate / stack / doctor below._")
+
+    def _show(result) -> None:
+        _set_md(health_box, _format_result(result, limit=12000))
+
+    with ui.row().classes("q-mb-md gap-2 flex-wrap"):
+        ui.button(
+            "Status",
+            icon="info",
+            on_click=lambda: _show(run_registered("status")),
+        ).props("outline")
+        ui.button(
+            "Validate",
+            icon="verified",
+            on_click=lambda: _show(run_registered("validate")),
+        ).props("outline")
+        ui.button(
+            "Stack",
+            icon="layers",
+            on_click=lambda: _show(run_registered("stack")),
+        ).props("outline")
+        ui.button(
+            "Doctor (quick)",
+            icon="medical_services",
+            on_click=lambda: _show(run_registered("doctor_quick")),
+        ).props("outline")
+        ui.button(
+            "Models verify",
+            icon="smart_toy",
+            on_click=lambda: _show(run_registered("models_verify")),
+        ).props("outline")
+        ui.button(
+            "Models list",
+            icon="list",
+            on_click=lambda: _show(run_registered("models_list")),
+        ).props("outline")
+
+    with ui.tabs().classes("w-full") as tabs:
+        tab_bible = ui.tab("Create bible")
+        tab_handoff = ui.tab("Handoff validate")
+    with ui.tab_panels(tabs, value=tab_bible).classes("w-full"):
+        with ui.tab_panel(tab_bible):
+            build_action_form(ui, "bible_create")
+        with ui.tab_panel(tab_handoff):
+            build_action_form(ui, "handoff_validate", force_confirm=False)
+
+    ui.timer(0.05, lambda: _show(run_registered("status")), once=True)


### PR DESCRIPTION
## Summary

Completes the NiceGUI shell surface area for core studio workflows:

| Route | Wired actions |
|-------|----------------|
| `/production` | status, validate, stack, doctor, models, bible_create, handoff_validate |
| `/imagine` | imagine_list, imagine_bridge, sequence_handoff, dna_handoff |

Nav now: Dashboard · Production · DNA · Sequences · Imagine · Quota

Streamlit still owns the multi-stage bible wizard and live xAI batch execute.

## Test plan

- [x] 20 pytest (PR6 + prior web pages)
- [x] HTTP 200 on all six routes
- [ ] Manual: `cinematic-studio web` → Production status → Imagine list