### PR TITLE
feat(aup): SpaceXAI AUP fail-closed gates and SFW-default plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -196,3 +196,6 @@ artifacts/animatics/
 
 # Streamlit
 .streamlit/secrets.toml
+
+# Local SpaceXAI AUP attestation (never commit)
+.aup_attestation.json

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
   "name": "grok-imagine-cinematic-studio",
-  "description": "Official Grok plugin marketplace for Grok Imagine Cinematic Studio v3.6 — 32 production skills, CLI tools, and 23-agent Role Cards.",
+  "description": "Third-party Grok plugin marketplace for Grok Imagine Cinematic Studio v3.6. Not affiliated with, endorsed by, or originating from xAI or SpaceXAI.",
   "owner": {
     "name": "FineComputer14451",
     "url": "https://github.com/FineComputer14451"
@@ -8,7 +8,7 @@
   "plugins": [
     {
       "name": "grok-imagine-cinematic-studio",
-      "description": "Full 23-agent cinematic studio with native Grok Imagine Video 1.5, Character DNA, long-form sequence extension, quota orchestration, NSFW pipelines, and AI delivery polish.",
+      "description": "SFW 23-agent cinematic studio for Grok Imagine Video 1.5, Character DNA, long-form sequence extension, quota orchestration, and AI delivery polish. Unofficial third-party plugin.",
       "category": "creative",
       "version": "3.6.5",
       "source": "./",
@@ -22,6 +22,20 @@
         "sequence extender",
         "production bible",
         "ai polish director"
+      ]
+    },
+    {
+      "name": "grok-imagine-cinematic-studio-nsfw",
+      "description": "Optional 18+ add-on: limited R-rated fictional adult material of imaginary adults. Requires AUP attestation. Not affiliated with xAI/SpaceXAI.",
+      "category": "creative",
+      "version": "3.6.5",
+      "source": "./.grok-plugin/nsfw-plugin.json",
+      "homepage": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio",
+      "keywords": [
+        "18+",
+        "aup",
+        "r-rated",
+        "imaginary adults"
       ]
     }
   ]

--- a/.grok-plugin/nsfw-plugin.json
+++ b/.grok-plugin/nsfw-plugin.json
@@ -1,0 +1,17 @@
+{
+  "name": "grok-imagine-cinematic-studio-nsfw",
+  "version": "3.6.5",
+  "description": "Optional 18+ R-rated fictional-adult add-on. Requires local AUP attestation. Not affiliated with xAI or SpaceXAI. Policy: https://x.ai/legal/acceptable-use-policy",
+  "aup_required": true,
+  "aup_url": "https://x.ai/legal/acceptable-use-policy",
+  "license": "MIT",
+  "skills": [
+    ".grok/skills/erosforge-nsfw-director",
+    ".grok/skills/nsfw-chain-qa-protocol",
+    ".grok/skills/nsfw-quota-orchestrator",
+    ".grok/skills/nsfw-sequence-extender"
+  ],
+  "commands": [
+    "commands/nsfw.md"
+  ]
+}

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -53,10 +53,6 @@
             "description": "Visual language architect and cinematic lens master. Defines camera moves, framing, lens choices, and translates emotio…"
           },
           {
-            "name": "erosforge-nsfw-director",
-            "description": "Adult/R-rated content specialist. Designs emotionally authentic, artistically justified intimate scenes with proper 1.5…"
-          },
-          {
             "name": "foley-sound-design-specialist",
             "description": "Hyper-realistic foley and immersive soundscape specialist. Designs detailed, physically accurate sound effects and envi…"
           },
@@ -111,18 +107,6 @@
           {
             "name": "narrative-arc-pacing-strategist",
             "description": "Story rhythm master and emotional architect. Designs three-act structure, pacing heatmap, tension/release curves, and e…"
-          },
-          {
-            "name": "nsfw-chain-qa-protocol",
-            "description": "NSFW extend and stitch chain QA protocol for intimate Grok Imagine Video 1.5 sequences. Runs the weighted 8-point artif…"
-          },
-          {
-            "name": "nsfw-quota-orchestrator",
-            "description": "Quota-aware NSFW production orchestrator for SuperGrok Heavy. Plans and executes batches of erotic image and video gene…"
-          },
-          {
-            "name": "nsfw-sequence-extender",
-            "description": "NSFW sensual sequence extension from reference frame or short clip to 30-120+ seconds. Plans erotic tension curves, Gro…"
           },
           {
             "name": "performance-emotion-director",
@@ -211,10 +195,6 @@
             "description": "Model and quota intelligence — region routing, aspect presets, live quota sync, and two-pass quality scheduling."
           },
           {
-            "name": "nsfw",
-            "description": "Activate ErosForge NSFW pipeline with quota-aware batch planning, model routing, chain QA, and sensual sequence extensi…"
-          },
-          {
             "name": "quota",
             "description": "Estimate production credits, assess budget risk, and get quota optimization recommendations for Imagine Video 1.5."
           },
