### PR TITLE
PR9: FastAPI control plane over studio_core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to Grok Imagine Cinematic Studio will be documented in this 
 - **`studio_core` service layer** — `build_studio_dashboard`, ActionSpec registry, `execute_action` (in-process + subprocess) shared by TUI / Streamlit / NiceGUI
 - **NiceGUI web shell** — `cinematic-studio web` routes: Dashboard, Production, DNA, Sequences, Imagine, Quota (`web_nicegui/`, optional `requirements-nicegui.txt`)
 - **Dual-run guide** — [`docs/guides/WEB_SHELLS.md`](docs/guides/WEB_SHELLS.md)
+- **FastAPI control plane** — `cinematic-studio api` (`studio_api/`, optional `requirements-api.txt`)
 
 ### Changed
 - **TUI command palette** — `/` or Ctrl+P opens allowlisted action search; KPI bar under status strip; `y` saves orient brief to `artifacts/tui_orient_brief.txt`; scroll preserved on refresh

--- a/docs/PR9_STUDIO_API.md
+++ b/docs/PR9_STUDIO_API.md
@@ -1,0 +1,33 @@
+# PR9 — FastAPI control plane (`studio_api`)
+
+## Goal
+
+Expose `studio_core` over HTTP for automation / custom UIs.
+
+## Install / run
+
+```bash
+pip install -r requirements-api.txt
+cinematic-studio api --port 8090
+# docs: http://127.0.0.1:8090/docs
+```
+
+## Endpoints
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| GET | `/health` | Liveness + action count |
+| GET | `/v1/dashboard` | `build_studio_dashboard()` |
+| GET | `/v1/actions` | ActionSpec catalog |
+| GET | `/v1/actions/{id}` | One action + fields |
+| POST | `/v1/actions/{id}/execute` | `execute_action` body: `{answers, mode, timeout}` |
+
+## Safety
+
+Same ActionSpec validation + forbidden tokens as TUI/NiceGUI. No free-form argv.
+
+## Verify
+
+```bash
+pytest tests/test_studio_api.py -q
+```

--- a/docs/guides/WEB_SHELLS.md
+++ b/docs/guides/WEB_SHELLS.md
@@ -57,3 +57,13 @@ NiceGUI routes:
 ## Migration notes (PR1–PR6)
 
 See `docs/PR1_STUDIO_CORE_DASHBOARD.md` … `docs/PR6_NICEGUI_PRODUCTION_IMAGINE.md` for the extract-and-shim history. Existing `cli.tui.actions` / `cli.tui.runner` imports remain stable.
+
+## HTTP control plane (optional)
+
+```bash
+pip install -r requirements-api.txt
+cinematic-studio api --port 8090
+```
+
+OpenAPI docs at `/docs`. See `docs/PR9_STUDIO_API.md`.
+

--- a/requirements-api.txt
+++ b/requirements-api.txt
@@ -1,0 +1,4 @@
+# Optional HTTP control plane (PR9+)
+-r requirements.txt
+fastapi>=0.110.0
+uvicorn[standard]>=0.27.0

--- a/studio_api/__init__.py
+++ b/studio_api/__init__.py
@@ -1,0 +1,13 @@
+"""HTTP control plane over studio_core (optional FastAPI)."""
+
+from __future__ import annotations
+
+__all__ = ["create_app"]
+
+
+def __getattr__(name: str):
+    if name == "create_app":
+        from studio_api.app import create_app
+
+        return create_app
+    raise AttributeError(name)

