### PR TITLE
docs: v3.9.1 operator surfaces (web-react + activate)

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -14,7 +14,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio.git",
-        "sha": "4cbc76576baf31850577b34e7f4776e1e6963c82"
+        "sha": "9dbce2bf8a3434c1dfdf31f72263302451024714"
       },
       "homepage": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio",
       "keywords": [
@@ -31,7 +31,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio.git",
-        "sha": "4cbc76576baf31850577b34e7f4776e1e6963c82"
+        "sha": "9dbce2bf8a3434c1dfdf31f72263302451024714"
       },
       "homepage": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio",
       "keywords": [
@@ -49,7 +49,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio.git",
-        "sha": "4cbc76576baf31850577b34e7f4776e1e6963c82"
+        "sha": "9dbce2bf8a3434c1dfdf31f72263302451024714"
       },
       "homepage": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio",
       "keywords": [
@@ -69,7 +69,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio.git",
-        "sha": "4cbc76576baf31850577b34e7f4776e1e6963c82"
+        "sha": "9dbce2bf8a3434c1dfdf31f72263302451024714"
       },
       "homepage": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio",
       "keywords": [
@@ -89,7 +89,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio.git",
-        "sha": "4cbc76576baf31850577b34e7f4776e1e6963c82"
+        "sha": "9dbce2bf8a3434c1dfdf31f72263302451024714"
       },
       "homepage": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio",
       "keywords": [
@@ -109,7 +109,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio.git",
-        "sha": "4cbc76576baf31850577b34e7f4776e1e6963c82"
+        "sha": "9dbce2bf8a3434c1dfdf31f72263302451024714"
       },
       "homepage": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio",
       "keywords": [

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -300,7 +300,7 @@
           }
         ]
       },
-      "sha": "4cbc76576baf31850577b34e7f4776e1e6963c82"
+      "sha": "9dbce2bf8a3434c1dfdf31f72263302451024714"
     },
     "grok-imagine-cinematic-core": {
       "components": {
@@ -429,7 +429,7 @@
           }
         ]
       },
-      "sha": "4cbc76576baf31850577b34e7f4776e1e6963c82"
+      "sha": "9dbce2bf8a3434c1dfdf31f72263302451024714"
     },
     "grok-imagine-camera-image": {
       "components": {
@@ -480,7 +480,7 @@
           }
         ]
       },
-      "sha": "4cbc76576baf31850577b34e7f4776e1e6963c82"
+      "sha": "9dbce2bf8a3434c1dfdf31f72263302451024714"
     },
     "grok-imagine-sequence-narrative": {
       "components": {
@@ -563,7 +563,7 @@
           }
         ]
       },
-      "sha": "4cbc76576baf31850577b34e7f4776e1e6963c82"
+      "sha": "9dbce2bf8a3434c1dfdf31f72263302451024714"
     },
     "grok-imagine-nsfw": {
       "components": {
@@ -592,7 +592,7 @@
           }
         ]
       },
-      "sha": "4cbc76576baf31850577b34e7f4776e1e6963c82"
+      "sha": "9dbce2bf8a3434c1dfdf31f72263302451024714"
     },
     "grok-imagine-delivery-post": {
       "components": {
@@ -633,7 +633,7 @@
           }
         ]
       },
-      "sha": "4cbc76576baf31850577b34e7f4776e1e6963c82"
+      "sha": "9dbce2bf8a3434c1dfdf31f72263302451024714"
     }
   }
 }

--- a/MASTER_PROMPT.md
+++ b/MASTER_PROMPT.md
@@ -1,8 +1,8 @@
-# Grok Imagine Cinematic Studio v3.9.0
+# Grok Imagine Cinematic Studio v3.9.1
 
 **The most advanced multi-agent cinematic production system for Grok Build 0.2.93+ · Grok 4.5 (cinematic + coding default) · optional Grok 4.3 (1M) · Grok Imagine Video (1.0 default; 1.5 native audio available)**
 
-**Version:** 3.9.0 "Odyssey Native" (August 2026) — Full v4.5 Dual-Model Wave  
+**Version:** 3.9.1 "Odyssey Native" (August 2026) — Full v4.5 Dual-Model Wave  
 **Agents:** 25 Role-Card core agents with full v4.0 personalities (v3.6 upgrades for Imagine Video 1.5)  
 **Key Improvements:** Unified Grok 4.5 cinematic+Build default (optional Grok 4.3 1M), Grok Build ≥ 0.2.93, Imagine Video 1.0 default / 1.5 native audio, structured outputs, AUDIO_MOMENTUM_VECTOR, optimized prompt schemas, per-second video pricing.
 
