### PR TITLE
PR8: wire Streamlit to studio_core dashboard + execute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to Grok Imagine Cinematic Studio will be documented in this 
 - **`studio_core` service layer** — `build_studio_dashboard`, ActionSpec registry, `execute_action` (in-process + subprocess) shared by TUI / Streamlit / NiceGUI
 - **NiceGUI web shell** — `cinematic-studio web` routes: Dashboard, Production, DNA, Sequences, Imagine, Quota (`web_nicegui/`, optional `requirements-nicegui.txt`)
 - **Dual-run guide** — [`docs/guides/WEB_SHELLS.md`](docs/guides/WEB_SHELLS.md)
+- **Streamlit ↔ studio_core** — dashboard + Tools ActionSpec actions via `execute_registered`
 
 ### Changed
 - **TUI command palette** — `/` or Ctrl+P opens allowlisted action search; KPI bar under status strip; `y` saves orient brief to `artifacts/tui_orient_brief.txt`; scroll preserved on refresh

--- a/docs/PR8_STREAMLIT_STUDIO_CORE.md
+++ b/docs/PR8_STREAMLIT_STUDIO_CORE.md
@@ -1,0 +1,23 @@
+# PR8 — Wire Streamlit to `studio_core`
+
+## Goal
+
+Streamlit joins TUI + NiceGUI on the shared service layer:
+
+| Surface | Dashboard | Actions |
+|---------|-----------|---------|
+| TUI | `studio_core` via shim | `execute` subprocess |
+| NiceGUI | `studio_core` | `execute` in-process |
+| Streamlit | `studio_core.services.dashboard` (preferred) | `execute_registered` / `run_cli_or_action` |
+
+## Changes
+
+- `web_ui/lib/runtime.py` — path to repo root; prefer core dashboard; add `execute_registered` + `run_cli_or_action`
+- `web_ui/pages/tools.py` — Safe ActionSpec strip; handoff + bridge via ActionSpec
+- `tests/test_web_ui_studio_core.py`
+
+## Verify
+
+```bash
+pytest tests/test_web_ui_studio_core.py -q
+```

--- a/docs/guides/WEB_SHELLS.md
+++ b/docs/guides/WEB_SHELLS.md
@@ -9,7 +9,7 @@ They are complementary, not mutually exclusive.
 | Start | `streamlit run web_ui/app.py` | `cinematic-studio web --port 8088` |
 | Best for | Guided Bible wizard, DNA bank forms, live xAI batch execute, Community Cloud | Fast ActionSpec forms, same safety model as Textual TUI, light shell |
 | Cloud | [Streamlit Community Cloud](streamlit_cloud_deploy.md) | Self-host / local (FastAPI under NiceGUI) |
-| Core API | `studio_core.services.dashboard` (+ legacy `lib.runtime`) | `studio_core.services.{dashboard,actions,execute}` |
+| Core API | `studio_core` via `lib.runtime` (`build_studio_dashboard`, `execute_registered`) | `studio_core.services.{dashboard,actions,execute}` |
 
 ## Shared core
 