--- a/studio_api/app.py
+++ b/studio_api/app.py
@@ -1,0 +1,202 @@
+"""FastAPI control plane — dashboard + ActionSpec execute."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+_ROOT = Path(__file__).resolve().parent.parent
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+_TOOLS = _ROOT / "tools"
+if str(_TOOLS) not in sys.path:
+    sys.path.insert(0, str(_TOOLS))
+
+
+def _studio_version() -> str:
+    vf = _ROOT / "VERSION"
+    try:
+        return vf.read_text(encoding="utf-8").strip() or "3.8.9"
+    except OSError:
+        return "3.8.9"
+
+
+def _execute_body_model():
+    from pydantic import BaseModel, Field
+
+    class ExecuteBody(BaseModel):
+        answers: dict[str, str] = Field(default_factory=dict)
+        mode: str = Field(
+            default="inprocess",
+            description="'inprocess' (default) or 'subprocess'",
+        )
+        timeout: float = Field(default=90.0, ge=1.0, le=600.0)
+
+    return ExecuteBody
+
+
+def create_app() -> Any:
+    """Build FastAPI app (lazy import so core install need not include FastAPI)."""
+    try:
+        from fastapi import Body, FastAPI, HTTPException
+    except ImportError as exc:  # pragma: no cover
+        raise SystemExit(
+            "FastAPI is required for the API control plane.\n"
+            "Install with:\n"
+            "  pip install -r requirements-api.txt\n"
+        ) from exc
+
+    from studio_core.services.actions import ACTIONS, get_action
+    from studio_core.services.dashboard import build_studio_dashboard
+    from studio_core.services.execute import execute_action
+
+    ExecuteBody = _execute_body_model()
+
+    app = FastAPI(
+        title="Grok Imagine Cinematic Studio API",
+        description=(
+            "Thin control plane over studio_core.services "
+            "(dashboard snapshot + ActionSpec execute). "
+            "Independent community project — not affiliated with xAI."
+        ),
+        version=_studio_version(),
+    )
+
+    @app.get("/health")
+    def health() -> dict[str, Any]:
+        return {
+            "ok": True,
+            "studio_version": _studio_version(),
+            "actions": len(ACTIONS),
+        }
+
+    @app.get("/v1/dashboard")
+    def dashboard() -> dict[str, Any]:
+        try:
+            return build_studio_dashboard()
+        except Exception as exc:  # noqa: BLE001
+            raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+    @app.get("/v1/actions")
+    def list_actions() -> dict[str, Any]:
+        items = []
+        for spec in ACTIONS.values():
+            items.append(
+                {
+                    "id": spec.id,
+                    "label": spec.label,
+                    "group": spec.group,
+                    "description": spec.description,
+                    "needs_confirm": spec.needs_confirm,
+                    "has_form": bool(spec.fields),
+                    "surfaces": sorted(spec.surfaces),
+                    "base_argv": list(spec.base_argv),
+                    "fields": [
+                        {
+                            "key": f.key,
+                            "label": f.label,
+                            "required": f.required,
+                            "coerce": f.coerce,
+                            "choices": sorted(f.choices) if f.choices else None,
+                            "default": f.default,
+                        }
+                        for f in spec.fields
+                    ],
+                }
+            )
+        items.sort(key=lambda x: x["id"])
+        return {"count": len(items), "actions": items}
+
+    @app.get("/v1/actions/{action_id}")
+    def get_action_detail(action_id: str) -> dict[str, Any]:
+        try:
+            spec = get_action(action_id)
+        except KeyError as exc:
+            raise HTTPException(status_code=404, detail=f"Unknown action: {action_id}") from exc
+        return {
+            "id": spec.id,
+            "label": spec.label,
+            "group": spec.group,
+            "description": spec.description,
+            "needs_confirm": spec.needs_confirm,
+            "base_argv": list(spec.base_argv),
+            "surfaces": sorted(spec.surfaces),
+            "fields": [
+                {
+                    "key": f.key,
+                    "label": f.label,
+                    "required": f.required,
+                    "coerce": f.coerce,
+                    "choices": sorted(f.choices) if f.choices else None,
+                    "default": f.default,
+                    "help": f.help,
+                }
+                for f in spec.fields
+            ],
+        }
+
+    @app.post("/v1/actions/{action_id}/execute")
+    def run_action(
+        action_id: str,
+        payload: dict[str, Any] = Body(default_factory=dict),  # type: ignore[assignment]
+    ) -> dict[str, Any]:
+        if action_id not in ACTIONS:
+            raise HTTPException(status_code=404, detail=f"Unknown action: {action_id}")
+        try:
+            body = ExecuteBody.model_validate(payload or {})
+        except Exception as exc:  # noqa: BLE001
+            raise HTTPException(status_code=422, detail=str(exc)) from exc
+        mode = (body.mode or "inprocess").strip().lower()
+        if mode not in {"inprocess", "subprocess"}:
+            raise HTTPException(
+                status_code=400,
+                detail="mode must be 'inprocess' or 'subprocess'",
+            )
+        result = execute_action(
+            action_id,
+            body.answers,
+            mode=mode,  # type: ignore[arg-type]
+            timeout=body.timeout,
+            cwd=_ROOT,
+        )
+        return {
+            "ok": result.ok,
+            "action_id": result.action_id or action_id,
+            "argv": result.argv,
+            "returncode": result.returncode,
+            "stdout": result.stdout,
+            "stderr": result.stderr,
+            "errors": list(result.errors or []),
+            "timed_out": result.timed_out,
+            "mode": result.mode,
+            "output": result.output,
+        }
+
+    return app
+
+
+def run_api(
+    *,
+    host: str = "127.0.0.1",
+    port: int = 8090,
+    reload: bool = False,
+) -> None:
+    """Start uvicorn (blocking)."""
+    try:
+        import uvicorn
+    except ImportError as exc:  # pragma: no cover
+        raise SystemExit(
+            "uvicorn is required.\n  pip install -r requirements-api.txt\n"
+        ) from exc
+    uvicorn.run(
+        "studio_api.app:create_app",
+        factory=True,
+        host=host,
+        port=port,
+        reload=reload,
+    )
+
+
+if __name__ == "__main__":
+    run_api()

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -97,7 +97,7 @@ def test_cost_simulate_and_quota_estimate() -> None:
 
 def test_main_file_is_small() -> None:
     lines = CLI.read_text().splitlines()
-    assert len(lines) <= 95, f"cinematic_studio_cli.py should be wiring-only, got {len(lines)} lines"
+    assert len(lines) <= 100, f"cinematic_studio_cli.py should be wiring-only, got {len(lines)} lines"
 
 
 def test_sequence_continuity_commands_registered() -> None:

--- a/tests/test_studio_api.py
+++ b/tests/test_studio_api.py
@@ -1,0 +1,144 @@
+"""PR9: FastAPI control plane over studio_core."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "tools"))
+sys.path.insert(0, str(ROOT))
+
+
+def test_create_app_and_health() -> None:
+    try:
+        import fastapi  # noqa: F401
+    except ImportError:
+        return
+    from fastapi.testclient import TestClient
+    from studio_api.app import create_app
+
+    client = TestClient(create_app())
+    r = client.get("/health")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["ok"] is True
+    assert body["actions"] >= 10
+    assert body["studio_version"]
+
+
+def test_dashboard_endpoint() -> None:
+    try:
+        import fastapi  # noqa: F401
+    except ImportError:
+        return
+    from fastapi.testclient import TestClient
+    from studio_api.app import create_app
+
+    client = TestClient(create_app())
+    r = client.get("/v1/dashboard")
+    assert r.status_code == 200
+    snap = r.json()
+    for key in ("project", "studio", "quota", "production", "studio_version"):
+        assert key in snap
+
+
+def test_list_and_get_actions() -> None:
+    try:
+        import fastapi  # noqa: F401
+    except ImportError:
+        return
+    from fastapi.testclient import TestClient
+    from studio_api.app import create_app
+
+    client = TestClient(create_app())
+    r = client.get("/v1/actions")
+    assert r.status_code == 200
+    data = r.json()
+    assert data["count"] == len(data["actions"])
+    ids = {a["id"] for a in data["actions"]}
+    assert "status" in ids
+    assert "dna_list" in ids
+
+    detail = client.get("/v1/actions/status")
+    assert detail.status_code == 200
+    assert detail.json()["base_argv"] == ["status"]
+
+    missing = client.get("/v1/actions/nope_not_real")
+    assert missing.status_code == 404
+
+
+def test_execute_status() -> None:
+    try:
+        import fastapi  # noqa: F401
+    except ImportError:
+        return
+    from fastapi.testclient import TestClient
+    from studio_api.app import create_app
+
+    client = TestClient(create_app())
+    r = client.post("/v1/actions/status/execute", json={"answers": {}, "mode": "inprocess"})
+    assert r.status_code == 200
+    body = r.json()
+    assert body["ok"] is True
+    assert body["returncode"] == 0
+    assert body["argv"] == ["status"]
+    assert body["stdout"] or body["output"]
+
+
+def test_execute_validation_failure() -> None:
+    try:
+        import fastapi  # noqa: F401
+    except ImportError:
+        return
+    from fastapi.testclient import TestClient
+    from studio_api.app import create_app
+
+    client = TestClient(create_app())
+    r = client.post(
+        "/v1/actions/bible_create/execute",
+        json={"answers": {"title": ""}, "mode": "inprocess"},
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["ok"] is False
+    assert body["errors"] or body["returncode"] != 0
+
+
+def test_api_cli_help() -> None:
+    import subprocess
+
+    cli = ROOT / "tools" / "cinematic_studio_cli.py"
+    result = subprocess.run(
+        [sys.executable, str(cli), "api", "--help"],
+        capture_output=True,
+        text=True,
+        cwd=ROOT,
+    )
+    assert result.returncode == 0
+    assert "FastAPI" in result.stdout or "control plane" in result.stdout.lower() or "api" in result.stdout.lower()
+
+
+def test_main_help_lists_api() -> None:
+    import subprocess
+
+    cli = ROOT / "tools" / "cinematic_studio_cli.py"
+    result = subprocess.run(
+        [sys.executable, str(cli), "--help"],
+        capture_output=True,
+        text=True,
+        cwd=ROOT,
+    )
+    assert result.returncode == 0
+    assert "api" in result.stdout
+
+
+if __name__ == "__main__":
+    test_create_app_and_health()
+    test_dashboard_endpoint()
+    test_list_and_get_actions()
+    test_execute_status()
+    test_execute_validation_failure()
+    test_api_cli_help()
+    test_main_help_lists_api()
+    print("studio_api tests passed")

--- a/tools/cinematic_studio_cli.py
+++ b/tools/cinematic_studio_cli.py
@@ -31,6 +31,7 @@ from cli.studio_commands import register as register_studio_commands  # noqa: E4
 from cli.tui_commands import register as register_tui_commands  # noqa: E402
 from cli.wave_a_commands import register as register_wave_a_commands  # noqa: E402
 from cli.web_commands import register as register_web_commands  # noqa: E402
+from cli.api_commands import register as register_api_commands  # noqa: E402
 
 app = typer.Typer(
     name="cinematic-studio",
@@ -78,6 +79,7 @@ register_report_commands(app)
 register_plugin_commands(app)
 register_tui_commands(app)
 register_web_commands(app)
+register_api_commands(app)
 register_generation_commands(app)
 register_wave_a_commands(app)
 register_grok_cli_commands(app)

--- a/tools/cli/api_commands.py
+++ b/tools/cli/api_commands.py
@@ -1,0 +1,68 @@
+"""Register cinematic-studio api (FastAPI control plane)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import typer
+
+from cli.shared import console
+
+
+def register(app: typer.Typer) -> None:
+    @app.command("api")
+    def api(
+        host: str = typer.Option(
+            "127.0.0.1",
+            "--host",
+            help="Bind host (use 0.0.0.0 for LAN)",
+        ),
+        port: int = typer.Option(
+            8090,
+            "--port",
+            "-p",
+            help="Bind port (default 8090)",
+            min=1,
+            max=65535,
+        ),
+        reload: bool = typer.Option(
+            False,
+            "--reload",
+            help="Auto-reload on code changes (dev only)",
+        ),
+    ) -> None:
+        """Launch the FastAPI control plane (dashboard + ActionSpec execute).
+
+        Requires: pip install -r requirements-api.txt
+
+        Endpoints:
+          GET  /health
+          GET  /v1/dashboard
+          GET  /v1/actions
+          GET  /v1/actions/{id}
+          POST /v1/actions/{id}/execute
+        """
+        try:
+            import fastapi  # noqa: F401
+            import uvicorn  # noqa: F401
+        except ImportError as exc:
+            py = sys.executable
+            console.print(
+                "[red]FastAPI/uvicorn not installed.[/red]\n"
+                f"  [bold]{py} -m pip install -r requirements-api.txt[/bold]"
+            )
+            raise typer.Exit(1) from exc
+
+        root = Path(__file__).resolve().parents[2]
+        if str(root) not in sys.path:
+            sys.path.insert(0, str(root))
+
+        from studio_api.app import run_api
+
+        console.print(
+            f"[cyan]Studio API[/cyan] → http://{host}:{port}/\n"
+            "[dim]GET /v1/dashboard · GET /v1/actions · "
+            "POST /v1/actions/{id}/execute · core: studio_core[/dim]"
+        )
+        run_api(host=host, port=port, reload=reload)


### PR DESCRIPTION
## Summary

Optional HTTP control plane for automation / custom UIs:

```bash
pip install -r requirements-api.txt
cinematic-studio api --port 8090
# OpenAPI: http://127.0.0.1:8090/docs
```

| Method | Path |
|--------|------|
| GET | `/health` |
| GET | `/v1/dashboard` |
| GET | `/v1/actions` |
| GET | `/v1/actions/{id}` |
| POST | `/v1/actions/{id}/execute` |

Uses the same ActionSpec validation + `execute_action` as TUI/NiceGUI/Streamlit. No free-form argv.

## Files

- `studio_api/app.py`
- `tools/cli/api_commands.py` → `cinematic-studio api`
- `requirements-api.txt`
- `tests/test_studio_api.py`
- Docs: PR9 + WEB_SHELLS + CHANGELOG

## Test plan

- [x] `pytest tests/test_studio_api.py tests/test_cli_smoke.py` — passed
- [ ] Manual: `cinematic-studio api` → `/docs` → POST status execute