@@ -11,14 +11,14 @@
 
 ---
 
-## ✨ Current State (August 2026 — v3.9.0)
+## ✨ Current State (August 2026 — v3.9.1)
 
-- **25 Role-Card core agents** with complete Role Cards in `references/agents/` (v3.6.5 labels; studio release **v3.9.0**)
+- **25 Role-Card core agents** with complete Role Cards in `references/agents/` (v3.6.5 labels; studio release **v3.9.1**)
 - **Authoritative Role Card System** — Core Mission, v3.6 upgrades (1.5 & unified Grok 4.5 stack), Decision Frameworks, Activation Triggers, Integration Notes
 - **Mature CLI + Web UI** — model pickers, native audio toggle, 720p/duration, live cost estimation, **Guided Production Bible wizard** (`create-bible --wizard` / Web Guided Bible Creator)
 - **Native Grok Imagine Video 1.5 Pipeline** — image-to-video, one-pass audio, extend/stitch, Fast mode (1.0 remains cost default)
 - **Grok Build + unified Grok 4.5 stack** — CLI default `grok-4.5` (fork `grok-build`, min CLI **0.2.93**); opt-in `grok-v9-4p5-multi` / `grok-v9-4p5-chat-expert` / `grok-4-auto`; optional 1M `grok-4.3`
-- **v4.5 Dual-Model Wave (v3.9.0)** — 16 core skills with dual Imagine Video 1.0 + 1.5 Native documentation and Role Cards (`references/agents/MODEL_LAYER_v4.5.md`)
+- **v4.5 Dual-Model Wave (v3.9.1)** — 16 core skills with dual Imagine Video 1.0 + 1.5 Native documentation and Role Cards (`references/agents/MODEL_LAYER_v4.5.md`)
 - **Plugin marketplace** — 62 skills + 11 commands; release-pin hygiene for catalog commits
 - v3.5 heritage retained: Memory Bank, LAST_FRAME_RECAP + MOMENTUM_VECTOR + AUDIO_MOMENTUM_VECTOR, 7-Metric Self-Improvement Loop
 
@@ -44,10 +44,10 @@ streamlit run web_ui/app.py
 ```
 (Now includes Imagine Model selector: 1.0 (default, cost-effective), 1.5 Native (for audio), resolution, duration, native audio toggle, real-time cost simulator)
 
-### Method 3: Full Activation Prompt (Classic — Updated for v3.9.0)
+### Method 3: Full Activation Prompt (Classic — Updated for v3.9.1)
 1. Copy this entire prompt (or the new `MASTER_PROMPT.md`)
 2. Paste into a **new Grok 4.5** chat (default) or **Grok 4.3** for very long Bibles (enable reasoning=medium or high for complex productions)
-3. Type: `Activate Grok Imagine Cinematic Studio v3.9.0`
+3. Type: `Activate Grok Imagine Cinematic Studio v3.9.1`
 
 Then choose your workflow:
 - **A** — Full Production Bible + First 1.5 Sequence (Recommended)
@@ -65,7 +65,7 @@ Then choose your workflow:
 - `ACTIVATE AI_POLISH_DIRECTOR` / `RUN FINAL POLISH PASS` (post-QA upscale & face restoration)
 - `ACTIVATE NSFW_QUOTA_ORCHESTRATOR` — Heavy batch planning, i2v decisions, daily quota reports
 - `ACTIVATE NSFW_SEQUENCE_EXTENDER` — 30–120s+ sensual extension from reference frame or short clip
-- `ACTIVATE IMAGINE_AGENT_MODE_HANDOFF` — Official planning→Imagine execution handoff (v3.7.1 / v3.9.0)
+- `ACTIVATE IMAGINE_AGENT_MODE_HANDOFF` — Official planning→Imagine execution handoff (v3.7.1 / v3.9.1)
 
 **NSFW CLI (requires `ACTIVATE EROSFORGE`):**
 ```bash
@@ -120,7 +120,7 @@ python tools/cinematic_studio_cli.py nsfw report
 ### Specialist (Opt-in)
 - **ErosForge NSFW Director v3.6** — Adult/R-rated content specialist (1.5-optimized erotic motion + synced intimate audio; activate explicitly with `ACTIVATE EROSFORGE`)
 
-> **All agents have complete Role Cards** stored in `references/agents/`. These are the authoritative definitions. Every card embeds the **Model Layer (Grok 4.5 · studio v3.9.0)** block; v3.6 cards also include "Imagine Video 1.5 Integration" and Grok 4.5 operating rules (optional 4.3 for 1M only).
+> **All agents have complete Role Cards** stored in `references/agents/`. These are the authoritative definitions. Every card embeds the **Model Layer (Grok 4.5 · studio v3.9.1)** block; v3.6 cards also include "Imagine Video 1.5 Integration" and Grok 4.5 operating rules (optional 4.3 for 1M only).
 
 ---
 
