### PR TITLE
PR7: dual-run docs for Streamlit + NiceGUI + studio_core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,15 @@ All notable changes to Grok Imagine Cinematic Studio will be documented in this 
 
 ## [Unreleased]
 
+### Added
+- **`studio_core` service layer** — `build_studio_dashboard`, ActionSpec registry, `execute_action` (in-process + subprocess) shared by TUI / Streamlit / NiceGUI
+- **NiceGUI web shell** — `cinematic-studio web` routes: Dashboard, Production, DNA, Sequences, Imagine, Quota (`web_nicegui/`, optional `requirements-nicegui.txt`)
+- **Dual-run guide** — [`docs/guides/WEB_SHELLS.md`](docs/guides/WEB_SHELLS.md)
+
 ### Changed
 - **TUI command palette** — `/` or Ctrl+P opens allowlisted action search; KPI bar under status strip; `y` saves orient brief to `artifacts/tui_orient_brief.txt`; scroll preserved on refresh
 - **TUI non-TTY fallback** — `cinematic-studio ui --print` (and bare `ui` without a TTY) prints the orient dashboard instead of hard-failing; optional `artifacts/tui_orient_brief.txt`
+- **TUI runner** — delegates to `studio_core.services.execute` (`mode=subprocess`); `cli.tui.actions` re-exports core ActionSpec catalog
 
 ## [3.8.9] - 2026-07-26
 

--- a/README.md
+++ b/README.md
@@ -46,9 +46,11 @@ Whether you’re crafting Marvel-style hero reveals, cyberpunk neon sequences, i
 
 - **TUI Home view modes** — `1` compact · `2` ops · `3` full · Tab cycle · `p` pause auto-refresh · action list filter
 - **Streamlit Dashboard view modes** — same compact/ops/full density (session radio; TUI 1/2/3 parity)
+- **Shared `studio_core` services** — UI-agnostic dashboard snapshot, ActionSpec registry, and `execute_action` (in-process / subprocess)
+- **NiceGUI web shell** — `cinematic-studio web` (Dashboard · Production · DNA · Sequences · Imagine · Quota); dual-run with Streamlit
 - Prior **3.8.8** — Operator UX control plane (readiness · convergence · delivery · handoff validate · Wave A packaging)
 
-See full details in [CHANGELOG.md](CHANGELOG.md) and [docs/releases/RELEASE_NOTES_v3.8.9.md](docs/releases/RELEASE_NOTES_v3.8.9.md).
+See full details in [CHANGELOG.md](CHANGELOG.md) and [docs/releases/RELEASE_NOTES_v3.8.9.md](docs/releases/RELEASE_NOTES_v3.8.9.md). Dual-run web guide: [docs/guides/WEB_SHELLS.md](docs/guides/WEB_SHELLS.md).
 
 ---
 
@@ -98,7 +100,9 @@ flowchart TB
 
     subgraph Tools["🛠️ Tools, CLI & Interfaces"]
         CLI["cinematic-studio CLI<br/>(models, dna, sequence, quota, nsfw, plugin...)"]
+        CORE["studio_core services<br/>dashboard · ActionSpec · execute"]
         WEBUI["Streamlit Web UI<br/>Guided Bible • DNA Bank • Cost Estimator"]
+        NICE["NiceGUI shell (optional)<br/>cinematic-studio web"]
         SKILLS["62 Custom Grok Skills<br/>(.grok/skills/)"]
     end
 
@@ -117,6 +121,9 @@ flowchart TB
     SD <--> MPA
     MPA --> PB --> DNA
     DNA --> HANDOFF
+    CLI --> CORE
+    CORE --> WEBUI
+    CORE --> NICE
     HANDOFF --> READINESS
     READINESS --> IMAGINE
     IMAGINE --> QA2 --> COLOR2 --> POLISH2 --> DELIVER
