### PR TITLE
docs: finish v3.9.1 stamps in README and AGENTS

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -14,7 +14,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio.git",
-        "sha": "9dbce2bf8a3434c1dfdf31f72263302451024714"
+        "sha": "6e0448e12058cac4451dae1316a907f41fe6eae6"
       },
       "homepage": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio",
       "keywords": [
@@ -31,7 +31,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio.git",
-        "sha": "9dbce2bf8a3434c1dfdf31f72263302451024714"
+        "sha": "6e0448e12058cac4451dae1316a907f41fe6eae6"
       },
       "homepage": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio",
       "keywords": [
@@ -49,7 +49,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio.git",
-        "sha": "9dbce2bf8a3434c1dfdf31f72263302451024714"
+        "sha": "6e0448e12058cac4451dae1316a907f41fe6eae6"
       },
       "homepage": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio",
       "keywords": [
@@ -69,7 +69,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio.git",
-        "sha": "9dbce2bf8a3434c1dfdf31f72263302451024714"
+        "sha": "6e0448e12058cac4451dae1316a907f41fe6eae6"
       },
       "homepage": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio",
       "keywords": [
@@ -89,7 +89,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio.git",
-        "sha": "9dbce2bf8a3434c1dfdf31f72263302451024714"
+        "sha": "6e0448e12058cac4451dae1316a907f41fe6eae6"
       },
       "homepage": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio",
       "keywords": [
@@ -109,7 +109,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio.git",
-        "sha": "9dbce2bf8a3434c1dfdf31f72263302451024714"
+        "sha": "6e0448e12058cac4451dae1316a907f41fe6eae6"
       },
       "homepage": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio",
       "keywords": [

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -300,7 +300,7 @@
           }
         ]
       },
-      "sha": "9dbce2bf8a3434c1dfdf31f72263302451024714"
+      "sha": "6e0448e12058cac4451dae1316a907f41fe6eae6"
     },
     "grok-imagine-cinematic-core": {
       "components": {
@@ -429,7 +429,7 @@
           }
         ]
       },
-      "sha": "9dbce2bf8a3434c1dfdf31f72263302451024714"
+      "sha": "6e0448e12058cac4451dae1316a907f41fe6eae6"
     },
     "grok-imagine-camera-image": {
       "components": {
@@ -480,7 +480,7 @@
           }
         ]
       },
-      "sha": "9dbce2bf8a3434c1dfdf31f72263302451024714"
+      "sha": "6e0448e12058cac4451dae1316a907f41fe6eae6"
     },
     "grok-imagine-sequence-narrative": {
       "components": {
@@ -563,7 +563,7 @@
           }
         ]
       },
-      "sha": "9dbce2bf8a3434c1dfdf31f72263302451024714"
+      "sha": "6e0448e12058cac4451dae1316a907f41fe6eae6"
     },
     "grok-imagine-nsfw": {
       "components": {
@@ -592,7 +592,7 @@
           }
         ]
       },
-      "sha": "9dbce2bf8a3434c1dfdf31f72263302451024714"
+      "sha": "6e0448e12058cac4451dae1316a907f41fe6eae6"
     },
     "grok-imagine-delivery-post": {
       "components": {
@@ -633,7 +633,7 @@
           }
         ]
       },
-      "sha": "9dbce2bf8a3434c1dfdf31f72263302451024714"
+      "sha": "6e0448e12058cac4451dae1316a907f41fe6eae6"
     }
   }
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -244,7 +244,7 @@ When working with or creating skills:
 - **Refine / iterate on previously generated images**: `generated-image-editor` (user-global when present)
 - **Upscale video for final delivery** (720p → 1080p/4K, face restoration): Activate `ai-video-upscaler`
 - Video / audio processing: Activate `cinematic-ffmpeg` or use `ffmpeg` / bash
-- **Full cinematic production**: Activate `grok-imagine-cinematic-studio` (25-agent core + specialist suite, **studio v3.9.0**)
+- **Full cinematic production**: Activate `grok-imagine-cinematic-studio` (25-agent core + specialist suite, **studio v3.9.1**)
 - **Planning → generation handoff**: Studio Director **Imagine Agent Mode Handoff** (see below)
 
 If native Imagine tools are unavailable, use `imagine-execution-bridge` / CLI (`imagine submit`, `sfw run`, `sequence run`) with a locked `VIDEO_PIPELINE_SPEC`.