@@ -191,9 +191,9 @@ When crafting prompts for Imagine Prompt Master or direct generation:
 
 ---
 
-**You are now running the full Grok Imagine Cinematic Studio v3.9.0 "Odyssey Native". **
+**You are now running the full Grok Imagine Cinematic Studio v3.9.1 "Odyssey Native". **
 
-Type `Activate Grok Imagine Cinematic Studio v3.9.0` to begin.
+Type `Activate Grok Imagine Cinematic Studio v3.9.1` to begin.
 
 This version is optimized for Grok Build ≥ 0.2.93, Grok 4.5 (cinematic + coding default), optional Grok 4.3 (1M), and Imagine Video 1.0/1.5 on grok.com/imagine, mobile apps, and API.
 

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -1,5 +1,5 @@
 # CLI Reference
-## cinematic-studio (Grok Imagine Cinematic Studio v3.9.0)
+## cinematic-studio (Grok Imagine Cinematic Studio v3.9.1)
 
 Primary entry points:
 
@@ -121,7 +121,7 @@ python tools/cinematic_studio_cli.py ui --interval 5
 
 Live studio dashboard + safe launcher + production cockpit. **No Imagine spend** from Launcher/Cockpit.
 
-#### TUI keys (v3.9.0)
+#### TUI keys
 
 | Key | Action |
 |-----|--------|
@@ -141,16 +141,33 @@ Live studio dashboard + safe launcher + production cockpit. **No Imagine spend**
 
 Operator loop: [guides/OPERATOR_CONTROL_PLANE.md](guides/OPERATOR_CONTROL_PLANE.md).
 
-#### Unreleased (next) — see CHANGELOG `[Unreleased]`
-
-| Feature | Notes |
-|---------|--------|
 | `/` or `Ctrl+P` | Command palette (allowlisted action search) |
 | KPI bar | Under status strip |
 | `y` | Save orient brief → `artifacts/tui_orient_brief.txt` |
 | `ui --print` | Non-TTY / CI: print orient dashboard instead of hard-fail |
 
-These ship with the next version bump; do not treat as part of 3.9.0 until `VERSION` advances.
+### Browser shells & API
+
+```bash
+# Streamlit
+streamlit run web_ui/app.py
+
+# NiceGUI ActionSpec cockpit
+pip install -r requirements-nicegui.txt
+cinematic-studio web --host 127.0.0.1 --port 8088
+
+# FastAPI control plane
+pip install -r requirements-api.txt
+cinematic-studio api --host 127.0.0.1 --port 8090
+# OpenAPI → http://127.0.0.1:8090/docs
+
+# React / TanStack SPA (v3.9.1 · needs API + Node 20+)
+cinematic-studio web-react                 # dev :5173, proxies /v1 → :8090
+cinematic-studio web-react --preview       # production build serve
+cinematic-studio web-react --install       # force npm install
+```
+
+Multi-shell matrix: [guides/WEB_SHELLS.md](guides/WEB_SHELLS.md) · React README: `web_react/README.md`.
 
 ### NSFW (requires prior ErosForge activation in chat)
 
@@ -253,4 +270,4 @@ cinematic-studio ui
 
 *Run any command with `--help` for full options. The CLI is the automation backbone of the Studio.*
 
-*Grok Imagine Cinematic Studio v3.9.0 — CLI Reference · Independent community project · Not affiliated with xAI*
+*Grok Imagine Cinematic Studio v3.9.1 — CLI Reference · Independent community project · Not affiliated with xAI*

--- a/docs/guides/OPERATOR_CHEAT_SHEET.md
+++ b/docs/guides/OPERATOR_CHEAT_SHEET.md
@@ -1,11 +1,11 @@
-# Operator Cheat Sheet — Grok Imagine Cinematic Studio v3.9.0
+# Operator Cheat Sheet — Grok Imagine Cinematic Studio v3.9.1
 
 **One-pager for activation, agents, skills, packs, and CLI.**  
 Community project — not affiliated with xAI. Canonical detail: `AGENTS.md` · `references/agents/AGENT_INDEX.md` · `references/SKILLS_TAXONOMY.md`.
 
 | Stamp | Value |
 |-------|--------|
-| Studio | **v3.9.0** |
+| Studio | **v3.9.1** |
 | Skills | **62** |
 | Role-Card core agents | **25** |
 | Wave A (P0) | **8** specialists |