@@ -166,7 +173,9 @@ Grok Imagine Cinematic Studio v3.8.9  (Studio Director + 25+ Agents · Grok 4.5 
 ├── tools/                        # character_dna, sequence_chain, quota_optimizer, nsfw_*, bible_stages, imagine_bridge, handoff_schema, cli/
 ├── tools/cinematic_studio_cli.py   # Unified CLI (create-bible --wizard, dna, sequence, quota, nsfw, imagine, plugin, validate...)
 ├── references/MODELS_v3.6.md   # Dual-stack registry (grok-4.5 cinematic default)
+├── studio_core/                  # UI-agnostic services (dashboard, ActionSpec, execute_action)
 ├── web_ui/app.py                 # Streamlit: Guided Bible, DNA bank, sequence dashboard, live cost estimation
+├── web_nicegui/                  # Optional NiceGUI shell (cinematic-studio web)
 ├── examples/                     # Production Bible templates
 ├── MASTER_PROMPT.md              # Primary activation prompt (v3.8+ compatible)
 ├── scripts/                      # Release helpers & verify shims
@@ -257,6 +266,9 @@ cinematic-studio plugin packs
 
 # Interactive terminal UI (dashboard + launcher + cockpit)
 cinematic-studio ui
+
+# Optional NiceGUI web shell (requires requirements-nicegui.txt)
+cinematic-studio web --port 8088
 # Cockpit (press c): Bible, DNA init/lock/handoff, Sequence init/add-clip/handoff,
 #   quota budget + sequence estimate, models verify / validate / stack
 # Launcher (press l): status, lists, validate, stack, show DNA/sequence
@@ -265,20 +277,34 @@ cinematic-studio ui
 
 See full command reference in the [Quick Start Guide](docs/guides/Quick_Start_Guide.md) and run `cinematic-studio --help`.
 
-### 4. Web UI (Recommended for Guided Work)
+### 4. Web UI (dual-run: Streamlit + NiceGUI)
+
+**Streamlit** (default · Community Cloud · full guided Bible wizard):
 
 ```bash
 streamlit run web_ui/app.py
 ```
 
-Beautiful dashboard featuring:
 - Multi-step Guided Bible Creator
 - Character DNA Bank & injection blocks
-- Live quota/cost estimator
-- Sequence health dashboard
-- Model pickers (grok-4.5 / 1.5 video)
+- Live quota/cost estimator + live xAI batch execute (when `XAI_API_KEY` is set)
+- Sequence health dashboard · model pickers (grok-4.5 / 1.5 video)
 
-Deployable to Streamlit Community Cloud (see `docs/guides/streamlit_cloud_deploy.md`). For a lightweight in-terminal live dashboard + safe command launcher (no browser), use `cinematic-studio ui` instead.
+Deployable to Streamlit Community Cloud (see [`docs/guides/streamlit_cloud_deploy.md`](docs/guides/streamlit_cloud_deploy.md)).
+
+**NiceGUI** (optional · same ActionSpec safety as the TUI):
+
+```bash
+pip install -r requirements-nicegui.txt
+cinematic-studio web --port 8088
+# → http://127.0.0.1:8088/
+# Routes: / · /production · /dna · /sequences · /imagine · /quota
+```
+
+Both shells share `studio_core.services` (dashboard snapshot, ActionSpec argv building, `execute_action`). Run either or both — they do not conflict. Details: [`docs/guides/WEB_SHELLS.md`](docs/guides/WEB_SHELLS.md).
+
+For a lightweight in-terminal live dashboard + safe command launcher (no browser), use `cinematic-studio ui`.
+
 ### 5. Full Documentation
 
 - **[Official Documentation](docs/OFFICIAL_DOCUMENTATION.md)** — Canonical product manual (install, workflow, agents, CLI, packs, ops)

--- a/docs/PR7_DUAL_RUN_DOCS.md
+++ b/docs/PR7_DUAL_RUN_DOCS.md
@@ -1,0 +1,18 @@
+# PR7 — Dual-run docs (Streamlit + NiceGUI)
+
+## Goal
+
+Document the completed UI migration: shared `studio_core` + dual web shells.
+
+## Changes
+
+| Path | Change |
+|------|--------|
+| `README.md` | What's new, architecture, CLI, dual-run Web UI section |
+| `CHANGELOG.md` | Unreleased: studio_core + NiceGUI + dual-run guide |
+| `docs/guides/WEB_SHELLS.md` | Operator guide for choosing Streamlit vs NiceGUI vs TUI |
+| `docs/guides/Quick_Start_Guide.md` | Surfaces table includes web shells + TUI |
+
+## No code behavior change
+
+This PR is documentation-only (unless a prior PR already shipped the shells).

--- a/docs/guides/Quick_Start_Guide.md
+++ b/docs/guides/Quick_Start_Guide.md
@@ -47,6 +47,9 @@ Check CLI version: `grok --version` (recommend ≥ 0.2.93).
 | **[grok.com/imagine](https://grok.com/imagine)** | Paste Execution Bridge packets (`cinematic-studio imagine bridge` from shell) |
 | **Grok mobile app** | Same as chat + in-app Imagine |
 | **Desktop / Android shell** | Full Method A + `cinematic-studio grok` + Grok Build CLI |
+| **Streamlit Web UI** | `streamlit run web_ui/app.py` — guided Bible, DNA bank, live batch (see [WEB_SHELLS.md](WEB_SHELLS.md)) |
+| **NiceGUI Web shell** | `cinematic-studio web` — ActionSpec pages on `studio_core` (optional) |
+| **Textual TUI** | `cinematic-studio ui` — terminal dashboard + launcher + cockpit |
 
 ### Activate the Full Studio (Recommended)
 

--- a/docs/guides/WEB_SHELLS.md
+++ b/docs/guides/WEB_SHELLS.md
@@ -1,0 +1,59 @@
+# Web shells — Streamlit + NiceGUI (dual-run)
+
+Grok Imagine Cinematic Studio exposes **two browser UIs** that share one service layer.
+They are complementary, not mutually exclusive.
+
+| | **Streamlit** (`web_ui/`) | **NiceGUI** (`web_nicegui/`) |
+|--|---------------------------|------------------------------|
+| Install | `requirements.txt` | `pip install -r requirements-nicegui.txt` |
+| Start | `streamlit run web_ui/app.py` | `cinematic-studio web --port 8088` |
+| Best for | Guided Bible wizard, DNA bank forms, live xAI batch execute, Community Cloud | Fast ActionSpec forms, same safety model as Textual TUI, light shell |
+| Cloud | [Streamlit Community Cloud](streamlit_cloud_deploy.md) | Self-host / local (FastAPI under NiceGUI) |
+| Core API | `studio_core.services.dashboard` (+ legacy `lib.runtime`) | `studio_core.services.{dashboard,actions,execute}` |
+
+## Shared core
+
+```text
+studio_core/
+  services/
+    dashboard.py   # build_studio_dashboard() → JSON snapshot
+    actions.py     # ActionSpec registry, validate_answers, answers_to_argv
+    execute.py     # execute_action(mode="inprocess"|"subprocess")
+```
+
+- **TUI** (`cinematic-studio ui`) uses `mode="subprocess"` for isolation.
+- **NiceGUI** uses `mode="inprocess"` (Typer invoke) for low latency.
+- Forbidden argv tokens and static allowlists are enforced in both paths.
+
+## Quick start
+
+```bash
+# Streamlit (default web UI)
+pip install -r requirements.txt
+streamlit run web_ui/app.py
+
+# NiceGUI (optional second shell — separate port)
+pip install -r requirements-nicegui.txt
+cinematic-studio web --host 127.0.0.1 --port 8088
+```
+
+NiceGUI routes:
+
+| Path | Role |
+|------|------|
+| `/` | Dashboard (compact / ops / full) |
+| `/production` | status · validate · stack · doctor · models · bible · handoff validate |
+| `/dna` | list · init · lock · show · handoff |
+| `/sequences` | list · init · add-clip · show · handoff · quota estimate |
+| `/imagine` | jobs · bridge · DNA/sequence handoff |
+| `/quota` | dashboard · sync · budget · sequence estimate |
+
+## When to use which
+
+- **Streamlit** — first-time producers, multi-stage Bible wizard, Streamlit Cloud deploy, live Imagine batch when an API key is present.
+- **NiceGUI** — operators who already know the CLI ActionSpec catalog, want cockpit-parity forms in a browser, or want a thin shell on top of `execute_action`.
+- **TUI** — SSH / no-browser environments (`cinematic-studio ui`).
+
+## Migration notes (PR1–PR6)
+
+See `docs/PR1_STUDIO_CORE_DASHBOARD.md` … `docs/PR6_NICEGUI_PRODUCTION_IMAGINE.md` for the extract-and-shim history. Existing `cli.tui.actions` / `cli.tui.runner` imports remain stable.


### PR DESCRIPTION
## Summary

Documentation-only wrap-up for the UI migration (PR1–PR6):

- **README** — What's new, architecture diagram, ASCII tree, CLI `web`, dual-run Web UI section
- **CHANGELOG** — Unreleased: `studio_core`, NiceGUI shell, dual-run guide
- **[docs/guides/WEB_SHELLS.md](docs/guides/WEB_SHELLS.md)** — when to use Streamlit vs NiceGUI vs TUI
- **Quick Start** — surfaces table includes web shells + TUI

No runtime code changes.

## Test plan

- [x] Manual review of README sections render
- [ ] Spot-check links on GitHub after merge