@@ -268,7 +268,7 @@ Document skills are typically **session / user-global** (not always in the 62-sk
 - Manage the official Grok Build binary (min **0.2.93**): `cinematic-studio grok status|ensure|update|install`
 - Method A meta installer ensures the binary and ships `tools/grok_build_cli.py` + `cli/grok_cli_commands.py`
 - **Android / Termux / NetHunter / desktop shell:** `export PATH="$HOME/.grok/bin:$HOME/.local/bin:$PATH"`; Method A from a clone
-- **grok.com chat:** no binary — `Activate Grok Imagine Cinematic Studio v3.9.0` or paste `MASTER_PROMPT.md`; Method A skills in `~/.grok/skills/` support chat ecosystems (skip declutter if you need both chat Method A + plugin)
+- **grok.com chat:** no binary — `Activate Grok Imagine Cinematic Studio v3.9.1` or paste `MASTER_PROMPT.md`; Method A skills in `~/.grok/skills/` support chat ecosystems (skip declutter if you need both chat Method A + plugin)
 - **grok.com/imagine:** surface `grok_com_imagine` — `imagine-execution-bridge` / `cinematic-studio imagine bridge` copy-paste packets
 - **Grok mobile chat app:** same as grok.com (Activate / Imagine only); shell for CLI
 - Meta path without wrapper: `bash scripts/cinematic_studio.sh grok ensure`
@@ -306,9 +306,9 @@ Use these in the **final response** (never inside function calls), when the runt
 For any complex visual storytelling, film-style image sequences, video production, or NSFW cinematic work:
 
 **Primary activation command:**  
-`Activate Grok Imagine Cinematic Studio v3.9.0` or `Start cinematic production`
+`Activate Grok Imagine Cinematic Studio v3.9.1` or `Start cinematic production`
 
-This engages the full **25 specialized agents** (Role Cards labeled v3.6.5–v4.5 under studio **v3.9.0**; Studio Director owns **Imagine Agent Mode Handoff**) plus pipeline specialists and **Wave A** scaffolds. **62 skills** implement the department. Core list:
+This engages the full **25 specialized agents** (Role Cards labeled v3.6.5–v4.5 under studio **v3.9.1**; Studio Director owns **Imagine Agent Mode Handoff**) plus pipeline specialists and **Wave A** scaffolds. **62 skills** implement the department. Core list:
 
 - Studio Director (`studio-director`), Mega Production Architect (`mega-production-architect`)
 - Director of Photography, Production Designer, Color Grading Supervisor
@@ -326,7 +326,7 @@ Model Layer for Role Cards: **`references/agents/MODEL_LAYER_v4.5.md`**.
 Identity Continuity: **`references/agents/IDENTITY_CONTINUITY_PROTOCOL_v3.8.md`**.  
 **Parallel Brief Protocol:** Concurrent multi-agent coordination under MAXIMUM AGENTIC MODE. Canonical: `references/agents/Parallel_Brief_Protocol.md`. Studio Director issues Parallel Briefs; specialist outputs converge into validated `imagine_agent_mode_handoff` packets.
 
-## Imagine Agent Mode Handoff (landed v3.7.1 · current studio v3.9.0)
+## Imagine Agent Mode Handoff (landed v3.7.1 · current studio v3.9.1)
 
 Studio Director routes planning → generation so pipeline context is never dropped.
 
@@ -409,7 +409,7 @@ Entry points by task (not exhaustive). Prefer slugs; full map = `AGENT_INDEX.md`
 | **GitHub Management** | `github-repo-manager` | Git lifecycle, PRs, releases, skill/plugin catalog pin hygiene |
 | **Documents** | `pdf`, `docx`, `pptx`, `xlsx` | Professional docs (session skills when available) |
 | **Memory** | `memory-edit` | Personal facts/preferences worth remembering |
-| **Grok Plugin & Meta** | `cinematic-studio-meta-installer` | Bootstrap/install/update the full **62-skill** suite (v3.9.0; packs + declutter `full_suite_wins`) |
+| **Grok Plugin & Meta** | `cinematic-studio-meta-installer` | Bootstrap/install/update the full **62-skill** suite (v3.9.1; packs + declutter `full_suite_wins`) |
 | **Localization** | `localization-subtitle-specialist` | SDH, multi-language, cultural adaptation |
 | **Production Bible** | `production-bible-workflow` | Guided create-bible / DNA / sequence / quota onboarding |
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## 🎬 Grok Imagine Cinematic Studio
 
-> **v3.9.0** — The most advanced multi-agent cinematic production system for Grok 4.5 Build + Grok 4.3 cinematic dual-stack
+> **v3.9.1** — The most advanced multi-agent cinematic production system for Grok 4.5 Build + Grok 4.3 cinematic dual-stack
 
 **Requires Grok Build ≥ 0.2.93** | **Native Imagine Video 1.5 support with synchronized audio**
 
@@ -15,7 +15,7 @@
 
 <p align="center">
   <a href="https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="MIT License"></a>
-  <img src="https://img.shields.io/badge/version-3.9.0-success.svg" alt="v3.9.0">
+  <img src="https://img.shields.io/badge/version-3.9.1-success.svg" alt="v3.9.1">
   <img src="https://img.shields.io/badge/Grok%20Build-%E2%89%A5%200.2.93-orange.svg" alt="Grok Build ≥ 0.2.93">
   <a href="https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio/stargazers"><img src="https://img.shields.io/github/stars/FineComputer14451/Grok-Imagine-Cinematic-Studio?style=social" alt="GitHub Stars"></a>
 </p>
@@ -42,7 +42,7 @@ Whether you’re crafting Marvel-style hero reveals, cyberpunk neon sequences, i
 
 ---
 
-## 🚀 What’s New in v3.9.0
+## 🚀 What’s New in v3.9.1
 
 - **TUI Home view modes** — `1` compact · `2` ops · `3` full · Tab cycle · `p` pause auto-refresh · action list filter
 - **Streamlit Dashboard view modes** — same compact/ops/full density (session radio; TUI 1/2/3 parity)
@@ -56,19 +56,19 @@ See full details in [CHANGELOG.md](CHANGELOG.md) and [docs/releases/RELEASE_NOTE
 
 ---
 
-## 🏗️ System Architecture (v3.9.0)
+## 🏗️ System Architecture (v3.9.1)
 
 **Core Philosophy**: A modular "studio" of specialized agents that collaborate under the **Studio Director**, with strong handoff protocols, identity locking, readiness gates, and production discipline. The system bridges high-level creative direction (Grok chat/Build) with low-level execution (Imagine Image/Video 1.5) while maintaining full traceability and quota awareness.
 
-### Updated Architecture Diagrams (v3.9.0)
+### Updated Architecture Diagrams (v3.9.1)
 
-These **Mermaid diagrams** are the current, live representation of the system. They reflect the plugin pack architecture, Imagine Agent Mode Handoff, Identity Continuity Protocol, color-grade → polish pipeline, and all readiness gates introduced through v3.9.0.
+These **Mermaid diagrams** are the current, live representation of the system. They reflect the plugin pack architecture, Imagine Agent Mode Handoff, Identity Continuity Protocol, color-grade → polish pipeline, and all readiness gates introduced through v3.9.1.
 
 ```mermaid
 flowchart TB
     subgraph UserLayer["👤 User Layer"]
         GrokChat["Grok Chat / Build CLI"]
-        Activate["Activate Studio v3.9.0<br/>or 'start cinematic production'"]
+        Activate["Activate Studio v3.9.1<br/>or 'start cinematic production'"]
     end
 
     subgraph Orchestration["🎬 Orchestration Layer"]
@@ -91,7 +91,7 @@ flowchart TB
         OTHER["Stunt, Performance, Key Art,<br/>Trailer, Production Design..."]
     end
 
-    subgraph Core["⚙️ Core Systems & Protocols (v3.9.0)"]
+    subgraph Core["⚙️ Core Systems & Protocols (v3.9.1)"]
         PB["Production Bible + Guided Wizard<br/>(CLI + Streamlit Web UI)"]
         DNA["Character DNA Pipeline<br/>Extract → Lock → Inject"]
         HANDOFF["Imagine Agent Mode Handoff<br/>+ Packet Validators"]
@@ -144,11 +144,11 @@ flowchart TB
     class HANDOFF,READINESS,PLUGIN accent
 ```
 
-**Orchestration & Production Flow (v3.9.0)**
+**Orchestration & Production Flow (v3.9.1)**
 
 ```mermaid
 flowchart TD
-    Start["Start New Project<br/>(Activate Studio v3.9.0)"] --> Bible["Build & Lock<br/>Production Bible<br/>(VIDEO_PIPELINE_SPEC 1.5)"]
+    Start["Start New Project<br/>(Activate Studio v3.9.1)"] --> Bible["Build & Lock<br/>Production Bible<br/>(VIDEO_PIPELINE_SPEC 1.5)"]
     Bible --> DNA["Character DNA<br/>Extract → Lock → Inject<br/>(Identity Continuity Protocol)"]
     DNA --> PreProd["Pre-Production<br/>Concepts, Mood Boards, DoP Language"]
     PreProd --> Principal["Principal Photography<br/>Sequence Director + Specialists<br/>(Stunts / VFX / Sound / NSFW)"]
@@ -168,10 +168,10 @@ flowchart TD
 > ![System Architecture](assets/system_architecture_v3.3.png)
 > ![Orchestration Flow](assets/orchestration_flow_v3.3.png)
 
-**Updated ASCII Overview (v3.9.0)**
+**Updated ASCII Overview (v3.9.1)**
 
 ``` 
-Grok Imagine Cinematic Studio v3.9.0  (Studio Director + 25+ Agents · Grok 4.5 primary)
+Grok Imagine Cinematic Studio v3.9.1  (Studio Director + 25+ Agents · Grok 4.5 primary)
 ├── .grok-plugin/                 # Marketplace manifests + plugin packs (full suite + 5 satellites)
 ├── references/agents/            # 25+ Role Cards, AGENT_INDEX, MODEL_LAYER, IDENTITY_CONTINUITY_PROTOCOL, IMAGINE_AGENT_MODE_HANDOFF
 ├── tools/                        # character_dna, sequence_chain, quota_optimizer, nsfw_*, bible_stages, imagine_bridge, handoff_schema, cli/
@@ -188,7 +188,7 @@ Grok Imagine Cinematic Studio v3.9.0  (Studio Director + 25+ Agents · Grok 4.5 
 └── .grok/skills/                 # 62 custom Grok skills (runtime engine)
 ```
 
-**Key v3.9.0 Components**
+**Key v3.9.1 Components**
 - `references/agents/` — Authoritative Role Cards + protocols (Studio Director owns orchestration & handoff decisions)
 - `references/agents/MODEL_LAYER_v4.5.md` + `IDENTITY_CONTINUITY_PROTOCOL_v3.8.md` — Operating rules + drift detection for every skill/agent
 - `MASTER_PROMPT.md` — Activation entrypoint with Grok 4.5 stack + Imagine Agent Mode Handoff
@@ -201,9 +201,9 @@ Grok Imagine Cinematic Studio v3.9.0  (Studio Director + 25+ Agents · Grok 4.5 
 
 ## 🎨 Visual Identity & Branding
 
-**Refreshed Premium Cinematic Banner (v3.9.0)**
+**Refreshed Premium Cinematic Banner (v3.9.1)**
 
-A brand new Hollywood-grade banner has been created specifically for v3.9.0. It features a massive cinematic camera lens with holographic AI elements, gold/teal accents, and premium film production aesthetics. The banner has been updated in `assets/banner.jpg`.
+A brand new Hollywood-grade banner has been created specifically for v3.9.1. It features a massive cinematic camera lens with holographic AI elements, gold/teal accents, and premium film production aesthetics. The banner has been updated in `assets/banner.jpg`.
 
 The included `assets/logo.jpg` and `assets/favicon.jpg` complete the visual identity for Web UI and repository presentation.
 
@@ -232,7 +232,7 @@ Every generation targets:
 In any Grok chat:
 
 ```
-Activate Grok Imagine Cinematic Studio v3.9.0
+Activate Grok Imagine Cinematic Studio v3.9.1
 ```
 
 or the shorter trigger:
@@ -350,7 +350,7 @@ Same ActionSpec safety model as the TUI (no free-form argv). See [`docs/PR9_STUD
 5. **Marketing Assets**: Key Art Designer + Trailer Director for posters, hero reveals, teasers
 
 **Pro Tip**: Combine steps naturally, e.g.:
-> "Activate Grok Imagine Cinematic Studio v3.9.0, start new project called 'VOIDWALKER', generate the full Production Bible with 1.5 video pipeline, lock the lead character DNA, and create the hero reveal key art."
+> "Activate Grok Imagine Cinematic Studio v3.9.1, start new project called 'VOIDWALKER', generate the full Production Bible with 1.5 video pipeline, lock the lead character DNA, and create the hero reveal key art."
 
 ---
 
@@ -452,11 +452,11 @@ This project is licensed under the **MIT License** — see [LICENSE](LICENSE) fo
 
 <p align="center">
   <strong>Built for creators who want cinematic AI that feels directed, not just generated.</strong><br>
-  <em>Grok Imagine Cinematic Studio v3.9.0 — July 2026 · Independent community project · Not affiliated with xAI</em>
+  <em>Grok Imagine Cinematic Studio v3.9.1 — August 2026 · Independent community project · Not affiliated with xAI</em>
 </p>
 
 ---
 
 **Ready to direct your next masterpiece?**
 
-Just say: **"Activate Grok Imagine Cinematic Studio v3.9.0"** and begin.
+Just say: **"Activate Grok Imagine Cinematic Studio v3.9.1"** and begin.


### PR DESCRIPTION
## Summary

Post-inspect cleanup: replace leftover **v3.9.0** marketing/activation stamps in `README.md` and `AGENTS.md` so the public face matches **VERSION 3.9.1** and the React cockpit release.

Historical changelog line for 3.9.0 multi-surface remains in AGENTS recent history.

## Test plan

- [x] `plugin catalog check --release`
- [ ] CI validate