@@ -225,6 +205,34 @@
           {
             "name": "validate",
             "description": "Run full Cinematic Studio validation — skills, agents, models, DNA, sequences, and project state health checks."
+          }
+        ]
+      }
+    },
+    "grok-imagine-cinematic-studio-nsfw": {
+      "components": {
+        "skills": [
+          {
+            "name": "erosforge-nsfw-director",
+            "description": "Adult/R-rated content specialist. Designs emotionally authentic, artistically justified intimate scenes with proper 1.5…"
+          },
+          {
+            "name": "nsfw-chain-qa-protocol",
+            "description": "NSFW extend and stitch chain QA protocol for intimate Grok Imagine Video 1.5 sequences. Runs the weighted 8-point artif…"
+          },
+          {
+            "name": "nsfw-quota-orchestrator",
+            "description": "Quota-aware NSFW production orchestrator for SuperGrok Heavy. Plans and executes batches of erotic image and video gene…"
+          },
+          {
+            "name": "nsfw-sequence-extender",
+            "description": "NSFW sensual sequence extension from reference frame or short clip to 30-120+ seconds. Plans erotic tension curves, Gro…"
+          }
+        ],
+        "commands": [
+          {
+            "name": "nsfw",
+            "description": "Activate ErosForge NSFW pipeline with quota-aware batch planning, model routing, chain QA, and sensual sequence extensi…"
           }
         ]
       }

--- a/.grok-plugin/plugin.json
+++ b/.grok-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "grok-imagine-cinematic-studio",
   "version": "3.6.5",
-  "description": "23-agent cinematic production suite for Grok Imagine Video 1.5 with native audio, Character DNA, sequence extension, quota orchestration, and delivery polish.",
+  "description": "Unofficial third-party SFW cinematic production suite for Grok Imagine Video 1.5. Not affiliated with xAI or SpaceXAI.",
   "author": {
     "name": "FineComputer14451",
     "url": "https://github.com/FineComputer14451"
@@ -32,7 +32,6 @@
     ".grok/skills/continuity-consistency-guardian",
     ".grok/skills/director-of-photography",
     ".grok/skills/director-of-photography-v3-3",
-    ".grok/skills/erosforge-nsfw-director",
     ".grok/skills/foley-sound-design-specialist",
     ".grok/skills/github-repo-manager",
     ".grok/skills/grok-imagine-cinematic-studio",
@@ -47,9 +46,6 @@
     ".grok/skills/localization-subtitle-specialist",
     ".grok/skills/mega-production-architect",
     ".grok/skills/narrative-arc-pacing-strategist",
-    ".grok/skills/nsfw-chain-qa-protocol",
-    ".grok/skills/nsfw-quota-orchestrator",
-    ".grok/skills/nsfw-sequence-extender",
     ".grok/skills/performance-emotion-director",
     ".grok/skills/post-production-color-grading-supervisor",
     ".grok/skills/production-bible-workflow",
@@ -73,7 +69,6 @@
     "commands/dna.md",
     "commands/imagine.md",
     "commands/intelligence.md",
-    "commands/nsfw.md",
     "commands/quota.md",
     "commands/sfw.md",
     "commands/validate.md"

--- a/.grok/skills/character-dna-extractor/SKILL.md
+++ b/.grok/skills/character-dna-extractor/SKILL.md
@@ -94,7 +94,7 @@ Handoff packet includes:
 
 ## NSFW Protocol
 
-Only include `nsfw_notes` when erotic/suggestive content is clearly visible in references. Remain clinical and consistency-focused. Compatible with ErosForge when explicitly activated.
+Intimate DNA is **opt-in and AUP-gated**. Require `subject_kind=imaginary_adult`, local 18+ attestation, and **no** reference photos. Refuse CSAM / minor-coded tropes. Do not undress or lock a real person’s likeness. Compatible with ErosForge only after `nsfw attest`. Policy: https://x.ai/legal/acceptable-use-policy
 
 ## Integration Chain
 

--- a/.grok/skills/erosforge-nsfw-director/SKILL.md
+++ b/.grok/skills/erosforge-nsfw-director/SKILL.md
@@ -5,7 +5,9 @@ description: Adult/R-rated content specialist. Designs emotionally authentic, ar
 
 # ErosForge NSFW Director v3.6
 
-**Activate explicitly with `ACTIVATE EROSFORGE`.**
+**Activate explicitly with `ACTIVATE EROSFORGE` after `nsfw attest`.**
+
+SpaceXAI AUP: limited R-rated fictional adult material of **imaginary adults** only. No real-person refs, no CSAM, no pornographic-beyond-R generation. Policy: https://x.ai/legal/acceptable-use-policy. This skill is **not** part of the default Grok plugin; it lives in the optional 18+ add-on.
 
 You are the emotionally intelligent, artistically rigorous specialist for adult and intimate content.
 
@@ -48,6 +50,7 @@ Track post-scene state and clothing displacement with precision.
 
 - Must be explicitly activated with `ACTIVATE EROSFORGE`.
 - Works closely with Performance & Emotion Director, Identity Lock Specialist, and Sonic Architect.
+- Never generate intimate content without AUP attestation, imaginary-adult subjects, and R-rated cap.
 - Never generate explicit content without proper emotional context and artistic justification.
 - Maintain strict state tracking for continuity in intimate scenes.
 

--- a/.grok/skills/i2i-refiner/references/NSFW_I2I_Quick_Reference.md
+++ b/.grok/skills/i2i-refiner/references/NSFW_I2I_Quick_Reference.md
@@ -1,113 +1,61 @@
 # NSFW I2I Quick Reference v3.6 — I2I Refiner
 
-**For use with:** `ACTIVATE I2I REFINER`  
-**Purpose:** High-fidelity explicit image refinement while protecting anatomy, fluids, expressions, and skin detail.
+**AUP cap:** SpaceXAI allows only **limited R-rated fictional adult** material of **imaginary adults** for age-verified operators. `tools/aup_gate.py` refuses genital/penetration/creampie/ahegao/hidden-camera language and any source-image intimate edit. Do not use this file to bypass Imagine filters. Policy: https://x.ai/legal/acceptable-use-policy
+
+**For use with:** `ACTIVATE I2I REFINER` after `nsfw attest`  
+**Purpose:** High-fidelity **R-rated implied** image refinement while protecting anatomy, fabric, expressions, and skin detail.
 
 ---
 
-## 1. Recommended Strength Curves (NSFW Optimized v3.6)
+## 1. Recommended Strength Curves (R-rated implied)
 
-| Pass                        | Recommended Strength | Focus                                              | Notes for Explicit Work                          |
-|-----------------------------|----------------------|----------------------------------------------------|--------------------------------------------------|
-| **Composition Pass**        | 0.58 – 0.72          | Pose, body position, framing, major forms          | Slightly lower than general cinematic            |
-| **Anatomy & Fluid Pass**    | 0.28 – 0.42          | Genitals, fluids, skin micro-texture, pores        | **Most critical pass** for explicit fidelity     |
-| **Skin / Expression / Polish Pass** | 0.12 – 0.25    | Micro-expressions, eye state, specular highlights, cinematic look | Very low strength — protect fine details         |
+| Pass | Recommended Strength | Focus |
+|------|----------------------|--------|
+| Composition | 0.55 – 0.70 | Pose, framing, wardrobe |
+| Skin / fabric | 0.20 – 0.35 | Cloth drape, skin texture |
+| Expression / polish | 0.10 – 0.22 | Eyes, micro-expression, grade |
 
-**Strong Recommendation:** Bias toward the **lower half** of these ranges for close-up explicit, ahegao, or heavy fluid shots. Higher Composition strength only when pose stability is at risk.
-
-**4-Pass Mode (Recommended for Difficult Explicit Frames)**
-
-Use this when working with:
-- Heavy fluids / creampie scenes
-- Extreme close-ups on genitals or face
-- Complex ahegao or intense expressions
-- Previous 3-pass results had artifacts
-
-| Pass                        | Strength Range     | Focus                                      |
-|-----------------------------|--------------------|--------------------------------------------|
-| 1. Composition Lock         | 0.55 – 0.68        | Pose + major forms                         |
-| 2. Anatomy Lock             | 0.30 – 0.40        | Genitals, hands, facial structure          |
-| 3. Fluids + Skin Detail     | 0.20 – 0.30        | Fluids, sheen, pores, micro-texture        |
-| 4. Expression + Final Polish| 0.10 – 0.20        | Micro-expressions + cinematic look         |
-
-**Activation:** `ACTIVATE I2I REFINER — 4-pass mode`
+Do **not** run genital, fluid, or ahegao passes — `aup_gate` will refuse those prompts.
 
 ---
 
-## 2. Core NSFW Prompt Additives (Copy-Paste)
-
-Append this block to almost every explicit i2i prompt:
+## 2. Core R-rated Prompt Additives
 
 ```
-exact anatomical fidelity, no deformed or smoothed genitals, preserved fluid details and specular highlights on wet skin, micro skin texture and pores visible, locked micro-expression and eye state, cinematic erotic lighting, photorealistic intimate details, no extra limbs or fingers in contact areas
-```
-
-**Stronger / More Protective Version** (use on difficult frames):
-
-```
-exact anatomical fidelity, zero deformation on breasts/nipples/vulva/penis/anus/hands, preserved arousal fluids and wetness physics, visible skin pores and subtle veins, locked ahegao or pleasure micro-expression, specular highlights on oiled or sweaty skin, cinematic intimate close-up lighting, photorealistic genital texture and detail
+implied intimacy, clothing on or tasteful suggestion, cinematic lighting, adult fictional characters, no real-person likeness, R-rated not pornographic
 ```
 
 ---
 
-## 3. Common Scene-Specific Additives
+## 3. Allowed scene notes
 
-### Close-up Genital / Penetration
-`, exact penetration detail, visible vaginal/anal stretching and grip, realistic internal texture, glistening fluids on shaft and entrance, no smoothing or melting of genital contact points`
+- Tender slow-burn, eye contact, fabric shift
+- Consensual observed intimacy with in-world camera awareness
+- Restraint as sculptural costume (adult fictional only)
 
-### Ahegao / Heavy Pleasure Face
-`, locked ahegao expression, rolled back eyes with visible whites, tongue out and drooling, heavy blush, tear lines, flushed skin, micro facial muscle tension`
-
-### Heavy Fluids / Creampie / Cum Play
-`, thick viscous semen and arousal fluids with realistic viscosity and stringing, cum dripping and pooling, wet skin sheen, preserved fluid placement across passes, no disappearing fluids`
-
-### Oiled / Shiny Skin
-`, heavily oiled glistening skin with strong specular highlights, visible oil droplets and streaks, enhanced skin reflectivity, cinematic erotic sheen`
-
-### Wet Clothing / See-through
-`, wet fabric clinging to skin, visible nipple and body detail through wet cloth, water droplets on fabric and skin, realistic wet fabric physics`
-
-### BDSM / Restraint Elements
-`, rope or restraint marks on skin, realistic pressure and indentation, skin bulging slightly around tight bindings, maintained hand/foot position and tension`
-
-### Multi-Person / Complex Contact
-`, clear separation of bodies and limbs, no merging of skin or anatomy at contact points, accurate hand placement and finger positioning on partner`
+Forbidden: hidden camera, nudify, real-person refs, pornographic anatomy additives.
 
 ---
 
-## 4. NSFW Artifact Guard Checklist (Run After Every Pass)
+## 4. Artifact Guard
 
-Before accepting a refined image, quickly check:
-
-- [ ] Genitals not melted, fused, or smoothed
-- [ ] No extra or missing fingers/hands in intimate contact
-- [ ] Fluids still visible and correctly placed (not erased)
-- [ ] Skin texture and pores still present (not plastic-looking)
-- [ ] Eye expression and micro-details intact
-- [ ] No color shifts on aroused skin or genitals
-- [ ] Anatomy proportions stable from reference/DNA
-- [ ] Fabric state (wet, pulled aside, stained) preserved
-
-If any fail → run another low-strength Detail or Polish pass with stronger protective language.
+- [ ] Hands/fingers intact
+- [ ] Fabric state stable
+- [ ] Identity lock holds
+- [ ] Still clearly R-rated / implied, not explicit
 
 ---
 
-## 5. Integration Notes
+## 5. Integration
 
-- **With Character DNA / Identity Lock:** Always pull key consistency anchors first. Explicit anatomy should be treated as part of the locked identity.
-- **With ErosForge NSFW Director:** Use i2i-refiner for keyframe fidelity. Hand off to ErosForge when you need emotional performance, timing, or full sequence direction.
-- **Before Video Extension:** Run full 3-pass NSFW i2i refinement on important explicit keyframes before sending to `cinematic-sequence-extender` or native video.
-- **Close-up vs Wide:** Close-ups can usually take even lower strength in pass 2–3. Wide shots may need slightly higher composition strength to hold body pose.
+Intimate DNA must be `subject_kind=imaginary_adult` with **no** reference photos. Hand off to ErosForge only after `nsfw attest`.
 
 ---
 
-## 6. Quick Activation Command Examples
+## 6. Activation
 
 ```
-ACTIVATE I2I REFINER on this keyframe with full NSFW protocol
-ACTIVATE I2I REFINER — protect anatomy and fluids, lower mid-pass strength
-I2I REFINER — ahegao close-up, heavy fluids, use strong protective additives
-ACTIVATE I2I REFINER — 4-pass mode
+ACTIVATE I2I REFINER on this keyframe with R-rated implied intimacy protocol
 ```
 
 ---

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ This is a persistent Linux sandbox environment (`/home/workdir/`) designed for a
 │       │   ├── scripts/         # Optional: executable helpers
 │       │   ├── references/      # Optional: long-form docs, production bibles, agent defs
 │       │   └── assets/          # Optional: templates, reference images, etc.
-├── .grok-plugin/                # Grok plugin manifests (marketplace.json, plugin.json, plugin-index.json for 44 skills + commands)
+├── .grok-plugin/                # Grok plugin manifests (SFW default + optional 18+ nsfw-plugin.json)
 ├── artifacts/                   # All outputs go here (images, docs, videos, code, etc.)
 ├── scripts/                     # Install/verify/update helpers + generate_plugin_index.py
 ├── web_ui/                      # Streamlit dashboard (model pickers, quota sim, DNA/sequence tools)
@@ -167,8 +167,8 @@ The **AI Polish Director** is the final post-production agent, activated after Q
 | **Sequence Extension**      | `cinematic-sequence-extender`, `extend-frame-to-video` | Extending stills into video, rough-cut animatics, or continuing clips |
 | **Custom Agents**           | `custom-grok-cinematic-agent`              | Drafting or customizing bespoke cinematic production agents / role cards |
 | **Quota & Efficiency**      | `workflow-quota-optimizer`                 | Long-form generation sessions, cost/quota management, production planning |
-| **NSFW Batch Orchestration**| `nsfw-quota-orchestrator`                    | Quota-aware erotic image+video batches on Heavy, i2v decisions, daily reports (with ErosForge) |
-| **NSFW Sequence Extension** | `nsfw-sequence-extender`                     | Sensual 30–120s+ extension from reference/clip, prompt chains, erotic pacing, artifact QA (with ErosForge) |
+| **NSFW Batch Orchestration**| `nsfw-quota-orchestrator`                    | Optional 18+ add-on. R-rated fictional imaginary adults only after `nsfw attest` (with ErosForge). Not in the default plugin. |
+| **NSFW Sequence Extension** | `nsfw-sequence-extender`                     | Optional 18+ add-on. R-rated implied intimacy extend after AUP attestation. |
 | **GitHub Management**       | `github-repo-manager`                      | Create repo, push, PRs, issues, file operations on GitHub |
 | **Video / Audio**           | `ffmpeg`                                   | Trimming, merging, subtitles, compression, GIFs, storyboards |
 | **Documents**               | `pdf`, `docx`, `pptx`, `xlsx`              | Professional document or presentation creation |
@@ -204,8 +204,9 @@ Local config: `~/.grok/config.toml` sets `fork_secondary_model = "grok-build"`.
 - Primary ongoing project: **Grok Imagine Cinematic Studio** (v3.6.5 "Odyssey Native") and related custom skills.
 - All generated artifacts **must** be saved to `/home/workdir/artifacts/`.
 - Persistent state and custom skills live in `/home/workdir/.grok/skills/`.
-- Grok plugin marketplace lives in `.grok-plugin/` (marketplace.json, plugin.json, plugin-index.json with 44 skills + 11 commands). Install via `grok plugin install FineComputer14451/Grok-Imagine-Cinematic-Studio --trust`.
-- The workspace supports both SFW cinematic work and NSFW/erotic cinematic pipelines (via ErosForge when explicitly activated).
+- Grok plugin marketplace lives in `.grok-plugin/`. **Default plugin is SFW-only.** Optional 18+ add-on: `.grok-plugin/nsfw-plugin.json`. Install via `grok plugin install FineComputer14451/Grok-Imagine-Cinematic-Studio --trust`.
+- This repo is an **unofficial third-party** studio. Not affiliated with xAI or SpaceXAI. Follow https://x.ai/legal/acceptable-use-policy.
+- Intimate / ErosForge work is **AUP-gated** (`tools/aup_gate.py`): 18+ attestation (`nsfw attest`), imaginary adults only, no real-person refs, R-rated cap. Default plugin does not ship NSFW skills.
 - Model stack (grok-4.3 / grok-build-0.1 / grok-imagine-video-1.5) and `VIDEO_PIPELINE_SPEC` are now wired everywhere (CLI, Web UI, handoffs, Production Bibles, Role Cards).
 - Recent 3.6.5 work: plugin support, CLI refactor + `models verify`, Web UI Streamlit modernization (`width="stretch"`), repo hygiene (deprecated `agents/` removed), docs refresh (README, CHANGELOG, RELEASE_NOTES_v3.6.md, AGENTS.md).
 - Keep this `AGENTS.md` in sync with the GitHub repository and other canonical docs (README, CHANGELOG, RELEASE_NOTES_v3.6.md).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,18 @@ All notable changes to Grok Imagine Cinematic Studio will be documented in this 
 ## [Unreleased]
 
 ### Added
+- **SpaceXAI AUP fail-closed gates** — `tools/aup_gate.py`, `nsfw attest`, 18+ / imaginary-adult / no-real-person checks; CSAM-stub refuse; R-rated cap; DNA intimate lock refuses photo refs
+- **Optional 18+ plugin** — `.grok-plugin/nsfw-plugin.json`; default marketplace plugin is SFW-only
 - **Grok plugin marketplace** — `.grok-plugin/marketplace.json`, `plugin.json`, and `scripts/generate_plugin_index.py` for `grok plugin marketplace add FineComputer14451/Grok-Imagine-Cinematic-Studio`
 
-### Removed
-- **Deprecated `agents/`** — legacy v3.4/v3.5 stubs; canonical Role Cards remain in `references/agents/`
-- **Stale skill mirrors** — duplicate Role Cards and v3.5 prompts under `grok-imagine-cinematic-studio/references/`
-- **Duplicate `references/agents/MASTER_PROMPT_v3.6.md`** — root `MASTER_PROMPT_v3.6.md` is canonical
-
 ### Changed
+- Imagine region failover **no longer hops 403/429** (policy / rate-limit fail closed)
+- Default `nsfw run` / `nsfw session` is **dry-run** (`--live` to generate)
+- Marketplace copy: third-party, **not affiliated** with xAI / SpaceXAI
+- ErosForge / I2I NSFW / kink templates capped at R-rated fictional imaginary adults
+- Shot tier `key_explicit` renamed to `key_intimate` (old name still accepted as an alias); `explicit` intensity removed from planner options
+- `nsfw decide` / `retry` require AUP attestation; `canonical_explicit_level()` refuses full-explicit intensity at shot build time
+- Sequence runner unit test no longer writes under `/tmp` (Termux-safe tempfile)
 - Moved `REPOSITORY_STRUCTURE.md` and `Example_Production_Bible_Example.md` into `docs/archive/` and `examples/`
 - **CI workflow** — removed deprecated `agents/**` path filters and validation scan
 - **README.md** — comprehensive update for v3.6.5 (plugin marketplace, 44-skill suite, model stack everywhere, updated architecture/project structure, agent crew to v3.6.5, CLI/Web UI examples, links)

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -32,7 +32,11 @@ Community leaders have the right and responsibility to remove, edit, or reject c
 
 ## Scope
 
-This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+This Code of Conduct applies within all **community spaces** (issues, PRs, discussions, chats). It does not describe product output. Optional 18+ R-rated **fictional** pipelines are gated by `tools/aup_gate.py` and the [SpaceXAI AUP](https://x.ai/legal/acceptable-use-policy); they are not license to harass people in this community.
+
+This Code of Conduct also applies when an individual is representing the community in public spaces. Examples of representing our community include using a project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+This project is **not affiliated with xAI or SpaceXAI**.
 
 ## Enforcement
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -28,7 +28,7 @@ This section will be updated as new contributors join.
 
 ## Special Thanks
 
-- The xAI team for building Grok 4.3 Beta — the incredible foundation that makes this studio possible.
+- The public Grok / xAI APIs and docs that this **unofficial** studio wraps. This project is not affiliated with, endorsed by, or originating from xAI or SpaceXAI.
 - The entire Grok community for inspiration, feedback, and pushing the boundaries of cinematic AI.
 
 ---

--- a/Kink_Specific_Cinematic_Template_Library_v3.3.md
+++ b/Kink_Specific_Cinematic_Template_Library_v3.3.md
@@ -1,6 +1,8 @@
 # Kink-Specific Cinematic Template Library v3.3
 
-**For use with ErosForge NSFW Director v3.3**
+**For use with ErosForge NSFW Director after `nsfw attest`.**
+
+AUP: 18+, imaginary adults only, **R-rated implied intimacy** (not pornographic). No real-person likenesses. No hidden-camera of unsuspecting people. Policy: https://x.ai/legal/acceptable-use-policy
 
 This library provides **pre-built, optimized cinematic templates** for common kinks and intimate scenarios. Each template includes:
 
@@ -52,16 +54,18 @@ This library provides **pre-built, optimized cinematic templates** for common ki
 
 ---
 
-## 4. Voyeurism
+## 4. Observed Intimacy (consensual, fictional adults)
 
 **Intensity:** Subtle → Medium  
-**Mood:** Secretive, tense, observational
+**Mood:** Aware, tense, observational — **in-world consent required**
+
+Must be clearly **fictional adults** who know they are on camera. Never hidden-camera of unsuspecting people. Never real persons.
 
 - **Lighting:** Low light, practical sources (streetlights, moonlight through windows, phone glow).
-- **Framing:** Through doorways, windows, mirrors, or from a hidden vantage point. Slightly obscured views.
+- **Framing:** Through an in-world doorway or mirror the characters know about. Slightly obscured views.
 - **Motion:** Still camera with very subtle movements. Heavy use of negative space.
-- **Color Grading:** Cool, desaturated, slightly grainy, surveillance aesthetic.
-- **Prompt Keywords:** `voyeuristic perspective, hidden camera, through window, secretive observation, low light, tense atmosphere`
+- **Color Grading:** Cool, desaturated, slightly grainy.
+- **Prompt Keywords:** `consensual observed intimacy, fictional adults, in-world awareness of camera, doorway frame, R-rated implied, low light`
 
 ---
 

--- a/MASTER_PROMPT_v3.6.md
+++ b/MASTER_PROMPT_v3.6.md
@@ -2,6 +2,8 @@
 
 **The most advanced multi-agent cinematic production system for Grok Build + Grok 4.3 + Grok Imagine Video 1.5 Native**
 
+> Unofficial third-party studio. **Not affiliated with xAI or SpaceXAI.** Follow https://x.ai/legal/acceptable-use-policy. Intimate work is 18+, imaginary adults only, R-rated (not pornographic), no real-person undress. Run `nsfw attest` before ErosForge. Default plugin is SFW-only.
+
 **Version:** 3.6.4 "Odyssey Native" (June 2026)  
 **Agents:** 23 Specialized Agents with full v4.0 personalities (v3.6 upgrades for Imagine Video 1.5)  
 **Key Improvements:** Full native integration with Grok Imagine Video 1.5 (image-to-video, one-pass native audio, improved physics/consistency/stitching), Grok 4.3 Full exploitation (1M token context, structured outputs, configurable reasoning, native PDF export, cross-chat memory), enhanced Video Pipeline protocols, AUDIO_MOMENTUM_VECTOR, 1.5-optimized prompt schemas, updated cost simulation for per-second video pricing.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 **The most advanced multi-agent cinematic production system for Grok Build + Grok 4.3 + Grok Imagine Video 1.5**
 
+> **Unofficial third-party project.** Not affiliated with, endorsed by, or originating from xAI or SpaceXAI. Operators must follow the [SpaceXAI Acceptable Use Policy](https://x.ai/legal/acceptable-use-policy). Intimate pipelines are **18+**, **imaginary adults only**, **R-rated (not pornographic)**, and require `nsfw attest`. Real-person undress/nudify is forbidden. The default Grok plugin is **SFW-only**.
+
 Transform any story into emotionally powerful, production-ready cinematic video with **native 1.5 image-to-video**, one-pass synchronized audio (lip-sync + SFX + ambience + music), perfect character consistency, persistent memory, and a full **23-agent** professional film crew.
 
 [![Version](https://img.shields.io/badge/version-3.6.5-blue)](https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio)
@@ -75,8 +77,9 @@ python tools/cinematic_studio_cli.py models list
 python tools/cinematic_studio_cli.py models verify
 python tools/cinematic_studio_cli.py quota estimate --duration 90 --clips 9 --fast-mode
 python tools/cinematic_studio_cli.py generate-prompt "Your story" --chat-model grok-4.3 --video-model 1.5
-python tools/cinematic_studio_cli.py nsfw extend plan "Intimate Sequence" --duration 90 --profile passionate --reference "..."
-python tools/cinematic_studio_cli.py nsfw plan "Hero Session" --shot "hero:Cover frame" --budget 800
+python tools/cinematic_studio_cli.py nsfw attest --i-am-18 --imaginary-adults --not-a-real-person --acknowledge-aup
+python tools/cinematic_studio_cli.py nsfw extend plan "Intimate Sequence" --duration 90 --profile passionate
+python tools/cinematic_studio_cli.py nsfw plan "Hero Session" --shot "hero:Cover frame candlelit embrace" --budget 800
 ```
 
 ### 3. Grok Build Plugin Marketplace (Recommended for Grok CLI)

--- a/commands/nsfw.md
+++ b/commands/nsfw.md
@@ -6,18 +6,25 @@ description: Activate ErosForge NSFW pipeline with quota-aware batch planning, m
 
 Start an explicit opt-in NSFW session with ErosForge, NSFW Quota Orchestrator, Reference Curator model routing, and NSFW Sequence Extender.
 
-**Requires explicit user consent.** Do not activate without clear opt-in.
+**Requires explicit user consent and a local SpaceXAI AUP attestation.** Do not activate without clear 18+ opt-in.
+
+Limited **R-rated fictional adult** material of **imaginary adults** only. No real-person photos, no CSAM, no pornographic-beyond-R generation. Policy: https://x.ai/legal/acceptable-use-policy
 
 ## Preflight
 
-1. **Confirm opt-in** — User must explicitly request NSFW/erotic production.
-2. **CLI available?**
+1. **Confirm opt-in** — User must explicitly request NSFW/erotic production and be 18+.
+2. **Attest**
+   ```bash
+   python tools/cinematic_studio_cli.py nsfw attest \
+     --i-am-18 --imaginary-adults --not-a-real-person --acknowledge-aup
+   ```
+3. **CLI available?**
    ```bash
    python tools/cinematic_studio_cli.py nsfw --help
    python tools/cinematic_studio_cli.py nsfw extend --help
    ```
-3. **Parameters** — Parse "$ARGUMENTS" for optional batch title or sequence name.
-4. **Activate skills:** `erosforge-nsfw-director`, `nsfw-quota-orchestrator`, `nsfw-sequence-extender`, `nsfw-chain-qa-protocol`.
+4. **Parameters** — Parse "$ARGUMENTS" for optional batch title or sequence name.
+5. **Activate skills:** `erosforge-nsfw-director`, `nsfw-quota-orchestrator`, `nsfw-sequence-extender`, `nsfw-chain-qa-protocol`.
 
 State the activation phrase:
 
@@ -26,7 +33,7 @@ State the activation phrase:
 ## Plan
 
 1. Engage **ErosForge NSFW Director** for scene design and intimacy physics.
-2. Run **Reference Curator** NSFW tier routing (hero/anchor/key_explicit → image-quality + 1.5).
+2. Run **Reference Curator** NSFW tier routing (hero/anchor/key_intimate → image-quality + 1.5).
 3. Plan batch under Heavy daily cap with 15% retry reserve.
 4. If "$ARGUMENTS" includes a sequence name, scaffold NSFW extension with tension profile.
 
@@ -38,7 +45,7 @@ State the activation phrase:
 python tools/cinematic_studio_cli.py nsfw plan "Session Title" \
   --shot "hero:Cover frame candlelit embrace" \
   --shot "consistency_anchor:Identity lock close-up" \
-  --shot "key_explicit:high:Primary intimate beat" \
+  --shot "hero:Primary intimate beat" \
   --budget 800
 ```
 

--- a/references/agents/Character_DNA_Extractor_v3.5.md
+++ b/references/agents/Character_DNA_Extractor_v3.5.md
@@ -25,7 +25,7 @@ The definitive forensic visual analyst and identity synthesizer for the Grok Ima
 - Generate versioned, copy-paste-ready output files and handoff packets.
 - Maintain strict “extract only what is visible” rule — flag any inference clearly.
 - Seamlessly prepare new characters for immediate onboarding into full cinematic productions or ongoing sequences.
-- Handle recurring user aesthetics (Harley Quinn “Midnight Puddin’ Tease”, One Piece adult reimaginings, Colombian silver pigtails/hotwife, schoolgirl, succubus, etc.) with signature element highlighting when present.
+- Handle recurring **adult fictional** aesthetics with signature element highlighting when present. Refuse minor-coded tropes (including “schoolgirl,” loli/shota, aged-down). Intimate DNA requires `subject_kind=imaginary_adult` and **no** uploaded photos of real people.
 - Offer intelligent chaining suggestions tailored to cinematic studio workflows.
 
 ## Specialized Protocols

--- a/references/agents/NSFW_Quota_Orchestrator.md
+++ b/references/agents/NSFW_Quota_Orchestrator.md
@@ -5,7 +5,7 @@ You are the production scheduler for quota-efficient NSFW/erotic sessions on Sup
 
 ## Core Mandate
 1. **Plan batches** under Heavy daily soft cap (2,500 credits) with 15% retry reserve
-2. **Prioritize** hero frames → consistency anchors → key explicit moments → support → filler
+2. **Prioritize** hero frames → consistency anchors → key intimate (R-rated) moments → support → filler
 3. **Decide** `image_prompt` vs `image_to_video` vs `video_prompt` per shot before spending
 4. **Retry intelligently** when QA fails — never burn quota on blind regens
 5. **Report daily** — credits used vs quality scores for every NSFW session
@@ -15,7 +15,7 @@ You are the production scheduler for quota-efficient NSFW/erotic sessions on Sup
 |------|--------------|---------------|
 | `hero` | 25% | First — cover shots, primary deliverables |
 | `consistency_anchor` | 15% | Before any dependent video — lock identity |
-| `key_explicit` | 35% | After anchors pass QA ≥7 |
+| `key_intimate` | 35% | After anchors pass QA ≥7 (`key_explicit` is a deprecated alias) |
 | `support` | 15% | If budget remains after heroes + keys |
 | `filler` | 10% | Only when daily cap <50% used |
 
@@ -25,7 +25,7 @@ You are the production scheduler for quota-efficient NSFW/erotic sessions on Sup
 
 | Shot Tier | Image Model | Video Model |
 |-----------|-------------|-------------|
-| `hero`, `key_explicit`, `consistency_anchor` | `grok-imagine-image-quality` | `grok-imagine-video-1.5` |
+| `hero`, `key_intimate`, `consistency_anchor` | `grok-imagine-image-quality` | `grok-imagine-video-1.5` |
 | `support` | `grok-imagine-image` | `grok-imagine-video-1.5` |
 | `filler` | `grok-imagine-image` | `grok-imagine-video` |
 

--- a/references/agents/Quality_Assurance_Guardian_v3.5.md
+++ b/references/agents/Quality_Assurance_Guardian_v3.5.md
@@ -9,6 +9,7 @@ You are the final 16-point QA gatekeeper. You rigorously evaluate every generate
 - Consistency Drift Detection (visual + emotional + timeline)
 - Failure Pattern Learning (feeds back into Imagine Prompt Master negative prompts)
 - NSFW Artistic Standards Review (tasteful eroticism, emotional truth, consent tone)
+- **AUP legal lane** — fail closed on CSAM tropes, real-person intimate likeness, and pornographic-beyond-R (`tools/aup_gate.py`) before artistic scoring
 - v4.0 Personality: Strict but fair, highly observant, protective of quality, calm and constructive in feedback
 
 ## Key Responsibilities

--- a/scripts/generate_plugin_index.py
+++ b/scripts/generate_plugin_index.py
@@ -14,9 +14,18 @@ COMMANDS_ROOT = REPO_ROOT / "commands"
 PLUGIN_DIR = REPO_ROOT / ".grok-plugin"
 INDEX_PATH = PLUGIN_DIR / "plugin-index.json"
 MANIFEST_PATH = PLUGIN_DIR / "plugin.json"
+NSFW_MANIFEST_PATH = PLUGIN_DIR / "nsfw-plugin.json"
 MARKETPLACE_PATH = PLUGIN_DIR / "marketplace.json"
 
 MAX_DESCRIPTION_LEN = 120
+
+NSFW_SKILL_DIR_NAMES = {
+    "erosforge-nsfw-director",
+    "nsfw-quota-orchestrator",
+    "nsfw-sequence-extender",
+    "nsfw-chain-qa-protocol",
+}
+NSFW_COMMAND_NAMES = {"nsfw"}
 
 
 def parse_frontmatter(path: Path) -> dict[str, str]:
@@ -43,12 +52,26 @@ def clean(text: str) -> str:
     return text
 
 
-def discover_commands() -> list[dict[str, str]]:
+def _is_nsfw_skill(name: str) -> bool:
+    return name in NSFW_SKILL_DIR_NAMES
+
+
+def _is_nsfw_command(name: str) -> bool:
+    return name in NSFW_COMMAND_NAMES
+
+
+def _nsfw_plugin_name(name: str) -> bool:
+    return "nsfw" in (name or "").lower()
+
+
+def discover_commands(*, nsfw: bool = False) -> list[dict[str, str]]:
     if not COMMANDS_ROOT.is_dir():
         return []
     items: list[dict[str, str]] = []
     for path in sorted(COMMANDS_ROOT.glob("*.md")):
         if path.stem.startswith("_"):
+            continue
+        if _is_nsfw_command(path.stem) != nsfw:
             continue
         frontmatter = parse_frontmatter(path)
         items.append(
@@ -60,11 +83,13 @@ def discover_commands() -> list[dict[str, str]]:
     return items
 
 
-def discover_skills() -> list[dict[str, str]]:
+def discover_skills(*, nsfw: bool = False) -> list[dict[str, str]]:
     items: list[dict[str, str]] = []
     for skill_dir in sorted(SKILLS_ROOT.iterdir()):
         skill_md = skill_dir / "SKILL.md"
         if not skill_md.is_file():
+            continue
+        if _is_nsfw_skill(skill_dir.name) != nsfw:
             continue
         frontmatter = parse_frontmatter(skill_md)
         items.append(
@@ -76,21 +101,21 @@ def discover_skills() -> list[dict[str, str]]:
     return items
 
 
-def skill_paths() -> list[str]:
+def skill_paths(*, nsfw: bool = False) -> list[str]:
     return [
         f".grok/skills/{skill_dir.name}"
         for skill_dir in sorted(SKILLS_ROOT.iterdir())
-        if (skill_dir / "SKILL.md").is_file()
+        if (skill_dir / "SKILL.md").is_file() and _is_nsfw_skill(skill_dir.name) == nsfw
     ]
 
 
-def command_paths() -> list[str]:
+def command_paths(*, nsfw: bool = False) -> list[str]:
     if not COMMANDS_ROOT.is_dir():
         return []
     return [
         f"commands/{path.name}"
         for path in sorted(COMMANDS_ROOT.glob("*.md"))
-        if not path.stem.startswith("_")
+        if not path.stem.startswith("_") and _is_nsfw_command(path.stem) == nsfw
     ]
 
 
@@ -103,8 +128,8 @@ def load_plugin_manifest() -> dict:
 
 
 def write_plugin_manifest(manifest: dict) -> None:
-    manifest["skills"] = skill_paths()
-    commands = command_paths()
+    manifest["skills"] = skill_paths(nsfw=False)
+    commands = command_paths(nsfw=False)
     if commands:
         manifest["commands"] = commands
     elif "commands" in manifest:
@@ -112,18 +137,36 @@ def write_plugin_manifest(manifest: dict) -> None:
     MANIFEST_PATH.write_text(json.dumps(manifest, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
 
 
+def write_nsfw_plugin_manifest() -> None:
+    payload = {
+        "name": "grok-imagine-cinematic-studio-nsfw",
+        "version": load_plugin_manifest().get("version", "3.6.5"),
+        "description": (
+            "Optional 18+ R-rated fictional-adult add-on. Requires local AUP attestation. "
+            "Not affiliated with xAI or SpaceXAI. Policy: https://x.ai/legal/acceptable-use-policy"
+        ),
+        "aup_required": True,
+        "aup_url": "https://x.ai/legal/acceptable-use-policy",
+        "license": "MIT",
+        "skills": skill_paths(nsfw=True),
+        "commands": command_paths(nsfw=True),
+    }
+    NSFW_MANIFEST_PATH.write_text(json.dumps(payload, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+
 def build_index() -> dict:
     marketplace = json.loads(MARKETPLACE_PATH.read_text(encoding="utf-8"))
     plugins = marketplace.get("plugins", [])
     records: dict[str, dict] = {}
-    skills = discover_skills()
-    commands = discover_commands()
     for entry in plugins:
         if not isinstance(entry, dict):
             continue
         plugin_name = entry.get("name")
         if not isinstance(plugin_name, str) or not plugin_name:
             continue
+        nsfw = _nsfw_plugin_name(plugin_name)
+        skills = discover_skills(nsfw=nsfw)
+        commands = discover_commands(nsfw=nsfw)
         components: dict[str, list] = {"skills": skills}
         if commands:
             components["commands"] = commands
@@ -138,6 +181,7 @@ def main() -> int:
 
     manifest = load_plugin_manifest()
     write_plugin_manifest(manifest)
+    write_nsfw_plugin_manifest()
 
     index = build_index()
     rendered = json.dumps(index, indent=2, ensure_ascii=False) + "\n"
@@ -156,7 +200,10 @@ def main() -> int:
     INDEX_PATH.write_text(rendered, encoding="utf-8")
     skills = discover_skills()
     commands = discover_commands()
-    print(f"Wrote {INDEX_PATH} ({len(skills)} skills, {len(commands)} commands)")
+    print(
+        f"Wrote {INDEX_PATH} ({len(skills)} SFW skills, {len(commands)} SFW commands); "
+        f"NSFW add-on → {NSFW_MANIFEST_PATH}"
+    )
     return 0
 
 

--- a/scripts/required_skills.manifest
+++ b/scripts/required_skills.manifest
@@ -12,7 +12,8 @@ character-dna-extractor
 continuity-consistency-guardian
 director-of-photography
 director-of-photography-v3-3
-erosforge-nsfw-director
+# Optional 18+ add-on (not in default plugin; requires nsfw attest)
+# erosforge-nsfw-director
 foley-sound-design-specialist
 i2i-cinematic-refiner
 i2i-refiner
@@ -21,9 +22,9 @@ key-art-poster-designer
 localization-subtitle-specialist
 mega-production-architect
 narrative-arc-pacing-strategist
-nsfw-quota-orchestrator
-nsfw-sequence-extender
-nsfw-chain-qa-protocol
+# nsfw-quota-orchestrator
+# nsfw-sequence-extender
+# nsfw-chain-qa-protocol
 performance-emotion-director
 post-production-color-grading-supervisor
 production-designer-set-decorator

--- a/tests/test_aup_gate.py
+++ b/tests/test_aup_gate.py
@@ -1,0 +1,354 @@
+"""Fail-closed SpaceXAI AUP gates — metadata/stub prompts only."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "tools"))
+
+from aup_gate import (  # noqa: E402
+    AUP_URL,
+    AUPGateError,
+    ATTESTATION_ENV,
+    attestation_is_valid,
+    gate_dna,
+    gate_imagine_prompt,
+    gate_nsfw_batch,
+    gate_nsfw_shot,
+    gate_text,
+    require_attestation,
+    scan_csam,
+    write_attestation,
+)
+
+
+def _attest_env() -> tuple[str, str]:
+    handle = tempfile.NamedTemporaryFile(prefix="aup-", suffix=".json", delete=False)
+    handle.close()
+    path = handle.name
+    os.environ[ATTESTATION_ENV] = path
+    write_attestation(
+        age_18_plus=True,
+        imaginary_adults_only=True,
+        not_a_real_person=True,
+        aup_acknowledged=True,
+        path=Path(path),
+    )
+    return path, ATTESTATION_ENV
+
+
+def _cleanup(path: str) -> None:
+    os.environ.pop(ATTESTATION_ENV, None)
+    try:
+        os.unlink(path)
+    except OSError:
+        pass
+
+
+def test_attestation_requires_all_flags() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        path = Path(tmp) / "attestation.json"
+        try:
+            write_attestation(
+                age_18_plus=True,
+                imaginary_adults_only=True,
+                not_a_real_person=False,
+                aup_acknowledged=True,
+                path=path,
+            )
+            raise AssertionError("expected AUPGateError")
+        except AUPGateError as exc:
+            assert "All four attestations" in str(exc)
+        assert not path.exists()
+
+
+def test_checkbox_is_not_attestation() -> None:
+    os.environ[ATTESTATION_ENV] = str(Path(__file__).resolve().parent / "missing-aup-attestation.json")
+    try:
+        require_attestation()
+        raise AssertionError("expected AUPGateError")
+    except AUPGateError as exc:
+        assert "nsfw attest" in str(exc)
+        assert AUP_URL in str(exc)
+    finally:
+        os.environ.pop(ATTESTATION_ENV, None)
+
+
+def test_valid_attestation_roundtrip() -> None:
+    path, _ = _attest_env()
+    try:
+        data = json.loads(Path(path).read_text())
+        assert attestation_is_valid(data)
+        assert require_attestation()["age_18_plus"] is True
+    finally:
+        _cleanup(path)
+
+
+def test_csam_keyword_refuse_uses_stubs_only() -> None:
+    assert scan_csam("loli aesthetic")
+    assert scan_csam("schoolgirl uniform")
+    assert scan_csam("aged down")
+    assert not scan_csam("childhood bedroom flashback")
+    try:
+        gate_text("underage character study")
+        raise AssertionError("expected AUPGateError")
+    except AUPGateError as exc:
+        assert "NCMEC" in str(exc)
+
+
+def test_explicit_beyond_r_refused_when_nsfw() -> None:
+    path, _ = _attest_env()
+    try:
+        try:
+            gate_text("creampie close-up", nsfw=True)
+            raise AssertionError("expected AUPGateError")
+        except AUPGateError as exc:
+            assert "R-rated" in str(exc)
+        gate_text("tender implied intimacy, clothing on, R-rated", nsfw=True)
+    finally:
+        _cleanup(path)
+
+
+def test_hidden_camera_refused() -> None:
+    path, _ = _attest_env()
+    try:
+        try:
+            gate_text("hidden camera through window", nsfw=True)
+            raise AssertionError("expected AUPGateError")
+        except AUPGateError as exc:
+            assert "hidden-camera" in str(exc) or "nudify" in str(exc)
+    finally:
+        _cleanup(path)
+
+
+def test_nsfw_shot_refuses_reference_image() -> None:
+    path, _ = _attest_env()
+    try:
+        try:
+            gate_nsfw_shot(
+                {
+                    "description": "candlelit embrace",
+                    "tier": "hero",
+                    "explicit_level": "moderate",
+                    "has_reference": True,
+                }
+            )
+            raise AssertionError("expected AUPGateError")
+        except AUPGateError as exc:
+            assert "reference" in str(exc).lower()
+    finally:
+        _cleanup(path)
+
+
+def test_nsfw_shot_refuses_explicit_level() -> None:
+    path, _ = _attest_env()
+    try:
+        try:
+            gate_nsfw_shot(
+                {
+                    "description": "slow reveal",
+                    "tier": "hero",
+                    "explicit_level": "explicit",
+                }
+            )
+            raise AssertionError("expected AUPGateError")
+        except AUPGateError as exc:
+            assert "suggestive or moderate" in str(exc)
+    finally:
+        _cleanup(path)
+
+
+def test_nsfw_batch_allows_r_rated_imaginary() -> None:
+    path, _ = _attest_env()
+    try:
+        gate_nsfw_batch(
+            "Hero Session",
+            [{"description": "Cover frame candlelit embrace", "tier": "hero", "explicit_level": "suggestive"}],
+        )
+    finally:
+        _cleanup(path)
+
+
+def test_dna_intimate_requires_imaginary_adult_no_photo() -> None:
+    path, _ = _attest_env()
+    try:
+        try:
+            gate_dna(
+                {
+                    "character_name": "Mara",
+                    "core_identity": "adult fictional lead",
+                    "facial_dna": "sharp cheekbones",
+                    "nsfw_notes": "implied intimacy continuity",
+                    "subject_kind": "unspecified",
+                    "reference_image_ids": [],
+                }
+            )
+            raise AssertionError("expected AUPGateError")
+        except AUPGateError as exc:
+            assert "imaginary_adult" in str(exc)
+
+        try:
+            gate_dna(
+                {
+                    "character_name": "Mara",
+                    "core_identity": "adult fictional lead",
+                    "facial_dna": "sharp cheekbones",
+                    "nsfw_notes": "implied intimacy continuity",
+                    "subject_kind": "imaginary_adult",
+                    "reference_image_ids": ["img_123"],
+                }
+            )
+            raise AssertionError("expected AUPGateError")
+        except AUPGateError as exc:
+            lowered = str(exc).lower()
+            assert "photos" in lowered or "reference" in lowered
+
+        gate_dna(
+            {
+                "character_name": "Mara",
+                "core_identity": "adult fictional lead",
+                "facial_dna": "sharp cheekbones",
+                "nsfw_notes": "implied intimacy continuity",
+                "subject_kind": "imaginary_adult",
+                "reference_image_ids": [],
+            }
+        )
+    finally:
+        _cleanup(path)
+
+
+def test_sfw_dna_with_refs_still_allowed() -> None:
+    gate_dna(
+        {
+            "character_name": "Elena Voss",
+            "core_identity": "detective",
+            "facial_dna": "grey eyes",
+            "subject_kind": "unspecified",
+            "reference_image_ids": ["hero_still"],
+        }
+    )
+
+
+def test_imagine_edit_intimate_plus_source_image_refused() -> None:
+    path, _ = _attest_env()
+    try:
+        try:
+            gate_imagine_prompt(
+                "intimate cinematic close-up",
+                nsfw=True,
+                has_reference_image=True,
+            )
+            raise AssertionError("expected AUPGateError")
+        except AUPGateError as exc:
+            lowered = str(exc).lower()
+            assert "nudify" in lowered or "source still" in lowered
+    finally:
+        _cleanup(path)
+
+
+def test_403_429_not_in_failover() -> None:
+    from imagine_regions import FAILOVER_STATUS_CODES
+
+    assert 403 not in FAILOVER_STATUS_CODES
+    assert 429 not in FAILOVER_STATUS_CODES
+    assert 500 in FAILOVER_STATUS_CODES
+
+
+def test_execute_nsfw_shot_requires_attestation() -> None:
+    from unittest.mock import patch
+
+    from aup_gate import AUPGateError
+    from batch_runner import execute_nsfw_shot
+    from nsfw_orchestrator import plan_batch
+
+    os.environ[ATTESTATION_ENV] = "/nonexistent-aup-attestation.json"
+    try:
+        batch = plan_batch(
+            "Gate Test",
+            [{"tier": "hero", "description": "Cover frame candlelit embrace"}],
+            budget_credits=200,
+        )
+        shot_id = batch["shots"][0]["shot_id"]
+        noop = lambda *args, **kwargs: None
+        with patch("quota_optimizer.save_project_state", noop), patch(
+            "project_state.save_project_state", noop
+        ):
+            try:
+                execute_nsfw_shot(batch, shot_id, dry_run=True, record_quota=False)
+                raise AssertionError("expected AUPGateError")
+            except AUPGateError as exc:
+                assert "attest" in str(exc)
+    finally:
+        os.environ.pop(ATTESTATION_ENV, None)
+
+
+def test_403_does_not_failover_regions() -> None:
+    import io
+    import urllib.error
+    from unittest.mock import patch
+
+    from imagine_client import ImagineAPIError, generate_image
+
+    calls: list[str] = []
+
+    def boom(method, path, *, payload, headers, timeout):
+        calls.append(str((payload or {}).get("region", "")))
+        raise urllib.error.HTTPError(
+            "https://api.x.ai/v1/images/generations",
+            403,
+            "Forbidden",
+            hdrs=None,
+            fp=io.BytesIO(b'{"error":"denied"}'),
+        )
+
+    with patch.dict(os.environ, {"XAI_API_KEY": "xai-test-placeholder-not-a-real-key"}):
+        with patch("imagine_client._request_single", boom):
+            try:
+                generate_image("Test cinematic still", dry_run=False)
+                raise AssertionError("expected ImagineAPIError")
+            except ImagineAPIError as exc:
+                assert exc.status == 403
+                assert "fail closed" in str(exc)
+    assert len(calls) == 1
+
+
+def test_default_plugin_excludes_nsfw() -> None:
+    plugin = json.loads((ROOT / ".grok-plugin" / "plugin.json").read_text())
+    skills = " ".join(plugin.get("skills", []))
+    commands = " ".join(plugin.get("commands", []))
+    assert "erosforge-nsfw-director" not in skills
+    assert "nsfw-quota-orchestrator" not in skills
+    assert "nsfw-sequence-extender" not in skills
+    assert "nsfw-chain-qa-protocol" not in skills
+    assert "commands/nsfw.md" not in commands
+    marketplace = json.loads((ROOT / ".grok-plugin" / "marketplace.json").read_text())
+    assert "Official Grok plugin marketplace" not in marketplace.get("description", "")
+    nsfw_plugin = json.loads((ROOT / ".grok-plugin" / "nsfw-plugin.json").read_text())
+    nsfw_skills = " ".join(nsfw_plugin.get("skills", []))
+    assert "erosforge-nsfw-director" in nsfw_skills
+    assert nsfw_plugin.get("aup_required") is True
+
+
+if __name__ == "__main__":
+    test_attestation_requires_all_flags()
+    test_checkbox_is_not_attestation()
+    test_valid_attestation_roundtrip()
+    test_csam_keyword_refuse_uses_stubs_only()
+    test_explicit_beyond_r_refused_when_nsfw()
+    test_hidden_camera_refused()
+    test_nsfw_shot_refuses_reference_image()
+    test_nsfw_shot_refuses_explicit_level()
+    test_nsfw_batch_allows_r_rated_imaginary()
+    test_dna_intimate_requires_imaginary_adult_no_photo()
+    test_sfw_dna_with_refs_still_allowed()
+    test_imagine_edit_intimate_plus_source_image_refused()
+    test_403_429_not_in_failover()
+    test_execute_nsfw_shot_requires_attestation()
+    test_403_does_not_failover_regions()
+    test_default_plugin_excludes_nsfw()
+    print("All AUP gate tests passed")

--- a/tests/test_nsfw_asset_models.py
+++ b/tests/test_nsfw_asset_models.py
@@ -30,11 +30,18 @@ def test_hero_tier_routes_image_quality() -> None:
     assert shot["image_quality"] is True
 
 
-def test_key_explicit_matches_hero_routing() -> None:
-    shot = apply_reference_curator_models({"tier": "key_explicit", "description": "Beat"})
-    mapping = NSFW_ASSET_MODEL_MAP["key_explicit"]
+def test_key_intimate_matches_hero_routing() -> None:
+    shot = apply_reference_curator_models({"tier": "key_intimate", "description": "Beat"})
+    mapping = NSFW_ASSET_MODEL_MAP["key_intimate"]
+    assert shot["tier"] == "key_intimate"
     assert shot["image_model"] == mapping["image_model"]
     assert shot["video_model"] == mapping["video_model"]
+
+
+def test_key_explicit_alias_normalizes() -> None:
+    shot = apply_reference_curator_models({"tier": "key_explicit", "description": "Beat"})
+    assert shot["tier"] == "key_intimate"
+    assert shot["image_model"] == NSFW_ASSET_MODEL_MAP["key_intimate"]["image_model"]
 
 
 def test_filler_uses_draft_video() -> None:
@@ -46,9 +53,21 @@ def test_filler_uses_draft_video() -> None:
 
 def test_parse_inline_shot_three_part() -> None:
     parsed = parse_inline_shot("key_explicit:high:Primary beat")
-    assert parsed["tier"] == "key_explicit"
+    assert parsed["tier"] == "key_intimate"
     assert parsed["motion_complexity"] == "high"
     assert parsed["description"] == "Primary beat"
+
+
+def test_canonical_explicit_level_refuses_full_explicit() -> None:
+    from nsfw_config import canonical_explicit_level
+
+    assert canonical_explicit_level("suggestive") == "suggestive"
+    assert canonical_explicit_level("") == "moderate"
+    try:
+        canonical_explicit_level("explicit")
+        raise AssertionError("expected ValueError")
+    except ValueError as exc:
+        assert "R-rated" in str(exc)
 
 
 def test_create_shot_includes_models() -> None:
@@ -63,11 +82,11 @@ def test_build_shot_context_canonical_fields() -> None:
         tier="key_explicit",
         motion="high",
         has_ref=True,
-        explicit="explicit",
+        explicit="moderate",
         duration=12.0,
     )
     assert shot["shot_id"] == "shot_001"
-    assert shot["tier"] == "key_explicit"
+    assert shot["tier"] == "key_intimate"
     assert shot["motion_complexity"] == "high"
     assert shot["has_reference"] is True
     assert shot["consistency_required"] is True
@@ -87,13 +106,13 @@ def test_decide_generation_mode_anchor_without_ref() -> None:
 
 
 def test_decide_generation_mode_i2v_with_ref_and_motion() -> None:
-    shot = build_shot_context("shot_002", tier="key_explicit", motion="high", has_ref=True)
+    shot = build_shot_context("shot_002", tier="key_intimate", motion="high", has_ref=True)
     decision = decide_generation_mode(shot, risk_level="low")
     assert decision["mode"] == "image_to_video"
 
 
 def test_decide_budget_override() -> None:
-    shot = build_shot_context("shot_003", tier="key_explicit", motion="high", has_ref=True)
+    shot = build_shot_context("shot_003", tier="key_intimate", motion="high", has_ref=True)
     decision = decide_generation_mode(shot, budget_remaining=50, risk_level="low")
     assert decision["mode"] == "image_prompt"
     assert any("Budget remaining" in r for r in decision["reasons"])
@@ -119,9 +138,11 @@ def test_plan_batch_applies_routing() -> None:
 
 if __name__ == "__main__":
     test_hero_tier_routes_image_quality()
-    test_key_explicit_matches_hero_routing()
+    test_key_intimate_matches_hero_routing()
+    test_key_explicit_alias_normalizes()
     test_filler_uses_draft_video()
     test_parse_inline_shot_three_part()
+    test_canonical_explicit_level_refuses_full_explicit()
     test_create_shot_includes_models()
     test_build_shot_context_canonical_fields()
     test_shot_tier_options_follow_priority()

--- a/tests/test_sequence_runner.py
+++ b/tests/test_sequence_runner.py
@@ -40,5 +40,8 @@ def test_sequence_run_dry_run(tmp_path) -> None:
 
 
 if __name__ == "__main__":
-    test_sequence_run_dry_run(Path("/tmp"))
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as tmp:
+        test_sequence_run_dry_run(Path(tmp))
     print("Sequence runner test passed")

--- a/tools/aup_gate.py
+++ b/tools/aup_gate.py
@@ -1,0 +1,352 @@
+#!/usr/bin/env python3
+"""
+SpaceXAI AUP fail-closed gates for Grok Imagine Cinematic Studio.
+
+Policy: https://x.ai/legal/acceptable-use-policy (effective 14 Aug 2026)
+
+Allowed intimate work: limited R-rated fictional adult material of
+imaginary adults, for 18+ operators who attested and enabled NSFW on
+their xAI account.
+
+Blocked: CSAM / minor-coded tropes, real-person undress/nudify,
+pornographic depictions beyond R-rated, hidden-camera NCII patterns.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
+from studio_paths import STUDIO_ROOT
+
+AUP_URL = "https://x.ai/legal/acceptable-use-policy"
+ATTESTATION_SCHEMA = "1.0"
+ATTESTATION_ENV = "GROK_STUDIO_AUP_ATTESTATION"
+DEFAULT_ATTESTATION_NAME = ".aup_attestation.json"
+
+REQUIRED_ATTESTATION_FLAGS = (
+    "age_18_plus",
+    "imaginary_adults_only",
+    "not_a_real_person",
+    "aup_acknowledged",
+)
+
+SUBJECT_KIND_IMAGINARY_ADULT = "imaginary_adult"
+ALLOWED_SUBJECT_KINDS = ("unspecified", "imaginary_adult", "real_person")
+R_RATED_EXPLICIT_LEVELS = frozenset({"suggestive", "moderate", ""})
+
+# Stub keyword refusals only — tests must not include illegal fixtures.
+_CSAM_PATTERNS: tuple[re.Pattern[str], ...] = tuple(
+    re.compile(p, re.IGNORECASE)
+    for p in (
+        r"\bloli(?:ta|con)?\b",
+        r"\bshota\b",
+        r"\bcsam\b",
+        r"\bchild\s*porn",
+        r"\bunderage\b",
+        r"\bpre[- ]?teen\b",
+        r"\baged[- ]?down\b",
+        r"\bschoolgirl\b",
+        r"\bunder[- ]?18\b",
+    )
+)
+
+_EXPLICIT_BEYOND_R_PATTERNS: tuple[re.Pattern[str], ...] = tuple(
+    re.compile(p, re.IGNORECASE)
+    for p in (
+        r"\bcreampie\b",
+        r"\bahegao\b",
+        r"\bpenetration\b",
+        r"\bgenitals?\b",
+        r"\bsemen\b",
+        r"\bcumshot\b",
+        r"\bexplicit porn",
+        r"\bhero explicit beat\b",
+    )
+)
+
+_NCII_PATTERNS: tuple[re.Pattern[str], ...] = tuple(
+    re.compile(p, re.IGNORECASE)
+    for p in (
+        r"\bhidden camera\b",
+        r"\bnudif(?:y|ying|ication)\b",
+        r"\bdeepfake\b",
+        r"\bundress(?:ing)? (?:her|him|them|this person)\b",
+    )
+)
+
+_INTIMATE_HINT = re.compile(
+    r"\b(nsfw|erotic|nude|nudity|explicit|erosforge)\b",
+    re.IGNORECASE,
+)
+
+
+class AUPGateError(ValueError):
+    """Raised when a request would violate SpaceXAI AUP."""
+
+
+def attestation_path() -> Path:
+    override = os.getenv(ATTESTATION_ENV, "").strip()
+    if override:
+        return Path(override)
+    return STUDIO_ROOT / DEFAULT_ATTESTATION_NAME
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def load_attestation(path: Path | None = None) -> dict[str, Any] | None:
+    target = path or attestation_path()
+    if not target.is_file():
+        return None
+    try:
+        data = json.loads(target.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def attestation_is_valid(data: dict[str, Any] | None) -> bool:
+    if not data:
+        return False
+    return all(data.get(flag) is True for flag in REQUIRED_ATTESTATION_FLAGS)
+
+
+def write_attestation(
+    *,
+    age_18_plus: bool,
+    imaginary_adults_only: bool,
+    not_a_real_person: bool,
+    aup_acknowledged: bool,
+    path: Path | None = None,
+) -> dict[str, Any]:
+    if not all((age_18_plus, imaginary_adults_only, not_a_real_person, aup_acknowledged)):
+        raise AUPGateError(
+            "All four attestations are required: 18+, imaginary adults only, "
+            f"not a real person, and AUP acknowledgment ({AUP_URL})."
+        )
+    payload = {
+        "schema_version": ATTESTATION_SCHEMA,
+        "age_18_plus": True,
+        "imaginary_adults_only": True,
+        "not_a_real_person": True,
+        "aup_acknowledged": True,
+        "aup_url": AUP_URL,
+        "attested_at": _now_iso(),
+    }
+    target = path or attestation_path()
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    try:
+        os.chmod(target, 0o600)
+    except OSError:
+        pass
+    return payload
+
+
+def require_attestation(path: Path | None = None) -> dict[str, Any]:
+    data = load_attestation(path)
+    if not attestation_is_valid(data):
+        raise AUPGateError(
+            "NSFW / intimate work requires a local 18+ AUP attestation. "
+            "Run: python tools/cinematic_studio_cli.py nsfw attest "
+            "--i-am-18 --imaginary-adults --not-a-real-person --acknowledge-aup "
+            f"(policy: {AUP_URL})"
+        )
+    assert data is not None
+    return data
+
+
+def _collect_matches(text: str, patterns: Iterable[re.Pattern[str]]) -> list[str]:
+    found: list[str] = []
+    for pattern in patterns:
+        match = pattern.search(text)
+        if match:
+            found.append(match.group(0))
+    return found
+
+
+def scan_csam(text: str) -> list[str]:
+    return _collect_matches(text or "", _CSAM_PATTERNS)
+
+
+def scan_explicit_beyond_r(text: str) -> list[str]:
+    return _collect_matches(text or "", _EXPLICIT_BEYOND_R_PATTERNS)
+
+
+def scan_ncii(text: str) -> list[str]:
+    return _collect_matches(text or "", _NCII_PATTERNS)
+
+
+def is_intimate_text(text: str) -> bool:
+    return bool(_INTIMATE_HINT.search(text or ""))
+
+
+def _join_fields(values: Iterable[Any]) -> str:
+    parts: list[str] = []
+    for value in values:
+        if value is None:
+            continue
+        if isinstance(value, (list, tuple)):
+            parts.extend(str(item) for item in value if item)
+        else:
+            text = str(value).strip()
+            if text:
+                parts.append(text)
+    return "\n".join(parts)
+
+
+def gate_text(text: str, *, nsfw: bool = False) -> None:
+    """Fail closed on CSAM always; on porn/NCII tropes when nsfw/intimate."""
+    blob = text or ""
+    csam = scan_csam(blob)
+    if csam:
+        raise AUPGateError(
+            "Blocked: minor-coded or CSAM-adjacent language is forbidden "
+            f"({', '.join(csam)}). SpaceXAI reports CSAM to NCMEC."
+        )
+    intimate = nsfw or is_intimate_text(blob)
+    if not intimate:
+        return
+    beyond_r = scan_explicit_beyond_r(blob)
+    if beyond_r:
+        raise AUPGateError(
+            "Blocked: pornographic / NC-17 depiction exceeds limited R-rated "
+            f"fictional adult material ({', '.join(beyond_r)}). Policy: {AUP_URL}"
+        )
+    ncii = scan_ncii(blob)
+    if ncii:
+        raise AUPGateError(
+            "Blocked: non-consensual / hidden-camera / nudify language "
+            f"({', '.join(ncii)}). Policy: {AUP_URL}"
+        )
+
+
+def _shot_blob(shot: dict[str, Any], extra: str = "") -> str:
+    return _join_fields(
+        [
+            shot.get("description"),
+            shot.get("tier"),
+            shot.get("explicit_level"),
+            shot.get("explicit"),
+            shot.get("prompt"),
+            shot.get("recommended_mode"),
+            extra,
+        ]
+    )
+
+
+def _shot_has_reference(shot: dict[str, Any]) -> bool:
+    if shot.get("has_reference") or shot.get("has_ref"):
+        return True
+    if shot.get("reference_image_id") or shot.get("reference_image_url"):
+        return True
+    refs = shot.get("reference_image_ids") or []
+    return bool(refs)
+
+
+def _explicit_level(shot: dict[str, Any]) -> str:
+    raw = shot.get("explicit_level") or shot.get("explicit") or ""
+    return str(raw).strip().lower()
+
+
+def gate_nsfw_shot(shot: dict[str, Any], *, extra_prompt: str = "") -> None:
+    require_attestation()
+    blob = _shot_blob(shot, extra_prompt)
+    gate_text(blob, nsfw=True)
+    level = _explicit_level(shot)
+    if level and level not in R_RATED_EXPLICIT_LEVELS:
+        raise AUPGateError(
+            "Blocked: explicit_level must be suggestive or moderate (R-rated). "
+            f"Got {level!r}. Full explicit is not allowed on SpaceXAI Imagine."
+        )
+    if _shot_has_reference(shot):
+        raise AUPGateError(
+            "Blocked: reference images cannot be used on the NSFW / intimate "
+            "path (real-person undress / publicity risk). Use imaginary-adult "
+            f"text DNA only. Policy: {AUP_URL}"
+        )
+
+
+def gate_nsfw_batch(title: str, shots: Iterable[dict[str, Any]]) -> None:
+    require_attestation()
+    gate_text(title or "", nsfw=True)
+    for shot in shots:
+        gate_nsfw_shot(shot)
+
+
+def gate_imagine_prompt(
+    prompt: str,
+    *,
+    nsfw: bool = False,
+    has_reference_image: bool = False,
+) -> None:
+    blob = prompt or ""
+    intimate = nsfw or is_intimate_text(blob)
+    if intimate:
+        require_attestation()
+    gate_text(blob, nsfw=intimate)
+    if intimate and has_reference_image:
+        raise AUPGateError(
+            "Blocked: image-to-image / i2v from a source still is not allowed "
+            "for intimate prompts (real-person nudify risk)."
+        )
+
+
+def _dna_is_intimate(dna: dict[str, Any]) -> bool:
+    notes = str(dna.get("nsfw_notes") or "")
+    if notes.strip():
+        return True
+    return is_intimate_text(
+        _join_fields(
+            [
+                dna.get("core_identity"),
+                dna.get("clothing_style"),
+                dna.get("nsfw_notes"),
+                dna.get("character_name"),
+            ]
+        )
+    )
+
+
+def _dna_has_reference(dna: dict[str, Any]) -> bool:
+    refs = dna.get("reference_image_ids") or []
+    if refs:
+        return True
+    source = str(dna.get("source") or "").lower()
+    return "upload" in source or "image" in source or "photo" in source
+
+
+def gate_dna(dna: dict[str, Any]) -> None:
+    blob = _join_fields(
+        [
+            dna.get("character_name"),
+            dna.get("core_identity"),
+            dna.get("facial_dna"),
+            dna.get("nsfw_notes"),
+            dna.get("subject_kind"),
+            dna.get("key_consistency_anchors"),
+        ]
+    )
+    gate_text(blob, nsfw=_dna_is_intimate(dna))
+    kind = str(dna.get("subject_kind") or "unspecified").strip().lower()
+    if kind and kind not in ALLOWED_SUBJECT_KINDS:
+        raise AUPGateError(f"Unknown subject_kind: {kind!r}")
+    if not _dna_is_intimate(dna):
+        return
+    require_attestation()
+    if kind != SUBJECT_KIND_IMAGINARY_ADULT:
+        raise AUPGateError(
+            "Intimate DNA requires subject_kind=imaginary_adult "
+            "(fictional adult, not a real person or lookalike)."
+        )
+    if _dna_has_reference(dna):
+        raise AUPGateError(
+            "Blocked: cannot lock uploaded / referenced photos into intimate "
+            "DNA (undress / right-of-publicity). Use text-only imaginary adults."
+        )

--- a/tools/batch_runner.py
+++ b/tools/batch_runner.py
@@ -9,6 +9,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
 
+from aup_gate import gate_imagine_prompt, gate_nsfw_shot
 from imagine_bridge import build_bridge_packet, bridge_to_markdown
 from imagine_client import (
     ImagineAPIError,
@@ -75,6 +76,9 @@ def execute_shot(
     if not shot:
         raise ValueError(f"Shot not found: {shot_id}")
 
+    if pipeline.name == "nsfw":
+        gate_nsfw_shot(shot, extra_prompt=prompt_override or "")
+
     if shot.get("status") not in ("scheduled", "pending", "qa_fail", "qa_pass"):
         if shot.get("quality_pass_status") == "quality_pass_pending":
             pass
@@ -90,6 +94,11 @@ def execute_shot(
     prompt = _build_shot_prompt(shot, override=prompt_override, prefix=pipeline.prompt_prefix)
     use_dry = is_dry_run() if dry_run is None else dry_run
     ref_url = _resolve_reference_url(shot)
+    gate_imagine_prompt(
+        prompt,
+        nsfw=pipeline.name == "nsfw",
+        has_reference_image=bool(ref_url),
+    )
 
     job_type = "video"
     img_model = shot.get("image_model", "grok-imagine-image")

--- a/tools/character_dna.py
+++ b/tools/character_dna.py
@@ -15,6 +15,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from aup_gate import gate_dna
 from models import build_video_pipeline_spec
 from project_state import load_project_state, save_project_state
 from studio_paths import CHARACTERS_DIR
@@ -49,6 +50,7 @@ def create_dna_scaffold(
     reference_image_ids: list[str] | None = None,
     nsfw_notes: str | None = None,
     source: str = "manual",
+    subject_kind: str = "unspecified",
 ) -> dict[str, Any]:
     """Create a v1.0 Character DNA profile scaffold."""
     anchors = key_anchors or []
@@ -74,6 +76,7 @@ def create_dna_scaffold(
         },
         "cinematic_viability_score": None,
         "nsfw_notes": nsfw_notes,
+        "subject_kind": subject_kind or "unspecified",
         "identity_lock_status": "pending",
         "studio_agent_version": STUDIO_AGENT_VERSION,
         "video_pipeline_spec": build_video_pipeline_spec(),
@@ -249,6 +252,7 @@ def character_dir(slug: str) -> Path:
 
 def save_character_dna(dna: dict[str, Any], *, characters_root: Path | None = None) -> tuple[Path, Path]:
     """Persist dna.json and dna.md under characters/{slug}/."""
+    gate_dna(dna)
     root = characters_root or CHARACTERS_DIR
     out_dir = root / dna["slug"]
     out_dir.mkdir(parents=True, exist_ok=True)
@@ -296,6 +300,7 @@ def lock_to_identity_bank(
     if state is None:
         state = load_project_state(state_file)
 
+    gate_dna(dna)
     prompts = build_prompt_blocks(dna)
     handoff = build_handoff_packet(dna)
     name = dna["character_name"]
@@ -367,6 +372,7 @@ def inject_into_prompt(
         raise FileNotFoundError(f"No DNA profile found for: {character_name}")
 
     dna = load_character_dna(dna_path)
+    gate_dna(dna)
     blocks = build_prompt_blocks(dna)
     injection = blocks[mode]
     return f"{injection}\n\n---\n\n{base_prompt.strip()}"

--- a/tools/cli/dna_commands.py
+++ b/tools/cli/dna_commands.py
@@ -38,6 +38,11 @@ def register(app: typer.Typer) -> None:
         emotion: str = typer.Option("", "--emotion", help="Emotional baseline"),
         motion: str = typer.Option("", "--motion", help="Motion DNA for video"),
         anchor: list[str] = typer.Option(None, "--anchor", help="Key consistency anchor (repeatable)"),
+        subject_kind: str = typer.Option(
+            "unspecified",
+            "--subject-kind",
+            help="unspecified | imaginary_adult | real_person (intimate DNA requires imaginary_adult)",
+        ),
         output: str = typer.Option(None, "--output", "-o", help="Output dna.json path"),
     ):
         """Create a new Character DNA profile scaffold."""
@@ -52,6 +57,7 @@ def register(app: typer.Typer) -> None:
             motion_dna=motion,
             key_anchors=anchor or [],
             source="cli-init",
+            subject_kind=subject_kind,
         )
         if output:
             out_path = Path(output)
@@ -71,7 +77,11 @@ def register(app: typer.Typer) -> None:
     ):
         """Validate and save a Character DNA profile to characters/{slug}/."""
         dna = load_character_dna(file)
-        json_path, md_path = save_character_dna(dna)
+        try:
+            json_path, md_path = save_character_dna(dna)
+        except ValueError as exc:
+            console.print(f"[red]{exc}[/red]")
+            raise typer.Exit(1) from exc
         console.print(f"[green]✅ DNA saved:[/green] {json_path}")
         console.print(f"[dim]Markdown:[/dim] {md_path}")
 
@@ -128,7 +138,11 @@ def register(app: typer.Typer) -> None:
     ):
         """Import DNA into Identity Lock memory bank."""
         dna = require_character_dna(name)
-        state = lock_to_identity_bank(dna)
+        try:
+            state = lock_to_identity_bank(dna)
+        except ValueError as exc:
+            console.print(f"[red]{exc}[/red]")
+            raise typer.Exit(1) from exc
         console.print(f"[green]✅ Identity Lock engaged for[/green] {dna['character_name']}")
         console.print(f"[dim]Status: locked | Drift threshold: 2.5 | Anchors: {len(dna.get('key_consistency_anchors', []))}[/dim]")
         console.print(f"[dim]Identity Lock entries: {len(state.get('identity_lock', {}))}[/dim]")

--- a/tools/cli/nsfw_commands.py
+++ b/tools/cli/nsfw_commands.py
@@ -12,6 +12,7 @@ from rich.markdown import Markdown
 from rich.panel import Panel
 from rich.table import Table
 
+from aup_gate import AUP_URL, AUPGateError, gate_nsfw_batch, require_attestation, write_attestation
 from models import DEFAULT_IMAGINE_VIDEO_MODEL
 from batch_runner import execute_nsfw_shot
 from quality_pass_scheduler import apply_quality_pass_promotion, get_pending_quality_passes
@@ -48,7 +49,41 @@ from cli.helpers import require_clip, require_sequence
 from cli.shared import AGENTS_DIR, STUDIO_ROOT, console
 
 
+def _require_aup() -> None:
+    try:
+        require_attestation()
+    except AUPGateError as exc:
+        console.print(f"[red]{exc}[/red]")
+        raise typer.Exit(1) from exc
+
+
 def register(nsfw_app: typer.Typer, extend_app: typer.Typer) -> None:
+    @nsfw_app.command("attest")
+    def nsfw_attest(
+        i_am_18: bool = typer.Option(False, "--i-am-18", help="Operator is 18 or older"),
+        imaginary_adults: bool = typer.Option(False, "--imaginary-adults", help="Subjects are fictional adults"),
+        not_a_real_person: bool = typer.Option(False, "--not-a-real-person", help="No real-person likenesses"),
+        acknowledge_aup: bool = typer.Option(False, "--acknowledge-aup", help=f"Acknowledge {AUP_URL}"),
+    ):
+        """Write a local 18+ SpaceXAI AUP attestation (required before NSFW plan/run)."""
+        try:
+            payload = write_attestation(
+                age_18_plus=i_am_18,
+                imaginary_adults_only=imaginary_adults,
+                not_a_real_person=not_a_real_person,
+                aup_acknowledged=acknowledge_aup,
+            )
+        except AUPGateError as exc:
+            console.print(f"[red]{exc}[/red]")
+            raise typer.Exit(1) from exc
+        console.print(Panel(
+            f"Attested at {payload['attested_at']}\n"
+            f"Policy: {AUP_URL}\n"
+            "Limited R-rated fictional adult material of imaginary adults only.",
+            title="AUP attestation saved",
+            border_style="green",
+        ))
+
     @nsfw_app.command("plan")
     def nsfw_plan(
         title: str = typer.Argument(..., help="Batch title"),
@@ -61,6 +96,7 @@ def register(nsfw_app: typer.Typer, extend_app: typer.Typer) -> None:
         output: str = typer.Option(None, "--output", "-o", help="Save markdown plan"),
     ):
         """Plan a prioritized NSFW batch under Heavy subscription limits."""
+        _require_aup()
         shots: list[dict] = []
         if file:
             shots = json.loads(Path(file).read_text())
@@ -70,6 +106,12 @@ def register(nsfw_app: typer.Typer, extend_app: typer.Typer) -> None:
         if not shots:
             console.print("[red]Provide --file or at least one --shot[/red]")
             raise typer.Exit(1)
+
+        try:
+            gate_nsfw_batch(title, shots)
+        except AUPGateError as exc:
+            console.print(f"[red]{exc}[/red]")
+            raise typer.Exit(1) from exc
 
         batch = plan_batch(title, shots, tier=tier, budget_credits=budget, fast_mode=fast_mode, two_pass=two_pass)
         path = save_batch(batch)
@@ -151,18 +193,24 @@ def register(nsfw_app: typer.Typer, extend_app: typer.Typer) -> None:
         shot_tier: str = typer.Option("support", "--tier", help="Shot tier"),
         motion: str = typer.Option("medium", "--motion", help="low / medium / high"),
         has_ref: bool = typer.Option(False, "--has-ref", help="Approved reference image exists"),
-        explicit: str = typer.Option("moderate", "--explicit", help="suggestive / moderate / explicit"),
+        explicit: str = typer.Option("moderate", "--explicit", help="suggestive / moderate (R-rated cap)"),
         duration: float = typer.Option(10.0, "--duration", "-d"),
     ):
         """Recommend image_prompt vs image_to_video vs video_prompt."""
-        shot = build_shot_context(
-            shot_id,
-            tier=shot_tier,
-            motion=motion,
-            has_ref=has_ref,
-            explicit=explicit,
-            duration=duration,
-        )
+        _require_aup()
+        try:
+            shot = build_shot_context(
+                shot_id,
+                tier=shot_tier,
+                motion=motion,
+                has_ref=has_ref,
+                explicit=explicit,
+                duration=duration,
+            )
+            gate_nsfw_shot(shot)
+        except (AUPGateError, ValueError) as exc:
+            console.print(f"[red]{exc}[/red]")
+            raise typer.Exit(1) from exc
         state = load_project_state()
         quota = state.get("quota", {})
         decision = decide_generation_mode(
@@ -186,9 +234,10 @@ def register(nsfw_app: typer.Typer, extend_app: typer.Typer) -> None:
         reason: str = typer.Option("physics_failure", "--reason", "-r", help="Failure reason key"),
         score: float = typer.Option(None, "--score", help="QA score received"),
         attempts: int = typer.Option(0, "--attempts", help="Prior attempt count"),
-        shot_tier: str = typer.Option("key_explicit", "--tier"),
+        shot_tier: str = typer.Option("key_intimate", "--tier"),
     ):
         """Suggest retry strategy after insufficient quality."""
+        _require_aup()
         shot = build_shot_context(
             shot_id,
             tier=shot_tier,
@@ -212,10 +261,11 @@ def register(nsfw_app: typer.Typer, extend_app: typer.Typer) -> None:
     def nsfw_run(
         batch_name: str = typer.Argument(..., help="Batch slug or ID"),
         shot_id: str = typer.Argument(..., help="Shot ID to execute"),
-        dry_run: bool = typer.Option(False, "--dry-run"),
+        dry_run: bool = typer.Option(True, "--dry-run/--live", help="Default dry-run. Pass --live only after AUP attestation."),
         prompt: str = typer.Option(None, "--prompt", "-p", help="Override generation prompt"),
     ):
         """Execute a batch shot via Imagine API (image / i2v / video)."""
+        _require_aup()
         from imagine_client import ImagineAPIError
 
         batch = load_batch(batch_name)
@@ -247,10 +297,11 @@ def register(nsfw_app: typer.Typer, extend_app: typer.Typer) -> None:
     def nsfw_session(
         batch_name: str = typer.Argument(..., help="Batch slug or ID"),
         count: int = typer.Option(3, "--count", "-n"),
-        dry_run: bool = typer.Option(False, "--dry-run"),
+        dry_run: bool = typer.Option(True, "--dry-run/--live", help="Default dry-run. Pass --live only after AUP attestation."),
         stop_on_fail: bool = typer.Option(True, "--stop-on-fail/--continue-on-fail"),
     ):
         """Run automated NSFW session — execute next priority shots."""
+        _require_aup()
         summary = run_batch_session(
             batch_name,
             pipeline="nsfw",
@@ -384,6 +435,7 @@ def register(nsfw_app: typer.Typer, extend_app: typer.Typer) -> None:
         output: str = typer.Option(None, "--output", "-o", help="Save markdown plan"),
     ):
         """Plan NSFW sensual extension with prompt chain and tension curve."""
+        _require_aup()
         if profile not in TENSION_PROFILES:
             console.print(f"[red]Unknown profile. Choose:[/red] {', '.join(TENSION_PROFILES)}")
             raise typer.Exit(1)
@@ -431,6 +483,7 @@ def register(nsfw_app: typer.Typer, extend_app: typer.Typer) -> None:
         output: str = typer.Option(None, "--output", "-o"),
     ):
         """Export ready-to-use Grok Imagine prompt chain."""
+        _require_aup()
         seq = require_sequence(sequence_name)
         chain = build_prompt_chain(seq)
         if not chain:

--- a/tools/imagine_client.py
+++ b/tools/imagine_client.py
@@ -16,8 +16,10 @@ import urllib.request
 import uuid
 from typing import Any
 
+from aup_gate import gate_imagine_prompt
 from imagine_regions import (
     FAILOVER_STATUS_CODES,
+    POLICY_FAIL_CLOSED_CODES,
     get_failover_chain,
     record_region_used,
     region_payload_fields,
@@ -116,6 +118,14 @@ def _request(
                 status=exc.code,
                 body=body,
             )
+            if exc.code in POLICY_FAIL_CLOSED_CODES:
+                last_error = ImagineAPIError(
+                    f"Imagine API {method.upper()} {path} failed ({exc.code}) region={reg} "
+                    "— fail closed (no region hop on 403/429 policy or rate-limit)",
+                    status=exc.code,
+                    body=body,
+                )
+                raise last_error from exc
             if exc.code in FAILOVER_STATUS_CODES and idx < len(regions) - 1:
                 record_region_used(reg, failed=True)
                 continue
@@ -143,6 +153,7 @@ def generate_image(
     dry_run: bool | None = None,
 ) -> dict[str, Any]:
     """Generate image(s) from a text prompt."""
+    gate_imagine_prompt(prompt, nsfw=False, has_reference_image=False)
     slug = resolve_image_model(model or DEFAULT_IMAGINE_IMAGE_MODEL)
     if _use_dry_run(dry_run):
         images = [
@@ -170,6 +181,7 @@ def edit_image(
     dry_run: bool | None = None,
 ) -> dict[str, Any]:
     """Edit a source image with a natural-language prompt."""
+    gate_imagine_prompt(prompt, nsfw=False, has_reference_image=True)
     slug = resolve_image_model(model or DEFAULT_IMAGINE_IMAGE_MODEL)
     if _use_dry_run(dry_run):
         return {
@@ -198,6 +210,7 @@ def submit_video_generation(
     dry_run: bool | None = None,
 ) -> dict[str, Any]:
     """Start async text-to-video or image-to-video generation."""
+    gate_imagine_prompt(prompt, nsfw=False, has_reference_image=bool(image_url))
     slug = resolve_video_model(model or DEFAULT_IMAGINE_VIDEO_MODEL)
     if _use_dry_run(dry_run):
         rid = _mock_request_id("vid")
@@ -232,6 +245,7 @@ def submit_video_extension(
     dry_run: bool | None = None,
 ) -> dict[str, Any]:
     """Start async video extension from an existing clip."""
+    gate_imagine_prompt(prompt, nsfw=False, has_reference_image=False)
     slug = resolve_video_model(model or "grok-imagine-video")
     if _use_dry_run(dry_run):
         rid = _mock_request_id("ext")

--- a/tools/imagine_regions.py
+++ b/tools/imagine_regions.py
@@ -19,7 +19,9 @@ IMAGINE_REGIONS: dict[str, dict[str, Any]] = {
 }
 
 DEFAULT_REGION = "us-east-1"
-FAILOVER_STATUS_CODES = frozenset({403, 429, 500, 502, 503, 504})
+# 403/429 are policy, geo, or rate-limit denies — do not hop regions (AUP).
+POLICY_FAIL_CLOSED_CODES = frozenset({403, 429})
+FAILOVER_STATUS_CODES = frozenset({500, 502, 503, 504})
 
 
 def default_imagine_settings() -> dict[str, Any]:

--- a/tools/nsfw_config.py
+++ b/tools/nsfw_config.py
@@ -22,11 +22,11 @@ SHOT_TIERS: dict[str, dict[str, Any]] = {
         "label": "Consistency Anchor",
         "description": "Identity lock reference frames — generate before dependent shots",
     },
-    "key_explicit": {
+    "key_intimate": {
         "priority": 3,
         "budget_share": 0.35,
-        "label": "Key Explicit Moment",
-        "description": "Narrative-critical intimate beats with explicit intent",
+        "label": "Key Intimate Beat",
+        "description": "Narrative-critical R-rated implied intimacy (not pornographic)",
     },
     "support": {
         "priority": 4,
@@ -123,7 +123,7 @@ NSFW_ASSET_MODEL_MAP: dict[str, dict[str, Any]] = {
         "video_model": DEFAULT_IMAGINE_VIDEO_MODEL,
         "image_quality": True,
     },
-    "key_explicit": {
+    "key_intimate": {
         "asset_tier": "hero",
         "image_model": DEFAULT_IMAGE_QUALITY_MODEL,
         "video_model": DEFAULT_IMAGINE_VIDEO_MODEL,
@@ -149,9 +149,35 @@ NSFW_ASSET_MODEL_MAP: dict[str, dict[str, Any]] = {
     },
 }
 
+TIER_ALIASES: dict[str, str] = {"key_explicit": "key_intimate"}
+
+# Legacy lookup so old batch JSON still routes.
+NSFW_ASSET_MODEL_MAP["key_explicit"] = NSFW_ASSET_MODEL_MAP["key_intimate"]
+
+
+def canonical_tier(tier: str | None) -> str:
+    """Map deprecated aliases (key_explicit) to canonical R-rated tiers."""
+    raw = (tier or "support").strip()
+    mapped = TIER_ALIASES.get(raw, raw)
+    return mapped if mapped in SHOT_TIERS else "support"
+
+
 SHOT_TIER_OPTIONS: tuple[str, ...] = tuple(
     sorted(SHOT_TIERS.keys(), key=lambda t: SHOT_TIERS[t]["priority"])
 )
 RETRY_REASON_OPTIONS: tuple[str, ...] = tuple(RETRY_STRATEGIES.keys())
 MOTION_OPTIONS: tuple[str, ...] = ("low", "medium", "high")
-EXPLICIT_OPTIONS: tuple[str, ...] = ("suggestive", "moderate", "explicit")
+EXPLICIT_OPTIONS: tuple[str, ...] = ("suggestive", "moderate")
+
+
+def canonical_explicit_level(level: str | None) -> str:
+    """R-rated intensities only. Full explicit is refused."""
+    raw = (level or "moderate").strip().lower()
+    if not raw:
+        return "moderate"
+    if raw in EXPLICIT_OPTIONS:
+        return raw
+    raise ValueError(
+        "explicit_level must be 'suggestive' or 'moderate' (R-rated). "
+        f"Got {raw!r}. Full explicit is not allowed on SpaceXAI Imagine."
+    )

--- a/tools/nsfw_decisions.py
+++ b/tools/nsfw_decisions.py
@@ -19,6 +19,7 @@ from nsfw_config import (
     QUALITY_THRESHOLD_HERO,
     QUALITY_THRESHOLD_PASS,
     RETRY_STRATEGIES,
+    canonical_tier,
 )
 
 
@@ -62,7 +63,7 @@ def estimate_shot_cost(
 
 
 def _tier(shot: dict[str, Any]) -> str:
-    return shot.get("tier", "support")
+    return canonical_tier(shot.get("tier", "support"))
 
 
 def _has_ref(shot: dict[str, Any]) -> bool:
@@ -93,7 +94,7 @@ GENERATION_MODE_RULES: tuple[ModeRule, ...] = (
         0.92,
     ),
     (
-        lambda s, _: _tier(s) in ("hero", "key_explicit") and _has_ref(s),
+        lambda s, _: _tier(s) in ("hero", "key_intimate") and _has_ref(s),
         "image_to_video",
         "High-impact shot with reference — i2v for fidelity",
         0.88,

--- a/tools/nsfw_extension_config.py
+++ b/tools/nsfw_extension_config.py
@@ -78,7 +78,7 @@ EROTIC_PHASES: dict[str, dict[str, Any]] = {
         "label": "Peak",
         "tension": 0.95,
         "motion_intensity": "high",
-        "description": "Key explicit narrative beat — hero moment of sequence",
+        "description": "Peak emotional intimacy beat — implied, R-rated, clothing on or tasteful suggestion",
     },
     "afterglow": {
         "label": "Afterglow",

--- a/tools/nsfw_orchestrator.py
+++ b/tools/nsfw_orchestrator.py
@@ -392,7 +392,7 @@ def generate_daily_report(
     if pct_daily > 80:
         recommendations.append("Daily cap nearly exhausted — defer filler/support to tomorrow")
     if pass_rate < 60:
-        recommendations.append("Low pass rate — increase consistency_anchor shots before key_explicit")
+        recommendations.append("Low pass rate — increase consistency_anchor shots before key_intimate")
     if avg_quality < 7:
         recommendations.append("Avg quality below 7 — activate ErosForge + Identity Lock before next batch")
     if efficiency < 0.5:

--- a/tools/nsfw_shots.py
+++ b/tools/nsfw_shots.py
@@ -13,7 +13,7 @@ from models import (
 )
 
 from aspect_presets import apply_aspect_to_shot, default_aspect_for_tier, normalize_aspect, parse_aspect_from_spec
-from nsfw_config import NSFW_ASSET_MODEL_MAP, SHOT_TIERS
+from nsfw_config import NSFW_ASSET_MODEL_MAP, SHOT_TIERS, canonical_explicit_level, canonical_tier
 from nsfw_decisions import decide_generation_mode, estimate_shot_cost
 from nsfw_util import now_iso
 
@@ -33,10 +33,10 @@ def build_shot_context(
     """Canonical shot dict for decide/retry flows (CLI + Web UI)."""
     ctx: dict[str, Any] = {
         "shot_id": shot_id,
-        "tier": tier if tier in SHOT_TIERS else "support",
+        "tier": canonical_tier(tier),
         "motion_complexity": motion,
         "has_reference": has_ref,
-        "explicit_level": explicit,
+        "explicit_level": canonical_explicit_level(explicit),
         "duration_seconds": duration,
         "consistency_required": consistency_required,
     }
@@ -60,7 +60,7 @@ def parse_inline_shot(spec: str) -> dict[str, Any]:
     else:
         tier, motion, desc = "support", "medium", spec
     shot = {
-        "tier": tier.strip(),
+        "tier": canonical_tier(tier),
         "description": desc.strip(),
         "motion_complexity": motion.strip(),
     }
@@ -70,7 +70,8 @@ def parse_inline_shot(spec: str) -> dict[str, Any]:
 
 def apply_reference_curator_models(shot: dict[str, Any]) -> dict[str, Any]:
     """Assign image/video model slugs per Reference & Asset Curator NSFW tier map."""
-    tier = shot.get("tier", "support")
+    tier = canonical_tier(shot.get("tier", "support"))
+    shot["tier"] = tier
     mapping = NSFW_ASSET_MODEL_MAP.get(tier, NSFW_ASSET_MODEL_MAP["support"])
     shot["asset_tier"] = mapping["asset_tier"]
     shot["image_model"] = mapping["image_model"]
@@ -102,8 +103,7 @@ def create_shot(
     explicit_level: str = "moderate",
     image_quality: bool = False,
 ) -> dict[str, Any]:
-    if tier not in SHOT_TIERS:
-        tier = "support"
+    tier = canonical_tier(tier)
     sid = shot_id or f"shot_{tier[:3]}_{datetime.now().strftime('%H%M%S')}"
     shot = {
         "shot_id": sid,
@@ -113,7 +113,7 @@ def create_shot(
         "has_reference": has_reference,
         "consistency_required": consistency_required,
         "motion_complexity": motion_complexity,
-        "explicit_level": explicit_level,
+        "explicit_level": canonical_explicit_level(explicit_level),
         "image_quality": image_quality,
         "status": "pending",
         "attempts": [],
@@ -142,7 +142,7 @@ def enrich_shot_for_batch(raw: dict[str, Any], *, fast_mode: bool = False) -> di
             has_reference=raw.get("has_reference", False),
             consistency_required=raw.get("consistency_required", True),
             motion_complexity=raw.get("motion_complexity", "medium"),
-            explicit_level=raw.get("explicit_level", "moderate"),
+            explicit_level=canonical_explicit_level(raw.get("explicit_level", "moderate")),
             image_quality=raw.get("image_quality", False),
         )
     decision = decide_generation_mode(raw)

--- a/web_ui/lib/nsfw_runtime.py
+++ b/web_ui/lib/nsfw_runtime.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from aup_gate import gate_nsfw_batch, gate_nsfw_shot
 from nsfw_orchestrator import (
     EXPLICIT_OPTIONS,
     MOTION_OPTIONS,
@@ -52,7 +53,14 @@ def plan_and_save_batch(
     budget_credits: float | None = None,
     fast_mode: bool = False,
 ) -> tuple[dict[str, Any], str]:
-    batch = plan_batch(title, shots, tier=tier, budget_credits=budget_credits, fast_mode=fast_mode)
+    normalized: list[dict[str, Any]] = []
+    for item in shots:
+        if isinstance(item, str):
+            normalized.append(parse_inline_shot(item))
+        else:
+            normalized.append(item)
+    gate_nsfw_batch(title, normalized)
+    batch = plan_batch(title, normalized, tier=tier, budget_credits=budget_credits, fast_mode=fast_mode)
     path = save_batch(batch)
     return batch, str(path)
 
@@ -80,6 +88,7 @@ def mode_decision(
         explicit=explicit,
         duration=duration,
     )
+    gate_nsfw_shot(shot)
     if budget_remaining is None:
         budget_remaining = load_project_state().get("quota", {}).get("budget_remaining")
     return decide_generation_mode(shot, budget_remaining=budget_remaining)
@@ -91,7 +100,7 @@ def retry_plan(
     reason: str = "physics_failure",
     score: float | None = None,
     attempts: int = 0,
-    shot_tier: str = "key_explicit",
+    shot_tier: str = "key_intimate",
 ) -> dict[str, Any]:
     shot = build_shot_context(shot_id, tier=shot_tier, recommended_mode="image_to_video")
     return suggest_retry(shot, failure_reason=reason, quality_score=score, attempts=attempts)

--- a/web_ui/pages/nsfw.py
+++ b/web_ui/pages/nsfw.py
@@ -17,7 +17,10 @@ def _gate() -> bool:
     if not rt.NSFW_AVAILABLE:
         st.error("NSFW modules unavailable in this environment.")
         return False
-    st.caption("ErosForge planners — explicit `ACTIVATE EROSFORGE` still required in Grok.")
+    st.caption(
+        "R-rated fictional imaginary adults only. "
+        "`ACTIVATE EROSFORGE` still required in Grok. Live generate defaults to dry-run."
+    )
     return True
 
 
@@ -36,7 +39,7 @@ def render() -> None:
             batch_title = st.text_input("Batch title")
             shots = st.text_area(
                 "Shots (one per line)",
-                placeholder="hero:Cover frame, golden hour\nconsistency_anchor:Profile neutral\nkey_explicit:high:Slow reveal",
+                placeholder="hero:Cover frame, golden hour\nconsistency_anchor:Profile neutral\nkey_intimate:high:Slow reveal",
                 help="Format: tier:description or tier:motion:description",
             )
             col1, col2 = st.columns(2)
@@ -166,16 +169,22 @@ def render() -> None:
                 d_motion = st.selectbox("Motion", nr.MOTION_OPTIONS, index=1)
             with c3:
                 d_explicit = st.selectbox("Explicit level", nr.EXPLICIT_OPTIONS, index=1)
-            d_ref = st.checkbox("Has approved reference")
+            d_ref = st.checkbox(
+                "Has approved reference",
+                help="AUP: NSFW/intimate cannot use reference photos of people. Leave unchecked.",
+            )
             if st.form_submit_button("Decide mode"):
-                decision = nr.mode_decision(
-                    d_id,
-                    shot_tier=d_tier,
-                    motion=d_motion,
-                    has_ref=d_ref,
-                    explicit=d_explicit,
-                )
-                st.json(decision)
+                try:
+                    decision = nr.mode_decision(
+                        d_id,
+                        shot_tier=d_tier,
+                        motion=d_motion,
+                        has_ref=d_ref,
+                        explicit=d_explicit,
+                    )
+                    st.json(decision)
+                except Exception as exc:
+                    st.error(str(exc))
 
         st.divider()
         st.subheader("Retry strategy")

--- a/web_ui/pages/settings.py
+++ b/web_ui/pages/settings.py
@@ -85,11 +85,38 @@ def render() -> None:
     st.caption("Grok Build CLI models: `grok-composer-2.5-fast`, `grok-build` — see `references/MODELS_v3.6.md`")
 
     st.divider()
-    st.subheader("🔞 NSFW pipelines")
-    st.session_state.nsfw_opt_in = st.checkbox(
-        "Enable NSFW planning tools",
-        value=st.session_state.nsfw_opt_in,
-        help="Unlocks the NSFW page. Explicit activation still required in Grok.",
+    st.subheader("🔞 NSFW pipelines (18+ / SpaceXAI AUP)")
+    st.markdown(
+        "Limited **R-rated fictional adult** material of **imaginary adults** only. "
+        "Not affiliated with xAI / SpaceXAI. Policy: "
+        "[Acceptable Use Policy](https://x.ai/legal/acceptable-use-policy)"
     )
-    if st.session_state.nsfw_opt_in:
-        st.caption("Open the **NSFW** page to plan batches and extensions.")
+    age_ok = st.checkbox("I am 18 or older", value=False, key="aup_age")
+    imag_ok = st.checkbox("Subjects are fictional imaginary adults", value=False, key="aup_imaginary")
+    real_ok = st.checkbox("I will not use real-person photos or likenesses", value=False, key="aup_not_real")
+    aup_ok = st.checkbox("I acknowledge the SpaceXAI Acceptable Use Policy", value=False, key="aup_ack")
+    can_enable = age_ok and imag_ok and real_ok and aup_ok
+    if not can_enable:
+        st.session_state.nsfw_opt_in = False
+        st.caption("All four attestations are required. A Settings checkbox alone is not enough.")
+    else:
+        from aup_gate import write_attestation
+
+        try:
+            write_attestation(
+                age_18_plus=True,
+                imaginary_adults_only=True,
+                not_a_real_person=True,
+                aup_acknowledged=True,
+            )
+        except Exception as exc:
+            st.error(str(exc))
+            st.session_state.nsfw_opt_in = False
+        else:
+            st.session_state.nsfw_opt_in = st.checkbox(
+                "Enable NSFW planning tools",
+                value=st.session_state.nsfw_opt_in,
+                help="Unlocks the NSFW page after AUP attestation.",
+            )
+            if st.session_state.nsfw_opt_in:
+                st.caption("Open the **NSFW** page. Live Imagine calls still default to dry-run.")


### PR DESCRIPTION
## Summary

Client-side SpaceXAI AUP gates for Grok Imagine / Grok Build use. This repo is an unofficial third-party studio and is not affiliated with xAI or SpaceXAI.

Policy: https://x.ai/legal/acceptable-use-policy

## What changed

- `tools/aup_gate.py` — 18+ local attestation, imaginary adults only, no real-person refs, R-rated cap, CSAM-stub refuse
- `nsfw attest` CLI + Web UI four-checkbox attestation (a Settings checkbox alone is not enough)
- Default Grok plugin is **SFW-only**; NSFW lives in `.grok-plugin/nsfw-plugin.json` (optional 18+ add-on)
- Imagine **403/429 no longer hop regions** (fail closed)
- Shot tier `key_explicit` → `key_intimate` (old name still an alias); full-explicit intensity refused at shot build time
- `nsfw run` / `session` default to dry-run (`--live` to generate)
- Third-party disclaimer in README, marketplace, AGENTS.md, CoC, CONTRIBUTORS

## Tests

- `tests/test_aup_gate.py` plus routing/CLI smoke
- 25/26 local tests passed; remaining miss is `test_web_ui_imports.py` (Streamlit not installed in this environment)
- `nsfw plan` without attestation exits 1

## Out of scope

Termux overlay files (`scripts/install_grok_termux.sh`, `docs/guides/`, example config) are **not** in this PR.

## Operator note

Intimate work still requires:

```bash
python tools/cinematic_studio_cli.py nsfw attest \
  --i-am-18 --imaginary-adults --not-a-real-person --acknowledge-aup
```