### PR TITLE
PR10: surface polish — README/CI for API, CORS, smoke script

### DIFF
--- a/.github/workflows/cinematic-agent-workflow-ci.yml
+++ b/.github/workflows/cinematic-agent-workflow-ci.yml
@@ -11,6 +11,7 @@ on:
       - 'web_ui/**'
       - 'web_nicegui/**'
       - 'studio_core/**'
+      - 'studio_api/**'
       - 'tools/**'
       - 'scripts/**'
       - 'tests/**'
@@ -26,6 +27,7 @@ on:
       - 'web_ui/**'
       - 'web_nicegui/**'
       - 'studio_core/**'
+      - 'studio_api/**'
       - 'tools/**'
       - 'scripts/**'
       - 'tests/**'
@@ -189,7 +191,7 @@ jobs:
         if: steps.check_dirs.outputs.directories_ok == 'true' || env.VALIDATION_MODE != 'standard'
         run: |
           echo "🐍 Checking Python files..."
-          python -m py_compile tools/cinematic_studio_cli.py web_ui/app.py studio_core/services/dashboard.py studio_core/services/actions.py studio_core/services/execute.py web_nicegui/app.py 2>/dev/null || echo "⚠️  Python check completed with warnings"
+          python -m py_compile tools/cinematic_studio_cli.py web_ui/app.py studio_core/services/dashboard.py studio_core/services/actions.py studio_core/services/execute.py web_nicegui/app.py studio_api/app.py 2>/dev/null || echo "⚠️  Python check completed with warnings"
 
           for f in MASTER_PROMPT_v3.6.md tools/cinematic_studio_cli.py web_ui/app.py; do
             if [ -f "$f" ]; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to Grok Imagine Cinematic Studio will be documented in this 
 - **Dual-run guide** — [`docs/guides/WEB_SHELLS.md`](docs/guides/WEB_SHELLS.md)
 - **Streamlit ↔ studio_core** — dashboard + Tools ActionSpec actions via `execute_registered`
 - **FastAPI control plane** — `cinematic-studio api` (`studio_api/`, optional `requirements-api.txt`)
+- **Surface polish** — README/CI for `studio_api`; API `GET /` + CORS; `scripts/smoke_studio_surfaces.py`
 
 ### Changed
 - **TUI command palette** — `/` or Ctrl+P opens allowlisted action search; KPI bar under status strip; `y` saves orient brief to `artifacts/tui_orient_brief.txt`; scroll preserved on refresh

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Whether you’re crafting Marvel-style hero reveals, cyberpunk neon sequences, i
 - **Streamlit Dashboard view modes** — same compact/ops/full density (session radio; TUI 1/2/3 parity)
 - **Shared `studio_core` services** — UI-agnostic dashboard snapshot, ActionSpec registry, and `execute_action` (in-process / subprocess)
 - **NiceGUI web shell** — `cinematic-studio web` (Dashboard · Production · DNA · Sequences · Imagine · Quota); dual-run with Streamlit
+- **FastAPI control plane** — `cinematic-studio api` (`/v1/dashboard`, ActionSpec execute)
 - Prior **3.8.8** — Operator UX control plane (readiness · convergence · delivery · handoff validate · Wave A packaging)
 
 See full details in [CHANGELOG.md](CHANGELOG.md) and [docs/releases/RELEASE_NOTES_v3.8.9.md](docs/releases/RELEASE_NOTES_v3.8.9.md). Dual-run web guide: [docs/guides/WEB_SHELLS.md](docs/guides/WEB_SHELLS.md).
@@ -103,6 +104,7 @@ flowchart TB
         CORE["studio_core services<br/>dashboard · ActionSpec · execute"]
         WEBUI["Streamlit Web UI<br/>Guided Bible • DNA Bank • Cost Estimator"]
         NICE["NiceGUI shell (optional)<br/>cinematic-studio web"]
+        API["FastAPI control plane<br/>cinematic-studio api"]
         SKILLS["62 Custom Grok Skills<br/>(.grok/skills/)"]
     end
 
@@ -124,6 +126,7 @@ flowchart TB
     CLI --> CORE
     CORE --> WEBUI
     CORE --> NICE
+    CORE --> API
     HANDOFF --> READINESS
     READINESS --> IMAGINE
     IMAGINE --> QA2 --> COLOR2 --> POLISH2 --> DELIVER