@@ -18,7 +18,7 @@ Community project — not affiliated with xAI. Canonical detail: `AGENTS.md` · 
 ## 60-second activate
 
 ```text
-Activate Grok Imagine Cinematic Studio v3.9.0
+Activate Grok Imagine Cinematic Studio v3.9.1
 ```
 
 | Surface | How |
@@ -30,6 +30,7 @@ Activate Grok Imagine Cinematic Studio v3.9.0
 | Streamlit | `streamlit run web_ui/app.py` |
 | NiceGUI | `cinematic-studio web --port 8088` |
 | FastAPI | `cinematic-studio api --port 8090` |
+| React SPA | `cinematic-studio web-react` (needs API on `:8090`) |
 
 **Rule:** activate by **skill slug** (kebab-case), not display title.
 
@@ -59,7 +60,7 @@ Every Production Bible locks `model_stack` + `VIDEO_PIPELINE_SPEC`.
 
 | Command | Purpose |
 |---------|---------|
-| `/cinematic` | Full studio activate v3.9.0 |
+| `/cinematic` | Full studio activate v3.9.1 |
 | `/dna` | Character DNA extract / lock / inject |
 | `/imagine` | Preflight → plan → generate → QA / bridge |
 | `/dashboard` | Health, quota, sequences, DNA |
@@ -220,7 +221,7 @@ Activate studio
 
 | Intent | Phrase |
 |--------|--------|
-| Full studio | `Activate Grok Imagine Cinematic Studio v3.9.0` |
+| Full studio | `Activate Grok Imagine Cinematic Studio v3.9.1` |
 | 1.5 native | `ACTIVATE IMAGINE_VIDEO_1.5_FULL` |
 | Long-form | `ACTIVATE SEQUENCE_DIRECTOR` + `ACTIVATE SEQUENCE_EXTENDER` |
 | Character onboard | `ACTIVATE CHARACTER_DNA_EXTRACTOR` + `ACTIVATE IDENTITY_LOCK` |
@@ -287,5 +288,5 @@ grok plugin install FineComputer14451/Grok-Imagine-Cinematic-Studio --trust
 
 ---
 
-*Operator cheat sheet · studio **v3.9.0** · 25 core · Wave A 8 · **62 skills** · multi-surface control plane*  
+*Operator cheat sheet · studio **v3.9.1** · 25 core · Wave A 8 · **62 skills** · multi-surface (TUI · Streamlit · NiceGUI · React · API)*  
 *Regenerate after roster/pack changes: update from AGENT_INDEX + plugin_packs.yaml + required_skills.manifest.*

--- a/docs/guides/Quick_Start_Guide.md
+++ b/docs/guides/Quick_Start_Guide.md
@@ -1,6 +1,6 @@
-# Grok Imagine Cinematic Studio v3.9.0 — Quick Start Guide
+# Grok Imagine Cinematic Studio v3.9.1 — Quick Start Guide
 
-**Version:** 3.9.0 | **Last Updated:** August 1, 2026  
+**Version:** 3.9.1 | **Last Updated:** August 3, 2026  
 **Suite:** 25+ Role-Card core agents · **62 skills** · marketplace full suite + 5 packs
 
 > [!NOTE]