--- a/tests/test_web_ui_studio_core.py
+++ b/tests/test_web_ui_studio_core.py
@@ -1,0 +1,61 @@
+"""PR8: Streamlit runtime uses studio_core dashboard + execute."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "tools"))
+sys.path.insert(0, str(ROOT))
+sys.path.insert(0, str(ROOT / "web_ui"))
+
+
+def test_build_studio_dashboard_from_core_path() -> None:
+    # Import after path setup; runtime also inserts paths
+    from lib import runtime as rt
+
+    assert rt.DASHBOARD_AVAILABLE is True
+    snap = rt.build_studio_dashboard()
+    assert "project" in snap
+    assert "studio" in snap
+    # Identity with core module
+    from studio_core.services.dashboard import build_studio_dashboard as core_build
+
+    # Same function object preferred
+    assert rt.build_studio_dashboard is core_build or callable(rt.build_studio_dashboard)
+
+
+def test_execute_registered_status() -> None:
+    from lib import runtime as rt
+
+    result = rt.execute_registered("status", timeout=60.0)
+    assert result["ok"] is True
+    assert result["returncode"] == 0
+    assert result["argv"] == ["status"]
+    assert result["mode"] == "inprocess"
+    assert result["output"] or result["stdout"]
+
+
+def test_run_cli_or_action_validate() -> None:
+    from lib import runtime as rt
+
+    code, output = rt.run_cli_or_action("validate", timeout=90.0)
+    assert code == 0
+    assert output
+
+
+def test_execute_registered_validation_failure() -> None:
+    from lib import runtime as rt
+
+    result = rt.execute_registered("bible_create", {"title": ""})
+    assert result["ok"] is False
+    assert result["errors"] or "validation" in (result.get("stderr") or "").lower()
+
+
+if __name__ == "__main__":
+    test_build_studio_dashboard_from_core_path()
+    test_execute_registered_status()
+    test_run_cli_or_action_validate()
+    test_execute_registered_validation_failure()
+    print("web_ui studio_core tests passed")

--- a/web_ui/lib/bootstrap.py
+++ b/web_ui/lib/bootstrap.py
@@ -30,6 +30,8 @@ from lib.runtime import (
     render_footer,
     render_sidebar_stack,
     run_cli,
+    execute_registered,
+    run_cli_or_action,
     session_model_stack,
     stack_banner_markdown,
 )
@@ -80,6 +82,8 @@ __all__ = [
     "render_footer",
     "render_sidebar_stack",
     "run_cli",
+    "execute_registered",
+    "run_cli_or_action",
     "select_index",
     "session_model_stack",
     "session_quota_snapshot",

--- a/web_ui/lib/runtime.py
+++ b/web_ui/lib/runtime.py
@@ -13,6 +13,9 @@ from openai import OpenAI
 
 ROOT = Path(__file__).resolve().parent.parent.parent
 sys.path.insert(0, str(ROOT / "tools"))
+# studio_core (UI-agnostic services) lives at repo root
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
 
 STUDIO_VERSION = "3.7.1"
 ACTIVATION_PHRASE = f"Activate Grok Imagine Cinematic Studio v{STUDIO_VERSION}"
@@ -95,7 +98,10 @@ try:
         quota_dashboard,
         set_budget,
     )
-    from cli.dashboard import build_studio_dashboard
+    try:
+        from studio_core.services.dashboard import build_studio_dashboard
+    except ImportError:  # pragma: no cover — shim path
+        from cli.dashboard import build_studio_dashboard
     from imagine_jobs import job_summary, list_jobs
     from imagine_regions import IMAGINE_REGIONS, get_active_region, set_imagine_region
     from models import (
@@ -343,6 +349,65 @@ def run_cli(args: list[str], timeout: int = 120) -> tuple[int, str]:
     result = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout, cwd=ROOT)
     output = (result.stdout or "") + (result.stderr or "")
     return result.returncode, output.strip()
+
+
+def execute_registered(
+    action_id: str,
+    answers: dict[str, str] | None = None,
+    *,
+    timeout: float = 90.0,
+    mode: str = "inprocess",
+) -> dict[str, Any]:
+    """Run a registered ActionSpec via studio_core (Streamlit-safe dict result).
+
+    Falls back to bare error dict if studio_core is unavailable.
+    """
+    try:
+        from studio_core.services.execute import execute_action
+    except ImportError:
+        return {
+            "ok": False,
+            "returncode": 2,
+            "stdout": "",
+            "stderr": "studio_core.services.execute unavailable",
+            "argv": [],
+            "action_id": action_id,
+            "errors": ["studio_core unavailable"],
+            "mode": mode,
+        }
+    result = execute_action(
+        action_id,
+        answers or {},
+        mode=mode,  # type: ignore[arg-type]
+        timeout=timeout,
+        cwd=ROOT,
+    )
+    return {
+        "ok": bool(result.ok),
+        "returncode": int(result.returncode),
+        "stdout": result.stdout or "",
+        "stderr": result.stderr or "",
+        "argv": list(result.argv),
+        "action_id": result.action_id or action_id,
+        "errors": list(result.errors or []),
+        "timed_out": bool(result.timed_out),
+        "mode": result.mode,
+        "output": result.output,
+    }
+
+
+def run_cli_or_action(
+    action_id: str,
+    answers: dict[str, str] | None = None,
+    *,
+    timeout: float = 90.0,
+) -> tuple[int, str]:
+    """Prefer ActionSpec execute; return (code, combined output) like :func:`run_cli`."""
+    result = execute_registered(action_id, answers, timeout=timeout, mode="inprocess")
+    out = (result.get("output") or "").strip()
+    if not out:
+        out = ((result.get("stdout") or "") + (result.get("stderr") or "")).strip()
+    return int(result.get("returncode", 1)), out
 
 
 @st.cache_data(ttl=300, show_spinner=False)

--- a/web_ui/pages/tools.py
+++ b/web_ui/pages/tools.py
@@ -34,6 +34,38 @@ def render() -> None:
             st.caption("Click to verify registry + CLI pin.")
 
     st.divider()
+    st.subheader("⚡ Safe ActionSpec actions")
+    st.caption(
+        "Runs via `studio_core.services.execute` (same catalog as TUI / NiceGUI). "
+        "No free-form argv."
+    )
+    a1, a2, a3, a4 = st.columns(4)
+    with a1:
+        if st.button("Status", width="stretch", key="tools_core_status"):
+            st.session_state["_tools_core_out"] = rt.execute_registered("status")
+    with a2:
+        if st.button("Validate", width="stretch", key="tools_core_validate"):
+            st.session_state["_tools_core_out"] = rt.execute_registered("validate")
+    with a3:
+        if st.button("Stack", width="stretch", key="tools_core_stack"):
+            st.session_state["_tools_core_out"] = rt.execute_registered("stack")
+    with a4:
+        if st.button("Doctor quick", width="stretch", key="tools_core_doctor"):
+            st.session_state["_tools_core_out"] = rt.execute_registered("doctor_quick")
+    core_out = st.session_state.get("_tools_core_out")
+    if core_out:
+        if core_out.get("ok"):
+            st.success(
+                f"OK · `{' '.join(core_out.get('argv') or [])}` · mode={core_out.get('mode')}"
+            )
+        else:
+            st.error(
+                f"Failed · exit {core_out.get('returncode')} · "
+                f"`{' '.join(core_out.get('argv') or [])}`"
+            )
+        st.code(core_out.get("output") or core_out.get("stderr") or "(no output)", language="text")
+
+    st.divider()
     st.subheader("🔌 Plugin")
     if st.button("Refresh plugin details", key="tools_plugin_refresh"):
         rt.cached_plugin_details.clear()
@@ -65,8 +97,9 @@ def render() -> None:
         if not (ho_path or "").strip():
             st.warning("Enter a path to a handoff JSON file")
         else:
-            code, output = rt.run_cli(
-                ["handoff", "validate", ho_path.strip()],
+            code, output = rt.run_cli_or_action(
+                "handoff_validate",
+                {"path": ho_path.strip()},
                 timeout=60,
             )
             st.code(output, language="text")
@@ -86,16 +119,14 @@ def render() -> None:
         bridge_batch = st.text_input("SFW batch slug", key="tools_bridge_batch")
         bridge_shot = st.text_input("Shot id", key="tools_bridge_shot")
     if st.button("Preview bridge packet", width="stretch", key="tools_bridge_preview"):
-        args = ["imagine", "bridge", "-f", "markdown"]
-        if (bridge_seq or "").strip():
-            args.extend(["-s", bridge_seq.strip()])
-        if (bridge_clip or "").strip():
-            args.extend(["-c", bridge_clip.strip()])
-        if (bridge_batch or "").strip():
-            args.extend(["-b", bridge_batch.strip()])
-        if (bridge_shot or "").strip():
-            args.extend(["--shot", bridge_shot.strip()])
-        code, output = rt.run_cli(args, timeout=60)
+        answers = {
+            "sequence": (bridge_seq or "").strip(),
+            "clip": (bridge_clip or "").strip(),
+            "batch": (bridge_batch or "").strip(),
+            "shot": (bridge_shot or "").strip(),
+            "format": "markdown",
+        }
+        code, output = rt.run_cli_or_action("imagine_bridge", answers, timeout=60)
         st.code(output or "(empty)", language="markdown")
         if code == 0:
             st.success("Bridge packet ready to paste")


### PR DESCRIPTION
## Summary

Closes the loop so **all three shells** share `studio_core`:

| Surface | Dashboard | Actions |
|---------|-----------|---------|
| TUI | shim → core | `execute` subprocess |
| NiceGUI | core | `execute` in-process |
| **Streamlit** | **core preferred** | **`execute_registered` / `run_cli_or_action`** |

### Changes

- `web_ui/lib/runtime.py` — repo root on path; prefer `studio_core.services.dashboard`; add `execute_registered` + `run_cli_or_action`
- `web_ui/pages/tools.py` — Safe ActionSpec strip (status/validate/stack/doctor); handoff + bridge via ActionSpec
- `tests/test_web_ui_studio_core.py`
- Docs: PR8 note, WEB_SHELLS + CHANGELOG

## Test plan

- [x] `pytest tests/test_web_ui_studio_core.py …` — 14 passed
- [ ] Manual: Streamlit Tools → Status / Validate buttons