@@ -176,6 +179,7 @@ Grok Imagine Cinematic Studio v3.8.9  (Studio Director + 25+ Agents · Grok 4.5 
 ├── studio_core/                  # UI-agnostic services (dashboard, ActionSpec, execute_action)
 ├── web_ui/app.py                 # Streamlit: Guided Bible, DNA bank, sequence dashboard, live cost estimation
 ├── web_nicegui/                  # Optional NiceGUI shell (cinematic-studio web)
+├── studio_api/                   # Optional FastAPI control plane (cinematic-studio api)
 ├── examples/                     # Production Bible templates
 ├── MASTER_PROMPT.md              # Primary activation prompt (v3.8+ compatible)
 ├── scripts/                      # Release helpers & verify shims
@@ -304,6 +308,17 @@ cinematic-studio web --port 8088
 Both shells share `studio_core.services` (dashboard snapshot, ActionSpec argv building, `execute_action`). Run either or both — they do not conflict. Details: [`docs/guides/WEB_SHELLS.md`](docs/guides/WEB_SHELLS.md).
 
 For a lightweight in-terminal live dashboard + safe command launcher (no browser), use `cinematic-studio ui`.
+
+**HTTP API** (optional automation / custom UIs):
+
+```bash
+pip install -r requirements-api.txt
+cinematic-studio api --port 8090
+# OpenAPI UI → http://127.0.0.1:8090/docs
+# GET /v1/dashboard · GET /v1/actions · POST /v1/actions/{id}/execute
+```
+
+Same ActionSpec safety model as the TUI (no free-form argv). See [`docs/PR9_STUDIO_API.md`](docs/PR9_STUDIO_API.md).
 
 ### 5. Full Documentation
 

--- a/docs/PR10_SURFACE_POLISH.md
+++ b/docs/PR10_SURFACE_POLISH.md
@@ -1,0 +1,15 @@
+# PR10 — Surface polish (README · CI · API · smoke)
+
+## Changes
+
+- README: FastAPI control plane in What's new, architecture, CLI, Web section
+- CI: track `studio_api/**` + py_compile `studio_api/app.py`
+- API: permissive CORS for local custom UIs; `GET /` index JSON
+- `scripts/smoke_studio_surfaces.py` — no long-running servers
+
+## Verify
+
+```bash
+pytest tests/test_studio_api.py -q
+python scripts/smoke_studio_surfaces.py
+```

--- a/scripts/smoke_studio_surfaces.py
+++ b/scripts/smoke_studio_surfaces.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Smoke-check studio_core + optional surfaces (no long-running servers)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "tools"))
+sys.path.insert(0, str(ROOT))
+
+
+def main() -> int:
+    errors: list[str] = []
+
+    try:
+        from studio_core.services.dashboard import build_studio_dashboard
+
+        snap = build_studio_dashboard()
+        assert "studio_version" in snap
+        print("OK  studio_core.dashboard", snap.get("studio_version"))
+    except Exception as exc:  # noqa: BLE001
+        errors.append(f"dashboard: {exc}")
+        print("FAIL studio_core.dashboard", exc)
+
+    try:
+        from studio_core.services.execute import execute_action
+
+        r = execute_action("status", mode="inprocess", timeout=60.0)
+        assert r.ok, r.stderr
+        print("OK  studio_core.execute status")
+    except Exception as exc:  # noqa: BLE001
+        errors.append(f"execute: {exc}")
+        print("FAIL studio_core.execute", exc)
+
+    try:
+        from studio_core.services.actions import ACTIONS
+
+        assert len(ACTIONS) >= 10
+        print("OK  studio_core.actions", len(ACTIONS))
+    except Exception as exc:  # noqa: BLE001
+        errors.append(f"actions: {exc}")
+        print("FAIL studio_core.actions", exc)
+
+    try:
+        import fastapi  # noqa: F401
+        from fastapi.testclient import TestClient
+        from studio_api.app import create_app
+
+        client = TestClient(create_app())
+        assert client.get("/health").status_code == 200
+        assert client.get("/").status_code == 200
+        print("OK  studio_api /health")
+    except ImportError:
+        print("SKIP studio_api (fastapi not installed)")
+    except Exception as exp:  # noqa: BLE001
+        errors.append(f"api: {exp}")
+        print("FAIL studio_api", exp)
+
+    try:
+        import nicegui  # noqa: F401
+        from web_nicegui.app import create_app as create_nicegui
+
+        create_nicegui()
+        print("OK  web_nicegui create_app")
+    except ImportError:
+        print("SKIP web_nicegui (nicegui not installed)")
+    except Exception as exp:  # noqa: BLE001
+        errors.append(f"nicegui: {exp}")
+        print("FAIL web_nicegui", exp)
+
+    if errors:
+        print("SMOKE FAILED:", "; ".join(errors))
+        return 1
+    print("SMOKE PASSED")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/studio_api/app.py
+++ b/studio_api/app.py
@@ -40,6 +40,7 @@ def create_app() -> Any:
     """Build FastAPI app (lazy import so core install need not include FastAPI)."""
     try:
         from fastapi import Body, FastAPI, HTTPException
+        from fastapi.middleware.cors import CORSMiddleware
     except ImportError as exc:  # pragma: no cover
         raise SystemExit(
             "FastAPI is required for the API control plane.\n"
@@ -62,6 +63,24 @@ def create_app() -> Any:
         ),
         version=_studio_version(),
     )
+
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=["*"],
+        allow_credentials=False,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+
+    @app.get("/", include_in_schema=False)
+    def root() -> dict[str, str]:
+        return {
+            "service": "grok-imagine-cinematic-studio-api",
+            "docs": "/docs",
+            "health": "/health",
+            "dashboard": "/v1/dashboard",
+            "actions": "/v1/actions",
+        }
 
     @app.get("/health")
     def health() -> dict[str, Any]:

--- a/tests/test_studio_api.py
+++ b/tests/test_studio_api.py
@@ -10,7 +10,24 @@ sys.path.insert(0, str(ROOT / "tools"))
 sys.path.insert(0, str(ROOT))
 
 
+def test_root_index() -> None:
+    try:
+        import fastapi  # noqa: F401
+    except ImportError:
+        return
+    from fastapi.testclient import TestClient
+    from studio_api.app import create_app
+
+    client = TestClient(create_app())
+    r = client.get("/")
+    assert r.status_code == 200
+    body = r.json()
+    assert body.get("docs") == "/docs"
+    assert body.get("health") == "/health"
+
+
 def test_create_app_and_health() -> None:
+
     try:
         import fastapi  # noqa: F401
     except ImportError:


### PR DESCRIPTION
## Summary

Polish pass after the dual-shell + API migration:

- **README** — FastAPI control plane (What's new, architecture, CLI, Web section)
- **CI** — `studio_api/**` paths + `py_compile studio_api/app.py`
- **API** — `GET /` service index + permissive CORS for local custom UIs
- **`scripts/smoke_studio_surfaces.py`** — core/API/NiceGUI smoke without long-running servers

## Test plan

- [x] `pytest tests/test_studio_api.py`
- [x] `python scripts/smoke_studio_surfaces.py`
- [x] workflow YAML parses