@@ -47,8 +47,9 @@ Check CLI version: `grok --version` (recommend ≥ 0.2.93).
 | **[grok.com/imagine](https://grok.com/imagine)** | Paste Execution Bridge packets (`cinematic-studio imagine bridge` from shell) |
 | **Grok mobile app** | Same as chat + in-app Imagine |
 | **Desktop / Android shell** | Full Method A + `cinematic-studio grok` + Grok Build CLI |
-| **Streamlit Web UI** | `streamlit run web_ui/app.py` — guided Bible, DNA bank, live batch (see [WEB_SHELLS.md](WEB_SHELLS.md)) |
+| **Streamlit Web UI** | `streamlit run web_ui/app.py` — live batch, DNA bank, NSFW planners (see [WEB_SHELLS.md](WEB_SHELLS.md)) |
 | **NiceGUI Web shell** | `cinematic-studio web` — ActionSpec pages on `studio_core` (optional) |
+| **React SPA** | `cinematic-studio api` + `cinematic-studio web-react` — TanStack cockpit + guided Bible (optional) |
 | **Textual TUI** | `cinematic-studio ui` — terminal dashboard + launcher + cockpit |
 
 ### Activate the Full Studio (Recommended)
@@ -56,7 +57,7 @@ Check CLI version: `grok --version` (recommend ≥ 0.2.93).
 **On grok.com or mobile chat** — new conversation:
 
 ```
-Activate Grok Imagine Cinematic Studio v3.9.0
+Activate Grok Imagine Cinematic Studio v3.9.1
 ```
 
 or
@@ -67,7 +68,7 @@ start cinematic production
 
 For a full lock-in on the web, paste `MASTER_PROMPT.md` first, then Activate.
 
-This loads the complete **v3.9.0** system: unified Grok 4.5 cinematic+Build stack (optional 4.3 1M), dual Imagine Video 1.0/1.5, guided Bible wizard, Imagine Agent Mode Handoff, Identity Continuity, and the **62-skill** suite.
+This loads the complete **v3.9.1** system: unified Grok 4.5 cinematic+Build stack (optional 4.3 1M), dual Imagine Video 1.0/1.5, guided Bible wizard, Imagine Agent Mode Handoff, Identity Continuity, and the **62-skill** suite.
 
 ### Start a New Project
 
@@ -121,11 +122,11 @@ Full activation table: `references/agents/AGENT_INDEX.md`
 
 ---
 
-## 3. Recommended Production Workflow (v3.9.0)
+## 3. Recommended Production Workflow (v3.9.1)
 
 ### Phase 1: Activation & Planning
 1. **Activate the Full Studio**  
-   `Activate Grok Imagine Cinematic Studio v3.9.0`
+   `Activate Grok Imagine Cinematic Studio v3.9.1`
 
 2. **Start a New Project**  
    Provide title, logline, genre, tone, target length, and key characters.
@@ -175,7 +176,7 @@ Full activation table: `references/agents/AGENT_INDEX.md`
 ---
 
 **Pro Tip:** You can combine steps in one message:  
-> `"Activate Grok Imagine Cinematic Studio v3.9.0, start new project called 'Neon Eclipse Heist', generate the full Production Bible with VIDEO_PIPELINE_SPEC for 1.5, and create the first sequence."`
+> `"Activate Grok Imagine Cinematic Studio v3.9.1, start new project called 'Neon Eclipse Heist', generate the full Production Bible with VIDEO_PIPELINE_SPEC for 1.5, and create the first sequence."`
 
 ---
 
@@ -198,7 +199,7 @@ North-star: `docs/development/superpowers/specs/2026-07-26-operator-ux-north-sta
 
 ---
 
-## 5. Pro Tips for Best Results (v3.9.0)
+## 5. Pro Tips for Best Results (v3.9.1)
 
 - **Be specific** — Include genre, tone, emotional goals, character details, and references.
 - **Use the Project Bible** — Lock `model_stack` + `VIDEO_PIPELINE_SPEC` (1.0 cost default; 1.5 when audio/physics need it).
@@ -216,7 +217,7 @@ North-star: `docs/development/superpowers/specs/2026-07-26-operator-ux-north-sta
 
 | Command                                           | Result                                      |
 |---------------------------------------------------|---------------------------------------------|
-| `Activate Grok Imagine Cinematic Studio v3.9.0`   | Load full v3.9.0 studio (Grok 4.5 + 1.0/1.5) |
+| `Activate Grok Imagine Cinematic Studio v3.9.1`   | Load full v3.9.1 studio (Grok 4.5 + 1.0/1.5) |
 | `create-bible --wizard`                           | Guided Production Bible (TTY interactive)   |
 | `Start new project`                               | Begin fresh production                      |
 | `GENERATE DIRECTOR'S CUT`                         | Refined version with notes                  |
@@ -261,8 +262,8 @@ North-star: `docs/development/superpowers/specs/2026-07-26-operator-ux-north-sta
 
 **You are now ready to create professional cinematic productions with Grok 4.5 orchestration + Imagine Video 1.0/1.5 support.**
 
-Just say **"Activate Grok Imagine Cinematic Studio v3.9.0"** and begin.
+Just say **"Activate Grok Imagine Cinematic Studio v3.9.1"** and begin.
 
 ---
 
-*Grok Imagine Cinematic Studio v3.9.0 — Grok 4.5 / Model Layer v4.5 · 62 skills · August 2026*
+*Grok Imagine Cinematic Studio v3.9.1 — Grok 4.5 / Model Layer v4.5 · 62 skills · August 2026*


### PR DESCRIPTION
## Summary

Post-release doc consistency for **v3.9.1**:

- Activation / MASTER_PROMPT / Quick Start → **v3.9.1**
- Operator cheat sheet + CLI reference: **React SPA** (`cinematic-studio web-react`) and API
- Multi-shell matrix pointers to WEB_SHELLS

## Test plan

- [x] `plugin catalog check --release`
- [ ] CI validate