### PR TITLE
feat(aup): SpaceXAI AUP fail-closed gates on v3.11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -201,6 +201,9 @@ artifacts/animatics/
 # Streamlit
 .streamlit/secrets.toml
 
+# Local SpaceXAI AUP attestation (never commit)
+.aup_attestation.json
+
 # React / Vite cockpit (web_react)
 web_react/node_modules/
 web_react/dist/

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -14,7 +14,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio.git",
-        "sha": "a3cc2f914f8a0b088d6c9f3de6c185972fa0127b"
+        "sha": "19200b2d4b67402502369c37fa0e783fba8d4ca4"
       },
       "homepage": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio",
       "keywords": [
@@ -31,7 +31,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio.git",
-        "sha": "a3cc2f914f8a0b088d6c9f3de6c185972fa0127b"
+        "sha": "19200b2d4b67402502369c37fa0e783fba8d4ca4"
       },
       "homepage": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio",
       "keywords": [
@@ -49,7 +49,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio.git",
-        "sha": "a3cc2f914f8a0b088d6c9f3de6c185972fa0127b"
+        "sha": "19200b2d4b67402502369c37fa0e783fba8d4ca4"
       },
       "homepage": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio",
       "keywords": [
@@ -69,7 +69,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio.git",
-        "sha": "a3cc2f914f8a0b088d6c9f3de6c185972fa0127b"
+        "sha": "19200b2d4b67402502369c37fa0e783fba8d4ca4"
       },
       "homepage": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio",
       "keywords": [
@@ -83,13 +83,13 @@
     },
     {
       "name": "grok-imagine-nsfw",
-      "description": "Explicit opt-in ErosForge + NSFW quota/sequence/chain QA. Requires user consent.",
+      "description": "Optional 18+ pack (SpaceXAI AUP). R-rated fictional imaginary adults only. Requires nsfw attest. Not affiliated with xAI/SpaceXAI.",
       "category": "creative",
       "version": "3.11.0",
       "source": {
         "source": "url",
         "url": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio.git",
-        "sha": "a3cc2f914f8a0b088d6c9f3de6c185972fa0127b"
+        "sha": "19200b2d4b67402502369c37fa0e783fba8d4ca4"
       },
       "homepage": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio",
       "keywords": [
@@ -109,7 +109,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio.git",
-        "sha": "a3cc2f914f8a0b088d6c9f3de6c185972fa0127b"
+        "sha": "19200b2d4b67402502369c37fa0e783fba8d4ca4"
       },
       "homepage": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio",
       "keywords": [

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -14,7 +14,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio.git",
-        "sha": "42bfe5f6b86fac28a78e1b3ed1db67839adf8c28"
+        "sha": "a3cc2f914f8a0b088d6c9f3de6c185972fa0127b"
       },
       "homepage": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio",
       "keywords": [
@@ -31,7 +31,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio.git",
-        "sha": "42bfe5f6b86fac28a78e1b3ed1db67839adf8c28"
+        "sha": "a3cc2f914f8a0b088d6c9f3de6c185972fa0127b"
       },
       "homepage": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio",
       "keywords": [
@@ -49,7 +49,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio.git",
-        "sha": "42bfe5f6b86fac28a78e1b3ed1db67839adf8c28"
+        "sha": "a3cc2f914f8a0b088d6c9f3de6c185972fa0127b"
       },
       "homepage": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio",
       "keywords": [
@@ -69,7 +69,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio.git",
-        "sha": "42bfe5f6b86fac28a78e1b3ed1db67839adf8c28"
+        "sha": "a3cc2f914f8a0b088d6c9f3de6c185972fa0127b"
       },
       "homepage": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio",
       "keywords": [
@@ -83,13 +83,13 @@
     },
     {
       "name": "grok-imagine-nsfw",
-      "description": "Optional 18+ pack: R-rated fictional imaginary adults only. Requires nsfw attest (SpaceXAI AUP). Not affiliated with xAI/SpaceXAI.",
+      "description": "Explicit opt-in ErosForge + NSFW quota/sequence/chain QA. Requires user consent.",
       "category": "creative",
       "version": "3.11.0",
       "source": {
         "source": "url",
         "url": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio.git",
-        "sha": "42bfe5f6b86fac28a78e1b3ed1db67839adf8c28"
+        "sha": "a3cc2f914f8a0b088d6c9f3de6c185972fa0127b"
       },
       "homepage": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio",
       "keywords": [
@@ -109,7 +109,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio.git",
-        "sha": "42bfe5f6b86fac28a78e1b3ed1db67839adf8c28"
+        "sha": "a3cc2f914f8a0b088d6c9f3de6c185972fa0127b"
       },
       "homepage": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio",
       "keywords": [

--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -83,7 +83,7 @@
     },
     {
       "name": "grok-imagine-nsfw",
-      "description": "Explicit opt-in ErosForge + NSFW quota/sequence/chain QA. Requires user consent.",
+      "description": "Optional 18+ pack: R-rated fictional imaginary adults only. Requires nsfw attest (SpaceXAI AUP). Not affiliated with xAI/SpaceXAI.",
       "category": "creative",
       "version": "3.11.0",
       "source": {

--- a/.grok-plugin/packs/nsfw/plugin.json
+++ b/.grok-plugin/packs/nsfw/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "grok-imagine-nsfw",
   "version": "3.11.0",
-  "description": "Explicit opt-in ErosForge + NSFW quota/sequence/chain QA. Requires user consent.",
+  "description": "Optional 18+ pack (SpaceXAI AUP). R-rated fictional imaginary adults only. Requires nsfw attest. Not affiliated with xAI/SpaceXAI.",
   "author": {
     "name": "FineComputer14451",
     "url": "https://github.com/FineComputer14451"

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -308,7 +308,7 @@
           }
         ]
       },
-      "sha": "a3cc2f914f8a0b088d6c9f3de6c185972fa0127b"
+      "sha": "19200b2d4b67402502369c37fa0e783fba8d4ca4"
     },
     "grok-imagine-cinematic-core": {
       "components": {
@@ -445,7 +445,7 @@
           }
         ]
       },
-      "sha": "a3cc2f914f8a0b088d6c9f3de6c185972fa0127b"
+      "sha": "19200b2d4b67402502369c37fa0e783fba8d4ca4"
     },
     "grok-imagine-camera-image": {
       "components": {
@@ -496,7 +496,7 @@
           }
         ]
       },
-      "sha": "a3cc2f914f8a0b088d6c9f3de6c185972fa0127b"
+      "sha": "19200b2d4b67402502369c37fa0e783fba8d4ca4"
     },
     "grok-imagine-sequence-narrative": {
       "components": {
@@ -579,7 +579,7 @@
           }
         ]
       },
-      "sha": "a3cc2f914f8a0b088d6c9f3de6c185972fa0127b"
+      "sha": "19200b2d4b67402502369c37fa0e783fba8d4ca4"
     },
     "grok-imagine-nsfw": {
       "components": {
@@ -608,7 +608,7 @@
           }
         ]
       },
-      "sha": "a3cc2f914f8a0b088d6c9f3de6c185972fa0127b"
+      "sha": "19200b2d4b67402502369c37fa0e783fba8d4ca4"
     },
     "grok-imagine-delivery-post": {
       "components": {
@@ -649,7 +649,7 @@
           }
         ]
       },
-      "sha": "a3cc2f914f8a0b088d6c9f3de6c185972fa0127b"
+      "sha": "19200b2d4b67402502369c37fa0e783fba8d4ca4"
     }
   }
 }

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -308,7 +308,7 @@
           }
         ]
       },
-      "sha": "42bfe5f6b86fac28a78e1b3ed1db67839adf8c28"
+      "sha": "a3cc2f914f8a0b088d6c9f3de6c185972fa0127b"
     },
     "grok-imagine-cinematic-core": {
       "components": {
@@ -445,7 +445,7 @@
           }
         ]
       },
-      "sha": "42bfe5f6b86fac28a78e1b3ed1db67839adf8c28"
+      "sha": "a3cc2f914f8a0b088d6c9f3de6c185972fa0127b"
     },
     "grok-imagine-camera-image": {
       "components": {
@@ -496,7 +496,7 @@
           }
         ]
       },
-      "sha": "42bfe5f6b86fac28a78e1b3ed1db67839adf8c28"
+      "sha": "a3cc2f914f8a0b088d6c9f3de6c185972fa0127b"
     },
     "grok-imagine-sequence-narrative": {
       "components": {
@@ -579,7 +579,7 @@
           }
         ]
       },
-      "sha": "42bfe5f6b86fac28a78e1b3ed1db67839adf8c28"
+      "sha": "a3cc2f914f8a0b088d6c9f3de6c185972fa0127b"
     },
     "grok-imagine-nsfw": {
       "components": {
@@ -608,7 +608,7 @@
           }
         ]
       },
-      "sha": "42bfe5f6b86fac28a78e1b3ed1db67839adf8c28"
+      "sha": "a3cc2f914f8a0b088d6c9f3de6c185972fa0127b"
     },
     "grok-imagine-delivery-post": {
       "components": {
@@ -649,7 +649,7 @@
           }
         ]
       },
-      "sha": "42bfe5f6b86fac28a78e1b3ed1db67839adf8c28"
+      "sha": "a3cc2f914f8a0b088d6c9f3de6c185972fa0127b"
     }
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to Grok Imagine Cinematic Studio will be documented in this 
 ## [Unreleased]
 
 ### Added
+- **SpaceXAI AUP fail-closed gates** — `tools/aup_gate.py`, `nsfw attest`, 18+/imaginary-adult/no-real-person checks, R-rated cap, 403/429 no region hop
 - **`commands` search** — `cinematic-studio commands [query]` lists visible command paths and one-line help; substring match on path + summary (Orient panel). Hidden ghosts stay hidden.
 - **SFW / NSFW help panels** — `sfw --help` and `nsfw --help` group Plan / Readiness / Spend / Quality (NSFW adds Extend).
 - **Wave A help panels** — `wave-a --help` groups Packets vs Gate (`validate` / `attach`).

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 > **v3.11.0** — Grok 4.6 cinematic+Build stack lock, Grok Build ≥ 1.0.5, Imagine Image 2.0 + Video 1.0/1.5 (`grok-4.5` aliases wrap 4.6)
 
+> **Unofficial third-party project.** Not affiliated with, endorsed by, or originating from xAI or SpaceXAI. Operators must follow the [SpaceXAI Acceptable Use Policy](https://x.ai/legal/acceptable-use-policy). Intimate pipelines are **18+**, **imaginary adults only**, **R-rated**, and require `nsfw attest`.
+
 **Requires Grok Build ≥ 1.0.5** | **Grok 4.6 cinematic+Build default** | **Native Imagine Video 1.5 support with synchronized audio**
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ## 🎬 Grok Imagine Cinematic Studio
 
 > **v3.11.0** — Grok 4.6 cinematic+Build stack lock, Grok Build ≥ 1.0.5, Imagine Image 2.0 + Video 1.0/1.5 (`grok-4.5` aliases wrap 4.6)
-
+>
 > **Unofficial third-party project.** Not affiliated with, endorsed by, or originating from xAI or SpaceXAI. Operators must follow the [SpaceXAI Acceptable Use Policy](https://x.ai/legal/acceptable-use-policy). Intimate pipelines are **18+**, **imaginary adults only**, **R-rated**, and require `nsfw attest`.
 
 **Requires Grok Build ≥ 1.0.5** | **Grok 4.6 cinematic+Build default** | **Native Imagine Video 1.5 support with synchronized audio**

--- a/config/plugin_packs.yaml
+++ b/config/plugin_packs.yaml
@@ -96,7 +96,7 @@ packs:
   nsfw:
     name: grok-imagine-nsfw
     display_name: Cinematic Studio NSFW (Opt-in)
-    description: Explicit opt-in ErosForge + NSFW quota/sequence/chain QA. Requires user consent.
+    description: Optional 18+ pack (SpaceXAI AUP). R-rated fictional imaginary adults only. Requires nsfw attest. Not affiliated with xAI/SpaceXAI.
     requires:
     - core
     skills:

--- a/tests/test_aup_gate.py
+++ b/tests/test_aup_gate.py
@@ -1,0 +1,348 @@
+"""Fail-closed SpaceXAI AUP gates — metadata/stub prompts only."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "tools"))
+
+from aup_gate import (  # noqa: E402
+    AUP_URL,
+    AUPGateError,
+    ATTESTATION_ENV,
+    attestation_is_valid,
+    gate_dna,
+    gate_imagine_prompt,
+    gate_nsfw_batch,
+    gate_nsfw_shot,
+    gate_text,
+    require_attestation,
+    scan_csam,
+    write_attestation,
+)
+
+
+def _attest_env() -> tuple[str, str]:
+    handle = tempfile.NamedTemporaryFile(prefix="aup-", suffix=".json", delete=False)
+    handle.close()
+    path = handle.name
+    os.environ[ATTESTATION_ENV] = path
+    write_attestation(
+        age_18_plus=True,
+        imaginary_adults_only=True,
+        not_a_real_person=True,
+        aup_acknowledged=True,
+        path=Path(path),
+    )
+    return path, ATTESTATION_ENV
+
+
+def _cleanup(path: str) -> None:
+    os.environ.pop(ATTESTATION_ENV, None)
+    try:
+        os.unlink(path)
+    except OSError:
+        pass
+
+
+def test_attestation_requires_all_flags() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        path = Path(tmp) / "attestation.json"
+        try:
+            write_attestation(
+                age_18_plus=True,
+                imaginary_adults_only=True,
+                not_a_real_person=False,
+                aup_acknowledged=True,
+                path=path,
+            )
+            raise AssertionError("expected AUPGateError")
+        except AUPGateError as exc:
+            assert "All four attestations" in str(exc)
+        assert not path.exists()
+
+
+def test_checkbox_is_not_attestation() -> None:
+    os.environ[ATTESTATION_ENV] = str(Path(__file__).resolve().parent / "missing-aup-attestation.json")
+    try:
+        require_attestation()
+        raise AssertionError("expected AUPGateError")
+    except AUPGateError as exc:
+        assert "nsfw attest" in str(exc)
+        assert AUP_URL in str(exc)
+    finally:
+        os.environ.pop(ATTESTATION_ENV, None)
+
+
+def test_valid_attestation_roundtrip() -> None:
+    path, _ = _attest_env()
+    try:
+        data = json.loads(Path(path).read_text())
+        assert attestation_is_valid(data)
+        assert require_attestation()["age_18_plus"] is True
+    finally:
+        _cleanup(path)
+
+
+def test_csam_keyword_refuse_uses_stubs_only() -> None:
+    assert scan_csam("loli aesthetic")
+    assert scan_csam("schoolgirl uniform")
+    assert scan_csam("aged down")
+    assert not scan_csam("childhood bedroom flashback")
+    try:
+        gate_text("underage character study")
+        raise AssertionError("expected AUPGateError")
+    except AUPGateError as exc:
+        assert "NCMEC" in str(exc)
+
+
+def test_explicit_beyond_r_refused_when_nsfw() -> None:
+    path, _ = _attest_env()
+    try:
+        try:
+            gate_text("creampie close-up", nsfw=True)
+            raise AssertionError("expected AUPGateError")
+        except AUPGateError as exc:
+            assert "R-rated" in str(exc)
+        gate_text("tender implied intimacy, clothing on, R-rated", nsfw=True)
+    finally:
+        _cleanup(path)
+
+
+def test_hidden_camera_refused() -> None:
+    path, _ = _attest_env()
+    try:
+        try:
+            gate_text("hidden camera through window", nsfw=True)
+            raise AssertionError("expected AUPGateError")
+        except AUPGateError as exc:
+            assert "hidden-camera" in str(exc) or "nudify" in str(exc)
+    finally:
+        _cleanup(path)
+
+
+def test_nsfw_shot_refuses_reference_image() -> None:
+    path, _ = _attest_env()
+    try:
+        try:
+            gate_nsfw_shot(
+                {
+                    "description": "candlelit embrace",
+                    "tier": "hero",
+                    "explicit_level": "moderate",
+                    "has_reference": True,
+                }
+            )
+            raise AssertionError("expected AUPGateError")
+        except AUPGateError as exc:
+            assert "reference" in str(exc).lower()
+    finally:
+        _cleanup(path)
+
+
+def test_nsfw_shot_refuses_explicit_level() -> None:
+    path, _ = _attest_env()
+    try:
+        try:
+            gate_nsfw_shot(
+                {
+                    "description": "slow reveal",
+                    "tier": "hero",
+                    "explicit_level": "explicit",
+                }
+            )
+            raise AssertionError("expected AUPGateError")
+        except AUPGateError as exc:
+            assert "suggestive or moderate" in str(exc)
+    finally:
+        _cleanup(path)
+
+
+def test_nsfw_batch_allows_r_rated_imaginary() -> None:
+    path, _ = _attest_env()
+    try:
+        gate_nsfw_batch(
+            "Hero Session",
+            [{"description": "Cover frame candlelit embrace", "tier": "hero", "explicit_level": "suggestive"}],
+        )
+    finally:
+        _cleanup(path)
+
+
+def test_dna_intimate_requires_imaginary_adult_no_photo() -> None:
+    path, _ = _attest_env()
+    try:
+        try:
+            gate_dna(
+                {
+                    "character_name": "Mara",
+                    "core_identity": "adult fictional lead",
+                    "facial_dna": "sharp cheekbones",
+                    "nsfw_notes": "implied intimacy continuity",
+                    "subject_kind": "unspecified",
+                    "reference_image_ids": [],
+                }
+            )
+            raise AssertionError("expected AUPGateError")
+        except AUPGateError as exc:
+            assert "imaginary_adult" in str(exc)
+
+        try:
+            gate_dna(
+                {
+                    "character_name": "Mara",
+                    "core_identity": "adult fictional lead",
+                    "facial_dna": "sharp cheekbones",
+                    "nsfw_notes": "implied intimacy continuity",
+                    "subject_kind": "imaginary_adult",
+                    "reference_image_ids": ["img_123"],
+                }
+            )
+            raise AssertionError("expected AUPGateError")
+        except AUPGateError as exc:
+            lowered = str(exc).lower()
+            assert "photos" in lowered or "reference" in lowered
+
+        gate_dna(
+            {
+                "character_name": "Mara",
+                "core_identity": "adult fictional lead",
+                "facial_dna": "sharp cheekbones",
+                "nsfw_notes": "implied intimacy continuity",
+                "subject_kind": "imaginary_adult",
+                "reference_image_ids": [],
+            }
+        )
+    finally:
+        _cleanup(path)
+
+
+def test_sfw_dna_with_refs_still_allowed() -> None:
+    gate_dna(
+        {
+            "character_name": "Elena Voss",
+            "core_identity": "detective",
+            "facial_dna": "grey eyes",
+            "subject_kind": "unspecified",
+            "reference_image_ids": ["hero_still"],
+        }
+    )
+
+
+def test_imagine_edit_intimate_plus_source_image_refused() -> None:
+    path, _ = _attest_env()
+    try:
+        try:
+            gate_imagine_prompt(
+                "intimate cinematic close-up",
+                nsfw=True,
+                has_reference_image=True,
+            )
+            raise AssertionError("expected AUPGateError")
+        except AUPGateError as exc:
+            lowered = str(exc).lower()
+            assert "nudify" in lowered or "source still" in lowered
+    finally:
+        _cleanup(path)
+
+
+def test_403_429_not_in_failover() -> None:
+    from imagine_regions import FAILOVER_STATUS_CODES
+
+    assert 403 not in FAILOVER_STATUS_CODES
+    assert 429 not in FAILOVER_STATUS_CODES
+    assert 500 in FAILOVER_STATUS_CODES
+
+
+def test_execute_nsfw_shot_requires_attestation() -> None:
+    from unittest.mock import patch
+
+    from aup_gate import AUPGateError
+    from batch_runner import execute_nsfw_shot
+    from nsfw_orchestrator import plan_batch
+
+    os.environ[ATTESTATION_ENV] = "/nonexistent-aup-attestation.json"
+    try:
+        batch = plan_batch(
+            "Gate Test",
+            [{"tier": "hero", "description": "Cover frame candlelit embrace"}],
+            budget_credits=200,
+        )
+        shot_id = batch["shots"][0]["shot_id"]
+        noop = lambda *args, **kwargs: None
+        with patch("quota_optimizer.save_project_state", noop), patch(
+            "project_state.save_project_state", noop
+        ):
+            try:
+                execute_nsfw_shot(batch, shot_id, dry_run=True, record_quota=False)
+                raise AssertionError("expected AUPGateError")
+            except AUPGateError as exc:
+                assert "attest" in str(exc)
+    finally:
+        os.environ.pop(ATTESTATION_ENV, None)
+
+
+def test_403_does_not_failover_regions() -> None:
+    import io
+    import urllib.error
+    from unittest.mock import patch
+
+    from imagine_client import ImagineAPIError, generate_image
+
+    calls: list[str] = []
+
+    def boom(method, path, *, payload, headers, timeout):
+        calls.append(str((payload or {}).get("region", "")))
+        raise urllib.error.HTTPError(
+            "https://api.x.ai/v1/images/generations",
+            403,
+            "Forbidden",
+            hdrs=None,
+            fp=io.BytesIO(b'{"error":"denied"}'),
+        )
+
+    with patch.dict(os.environ, {"XAI_API_KEY": "xai-test-placeholder-not-a-real-key"}):
+        with patch("imagine_client._request_single", boom):
+            try:
+                generate_image("Test cinematic still", dry_run=False)
+                raise AssertionError("expected ImagineAPIError")
+            except ImagineAPIError as exc:
+                assert exc.status == 403
+                assert "fail closed" in str(exc)
+    assert len(calls) == 1
+
+
+def test_nsfw_pack_is_opt_in_aup() -> None:
+    marketplace = json.loads((ROOT / ".grok-plugin" / "marketplace.json").read_text())
+    assert "Official Grok plugin marketplace" not in marketplace.get("description", "")
+    packs = {p["name"]: p for p in marketplace.get("plugins", [])}
+    nsfw = packs.get("grok-imagine-nsfw")
+    assert nsfw, "v3.11 modular nsfw pack missing"
+    desc = nsfw.get("description", "").lower()
+    assert "18+" in desc or "aup" in desc
+    assert "imaginary" in desc or "attest" in desc
+
+
+if __name__ == "__main__":
+    test_attestation_requires_all_flags()
+    test_checkbox_is_not_attestation()
+    test_valid_attestation_roundtrip()
+    test_csam_keyword_refuse_uses_stubs_only()
+    test_explicit_beyond_r_refused_when_nsfw()
+    test_hidden_camera_refused()
+    test_nsfw_shot_refuses_reference_image()
+    test_nsfw_shot_refuses_explicit_level()
+    test_nsfw_batch_allows_r_rated_imaginary()
+    test_dna_intimate_requires_imaginary_adult_no_photo()
+    test_sfw_dna_with_refs_still_allowed()
+    test_imagine_edit_intimate_plus_source_image_refused()
+    test_403_429_not_in_failover()
+    test_execute_nsfw_shot_requires_attestation()
+    test_403_does_not_failover_regions()
+    test_nsfw_pack_is_opt_in_aup()
+    print("All AUP gate tests passed")

--- a/tests/test_nsfw_asset_models.py
+++ b/tests/test_nsfw_asset_models.py
@@ -30,11 +30,18 @@ def test_hero_tier_routes_image_quality() -> None:
     assert shot["image_quality"] is True
 
 
-def test_key_explicit_matches_hero_routing() -> None:
-    shot = apply_reference_curator_models({"tier": "key_explicit", "description": "Beat"})
-    mapping = NSFW_ASSET_MODEL_MAP["key_explicit"]
+def test_key_intimate_matches_hero_routing() -> None:
+    shot = apply_reference_curator_models({"tier": "key_intimate", "description": "Beat"})
+    mapping = NSFW_ASSET_MODEL_MAP["key_intimate"]
+    assert shot["tier"] == "key_intimate"
     assert shot["image_model"] == mapping["image_model"]
     assert shot["video_model"] == mapping["video_model"]
+
+
+def test_key_explicit_alias_normalizes() -> None:
+    shot = apply_reference_curator_models({"tier": "key_explicit", "description": "Beat"})
+    assert shot["tier"] == "key_intimate"
+    assert shot["image_model"] == NSFW_ASSET_MODEL_MAP["key_intimate"]["image_model"]
 
 
 def test_filler_uses_draft_video() -> None:
@@ -46,7 +53,7 @@ def test_filler_uses_draft_video() -> None:
 
 def test_parse_inline_shot_three_part() -> None:
     parsed = parse_inline_shot("key_explicit:high:Primary beat")
-    assert parsed["tier"] == "key_explicit"
+    assert parsed["tier"] == "key_intimate"
     assert parsed["motion_complexity"] == "high"
     assert parsed["description"] == "Primary beat"
 
@@ -63,11 +70,11 @@ def test_build_shot_context_canonical_fields() -> None:
         tier="key_explicit",
         motion="high",
         has_ref=True,
-        explicit="explicit",
+        explicit="moderate",
         duration=12.0,
     )
     assert shot["shot_id"] == "shot_001"
-    assert shot["tier"] == "key_explicit"
+    assert shot["tier"] == "key_intimate"
     assert shot["motion_complexity"] == "high"
     assert shot["has_reference"] is True
     assert shot["consistency_required"] is True
@@ -119,7 +126,8 @@ def test_plan_batch_applies_routing() -> None:
 
 if __name__ == "__main__":
     test_hero_tier_routes_image_quality()
-    test_key_explicit_matches_hero_routing()
+    test_key_intimate_matches_hero_routing()
+    test_key_explicit_alias_normalizes()
     test_filler_uses_draft_video()
     test_parse_inline_shot_three_part()
     test_create_shot_includes_models()

--- a/tools/aup_gate.py
+++ b/tools/aup_gate.py
@@ -1,0 +1,352 @@
+#!/usr/bin/env python3
+"""
+SpaceXAI AUP fail-closed gates for Grok Imagine Cinematic Studio.
+
+Policy: https://x.ai/legal/acceptable-use-policy (effective 14 Aug 2026)
+
+Allowed intimate work: limited R-rated fictional adult material of
+imaginary adults, for 18+ operators who attested and enabled NSFW on
+their xAI account.
+
+Blocked: CSAM / minor-coded tropes, real-person undress/nudify,
+pornographic depictions beyond R-rated, hidden-camera NCII patterns.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
+from studio_paths import STUDIO_ROOT
+
+AUP_URL = "https://x.ai/legal/acceptable-use-policy"
+ATTESTATION_SCHEMA = "1.0"
+ATTESTATION_ENV = "GROK_STUDIO_AUP_ATTESTATION"
+DEFAULT_ATTESTATION_NAME = ".aup_attestation.json"
+
+REQUIRED_ATTESTATION_FLAGS = (
+    "age_18_plus",
+    "imaginary_adults_only",
+    "not_a_real_person",
+    "aup_acknowledged",
+)
+
+SUBJECT_KIND_IMAGINARY_ADULT = "imaginary_adult"
+ALLOWED_SUBJECT_KINDS = ("unspecified", "imaginary_adult", "real_person")
+R_RATED_EXPLICIT_LEVELS = frozenset({"suggestive", "moderate", ""})
+
+# Stub keyword refusals only — tests must not include illegal fixtures.
+_CSAM_PATTERNS: tuple[re.Pattern[str], ...] = tuple(
+    re.compile(p, re.IGNORECASE)
+    for p in (
+        r"\bloli(?:ta|con)?\b",
+        r"\bshota\b",
+        r"\bcsam\b",
+        r"\bchild\s*porn",
+        r"\bunderage\b",
+        r"\bpre[- ]?teen\b",
+        r"\baged[- ]?down\b",
+        r"\bschoolgirl\b",
+        r"\bunder[- ]?18\b",
+    )
+)
+
+_EXPLICIT_BEYOND_R_PATTERNS: tuple[re.Pattern[str], ...] = tuple(
+    re.compile(p, re.IGNORECASE)
+    for p in (
+        r"\bcreampie\b",
+        r"\bahegao\b",
+        r"\bpenetration\b",
+        r"\bgenitals?\b",
+        r"\bsemen\b",
+        r"\bcumshot\b",
+        r"\bexplicit porn",
+        r"\bhero explicit beat\b",
+    )
+)
+
+_NCII_PATTERNS: tuple[re.Pattern[str], ...] = tuple(
+    re.compile(p, re.IGNORECASE)
+    for p in (
+        r"\bhidden camera\b",
+        r"\bnudif(?:y|ying|ication)\b",
+        r"\bdeepfake\b",
+        r"\bundress(?:ing)? (?:her|him|them|this person)\b",
+    )
+)
+
+_INTIMATE_HINT = re.compile(
+    r"\b(nsfw|erotic|nude|nudity|explicit|erosforge)\b",
+    re.IGNORECASE,
+)
+
+
+class AUPGateError(ValueError):
+    """Raised when a request would violate SpaceXAI AUP."""
+
+
+def attestation_path() -> Path:
+    override = os.getenv(ATTESTATION_ENV, "").strip()
+    if override:
+        return Path(override)
+    return STUDIO_ROOT / DEFAULT_ATTESTATION_NAME
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def load_attestation(path: Path | None = None) -> dict[str, Any] | None:
+    target = path or attestation_path()
+    if not target.is_file():
+        return None
+    try:
+        data = json.loads(target.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def attestation_is_valid(data: dict[str, Any] | None) -> bool:
+    if not data:
+        return False
+    return all(data.get(flag) is True for flag in REQUIRED_ATTESTATION_FLAGS)
+
+
+def write_attestation(
+    *,
+    age_18_plus: bool,
+    imaginary_adults_only: bool,
+    not_a_real_person: bool,
+    aup_acknowledged: bool,
+    path: Path | None = None,
+) -> dict[str, Any]:
+    if not all((age_18_plus, imaginary_adults_only, not_a_real_person, aup_acknowledged)):
+        raise AUPGateError(
+            "All four attestations are required: 18+, imaginary adults only, "
+            f"not a real person, and AUP acknowledgment ({AUP_URL})."
+        )
+    payload = {
+        "schema_version": ATTESTATION_SCHEMA,
+        "age_18_plus": True,
+        "imaginary_adults_only": True,
+        "not_a_real_person": True,
+        "aup_acknowledged": True,
+        "aup_url": AUP_URL,
+        "attested_at": _now_iso(),
+    }
+    target = path or attestation_path()
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    try:
+        os.chmod(target, 0o600)
+    except OSError:
+        pass
+    return payload
+
+
+def require_attestation(path: Path | None = None) -> dict[str, Any]:
+    data = load_attestation(path)
+    if not attestation_is_valid(data):
+        raise AUPGateError(
+            "NSFW / intimate work requires a local 18+ AUP attestation. "
+            "Run: python tools/cinematic_studio_cli.py nsfw attest "
+            "--i-am-18 --imaginary-adults --not-a-real-person --acknowledge-aup "
+            f"(policy: {AUP_URL})"
+        )
+    assert data is not None
+    return data
+
+
+def _collect_matches(text: str, patterns: Iterable[re.Pattern[str]]) -> list[str]:
+    found: list[str] = []
+    for pattern in patterns:
+        match = pattern.search(text)
+        if match:
+            found.append(match.group(0))
+    return found
+
+
+def scan_csam(text: str) -> list[str]:
+    return _collect_matches(text or "", _CSAM_PATTERNS)
+
+
+def scan_explicit_beyond_r(text: str) -> list[str]:
+    return _collect_matches(text or "", _EXPLICIT_BEYOND_R_PATTERNS)
+
+
+def scan_ncii(text: str) -> list[str]:
+    return _collect_matches(text or "", _NCII_PATTERNS)
+
+
+def is_intimate_text(text: str) -> bool:
+    return bool(_INTIMATE_HINT.search(text or ""))
+
+
+def _join_fields(values: Iterable[Any]) -> str:
+    parts: list[str] = []
+    for value in values:
+        if value is None:
+            continue
+        if isinstance(value, (list, tuple)):
+            parts.extend(str(item) for item in value if item)
+        else:
+            text = str(value).strip()
+            if text:
+                parts.append(text)
+    return "\n".join(parts)
+
+
+def gate_text(text: str, *, nsfw: bool = False) -> None:
+    """Fail closed on CSAM always; on porn/NCII tropes when nsfw/intimate."""
+    blob = text or ""
+    csam = scan_csam(blob)
+    if csam:
+        raise AUPGateError(
+            "Blocked: minor-coded or CSAM-adjacent language is forbidden "
+            f"({', '.join(csam)}). SpaceXAI reports CSAM to NCMEC."
+        )
+    intimate = nsfw or is_intimate_text(blob)
+    if not intimate:
+        return
+    beyond_r = scan_explicit_beyond_r(blob)
+    if beyond_r:
+        raise AUPGateError(
+            "Blocked: pornographic / NC-17 depiction exceeds limited R-rated "
+            f"fictional adult material ({', '.join(beyond_r)}). Policy: {AUP_URL}"
+        )
+    ncii = scan_ncii(blob)
+    if ncii:
+        raise AUPGateError(
+            "Blocked: non-consensual / hidden-camera / nudify language "
+            f"({', '.join(ncii)}). Policy: {AUP_URL}"
+        )
+
+
+def _shot_blob(shot: dict[str, Any], extra: str = "") -> str:
+    return _join_fields(
+        [
+            shot.get("description"),
+            shot.get("tier"),
+            shot.get("explicit_level"),
+            shot.get("explicit"),
+            shot.get("prompt"),
+            shot.get("recommended_mode"),
+            extra,
+        ]
+    )
+
+
+def _shot_has_reference(shot: dict[str, Any]) -> bool:
+    if shot.get("has_reference") or shot.get("has_ref"):
+        return True
+    if shot.get("reference_image_id") or shot.get("reference_image_url"):
+        return True
+    refs = shot.get("reference_image_ids") or []
+    return bool(refs)
+
+
+def _explicit_level(shot: dict[str, Any]) -> str:
+    raw = shot.get("explicit_level") or shot.get("explicit") or ""
+    return str(raw).strip().lower()
+
+
+def gate_nsfw_shot(shot: dict[str, Any], *, extra_prompt: str = "") -> None:
+    require_attestation()
+    blob = _shot_blob(shot, extra_prompt)
+    gate_text(blob, nsfw=True)
+    level = _explicit_level(shot)
+    if level and level not in R_RATED_EXPLICIT_LEVELS:
+        raise AUPGateError(
+            "Blocked: explicit_level must be suggestive or moderate (R-rated). "
+            f"Got {level!r}. Full explicit is not allowed on SpaceXAI Imagine."
+        )
+    if _shot_has_reference(shot):
+        raise AUPGateError(
+            "Blocked: reference images cannot be used on the NSFW / intimate "
+            "path (real-person undress / publicity risk). Use imaginary-adult "
+            f"text DNA only. Policy: {AUP_URL}"
+        )
+
+
+def gate_nsfw_batch(title: str, shots: Iterable[dict[str, Any]]) -> None:
+    require_attestation()
+    gate_text(title or "", nsfw=True)
+    for shot in shots:
+        gate_nsfw_shot(shot)
+
+
+def gate_imagine_prompt(
+    prompt: str,
+    *,
+    nsfw: bool = False,
+    has_reference_image: bool = False,
+) -> None:
+    blob = prompt or ""
+    intimate = nsfw or is_intimate_text(blob)
+    if intimate:
+        require_attestation()
+    gate_text(blob, nsfw=intimate)
+    if intimate and has_reference_image:
+        raise AUPGateError(
+            "Blocked: image-to-image / i2v from a source still is not allowed "
+            "for intimate prompts (real-person nudify risk)."
+        )
+
+
+def _dna_is_intimate(dna: dict[str, Any]) -> bool:
+    notes = str(dna.get("nsfw_notes") or "")
+    if notes.strip():
+        return True
+    return is_intimate_text(
+        _join_fields(
+            [
+                dna.get("core_identity"),
+                dna.get("clothing_style"),
+                dna.get("nsfw_notes"),
+                dna.get("character_name"),
+            ]
+        )
+    )
+
+
+def _dna_has_reference(dna: dict[str, Any]) -> bool:
+    refs = dna.get("reference_image_ids") or []
+    if refs:
+        return True
+    source = str(dna.get("source") or "").lower()
+    return "upload" in source or "image" in source or "photo" in source
+
+
+def gate_dna(dna: dict[str, Any]) -> None:
+    blob = _join_fields(
+        [
+            dna.get("character_name"),
+            dna.get("core_identity"),
+            dna.get("facial_dna"),
+            dna.get("nsfw_notes"),
+            dna.get("subject_kind"),
+            dna.get("key_consistency_anchors"),
+        ]
+    )
+    gate_text(blob, nsfw=_dna_is_intimate(dna))
+    kind = str(dna.get("subject_kind") or "unspecified").strip().lower()
+    if kind and kind not in ALLOWED_SUBJECT_KINDS:
+        raise AUPGateError(f"Unknown subject_kind: {kind!r}")
+    if not _dna_is_intimate(dna):
+        return
+    require_attestation()
+    if kind != SUBJECT_KIND_IMAGINARY_ADULT:
+        raise AUPGateError(
+            "Intimate DNA requires subject_kind=imaginary_adult "
+            "(fictional adult, not a real person or lookalike)."
+        )
+    if _dna_has_reference(dna):
+        raise AUPGateError(
+            "Blocked: cannot lock uploaded / referenced photos into intimate "
+            "DNA (undress / right-of-publicity). Use text-only imaginary adults."
+        )

--- a/tools/batch_runner.py
+++ b/tools/batch_runner.py
@@ -9,6 +9,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
 
+from aup_gate import gate_imagine_prompt, gate_nsfw_shot
 from imagine_bridge import build_bridge_packet, bridge_to_markdown
 from imagine_client import (
     ImagineAPIError,
@@ -75,6 +76,9 @@ def execute_shot(
     if not shot:
         raise ValueError(f"Shot not found: {shot_id}")
 
+    if pipeline.name == "nsfw":
+        gate_nsfw_shot(shot, extra_prompt=prompt_override or "")
+
     if shot.get("status") not in ("scheduled", "pending", "qa_fail", "qa_pass"):
         if shot.get("quality_pass_status") == "quality_pass_pending":
             pass
@@ -90,6 +94,11 @@ def execute_shot(
     prompt = _build_shot_prompt(shot, override=prompt_override, prefix=pipeline.prompt_prefix)
     use_dry = is_dry_run() if dry_run is None else dry_run
     ref_url = _resolve_reference_url(shot)
+    gate_imagine_prompt(
+        prompt,
+        nsfw=pipeline.name == "nsfw",
+        has_reference_image=bool(ref_url),
+    )
 
     job_type = "video"
     img_model = shot.get("image_model", "grok-imagine-image")

--- a/tools/character_dna.py
+++ b/tools/character_dna.py
@@ -15,6 +15,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from aup_gate import gate_dna
 from models import build_video_pipeline_spec
 from project_state import load_project_state, save_project_state
 from studio_paths import CHARACTERS_DIR
@@ -57,6 +58,7 @@ def create_dna_scaffold(
     reference_image_ids: list[str] | None = None,
     nsfw_notes: str | None = None,
     source: str = "manual",
+    subject_kind: str = "unspecified",
 ) -> dict[str, Any]:
     """Create a v1.0 Character DNA profile scaffold."""
     anchors = key_anchors or []
@@ -82,6 +84,7 @@ def create_dna_scaffold(
         },
         "cinematic_viability_score": None,
         "nsfw_notes": nsfw_notes,
+        "subject_kind": subject_kind or "unspecified",
         "identity_lock_status": "pending",
         "studio_agent_version": STUDIO_AGENT_VERSION,
         "video_pipeline_spec": build_video_pipeline_spec(),
@@ -314,6 +317,7 @@ def character_dir(slug: str) -> Path:
 
 def save_character_dna(dna: dict[str, Any], *, characters_root: Path | None = None) -> tuple[Path, Path]:
     """Persist dna.json and dna.md under characters/{slug}/."""
+    gate_dna(dna)
     root = characters_root or CHARACTERS_DIR
     out_dir = root / dna["slug"]
     out_dir.mkdir(parents=True, exist_ok=True)
@@ -361,6 +365,7 @@ def lock_to_identity_bank(
     if state is None:
         state = load_project_state(state_file)
 
+    gate_dna(dna)
     prompts = build_prompt_blocks(dna)
     handoff = build_handoff_packet(dna)
     name = dna["character_name"]

--- a/tools/cli/help_ia.py
+++ b/tools/cli/help_ia.py
@@ -158,6 +158,7 @@ NESTED_MAPS: dict[str, dict[str, str]] = {
         "retry": "Quality",
     },
     "nsfw": {
+        "attest": "Plan",
         "plan": "Plan",
         "list": "Plan",
         "next": "Plan",

--- a/tools/cli/nsfw_commands.py
+++ b/tools/cli/nsfw_commands.py
@@ -12,6 +12,7 @@ from rich.markdown import Markdown
 from rich.panel import Panel
 from rich.table import Table
 
+from aup_gate import AUP_URL, AUPGateError, gate_nsfw_batch, require_attestation, write_attestation
 from models import DEFAULT_IMAGINE_VIDEO_MODEL
 from batch_runner import execute_nsfw_shot
 from quality_pass_scheduler import apply_quality_pass_promotion, get_pending_quality_passes
@@ -49,10 +50,45 @@ from cli.shared import AGENTS_DIR, STUDIO_ROOT, console
 from cli.spend_preflight import find_shot, preflight_spend, register_plate_motion_commands
 
 
+def _require_aup() -> None:
+    try:
+        require_attestation()
+    except AUPGateError as exc:
+        console.print(f"[red]{exc}[/red]")
+        raise typer.Exit(1) from exc
+
+
 def register(nsfw_app: typer.Typer, extend_app: typer.Typer) -> None:
     register_plate_motion_commands(
         nsfw_app, load_batch=load_batch, save_batch=save_batch
     )
+
+    @nsfw_app.command("attest")
+    def nsfw_attest(
+        i_am_18: bool = typer.Option(False, "--i-am-18", help="Operator is 18 or older"),
+        imaginary_adults: bool = typer.Option(False, "--imaginary-adults", help="Subjects are fictional adults"),
+        not_a_real_person: bool = typer.Option(False, "--not-a-real-person", help="No real-person likenesses"),
+        acknowledge_aup: bool = typer.Option(False, "--acknowledge-aup", help=f"Acknowledge {AUP_URL}"),
+    ):
+        """Write a local 18+ SpaceXAI AUP attestation (required before NSFW plan/run)."""
+        try:
+            payload = write_attestation(
+                age_18_plus=i_am_18,
+                imaginary_adults_only=imaginary_adults,
+                not_a_real_person=not_a_real_person,
+                aup_acknowledged=acknowledge_aup,
+            )
+        except AUPGateError as exc:
+            console.print(f"[red]{exc}[/red]")
+            raise typer.Exit(1) from exc
+        console.print(Panel(
+            f"Attested at {payload['attested_at']}\n"
+            f"Policy: {AUP_URL}\n"
+            "Limited R-rated fictional adult material of imaginary adults only.",
+            title="AUP attestation saved",
+            border_style="green",
+        ))
+
     @nsfw_app.command("plan")
     def nsfw_plan(
         title: str = typer.Argument(..., help="Batch title"),
@@ -65,6 +101,7 @@ def register(nsfw_app: typer.Typer, extend_app: typer.Typer) -> None:
         output: str = typer.Option(None, "--output", "-o", help="Save markdown plan"),
     ):
         """Plan a prioritized NSFW batch under Heavy subscription limits."""
+        _require_aup()
         shots: list[dict] = []
         if file:
             shots = json.loads(Path(file).read_text())
@@ -74,6 +111,12 @@ def register(nsfw_app: typer.Typer, extend_app: typer.Typer) -> None:
         if not shots:
             console.print("[red]Provide --file or at least one --shot[/red]")
             raise typer.Exit(1)
+
+        try:
+            gate_nsfw_batch(title, shots)
+        except AUPGateError as exc:
+            console.print(f"[red]{exc}[/red]")
+            raise typer.Exit(1) from exc
 
         batch = plan_batch(title, shots, tier=tier, budget_credits=budget, fast_mode=fast_mode, two_pass=two_pass)
         path = save_batch(batch)
@@ -155,10 +198,11 @@ def register(nsfw_app: typer.Typer, extend_app: typer.Typer) -> None:
         shot_tier: str = typer.Option("support", "--tier", help="Shot tier"),
         motion: str = typer.Option("medium", "--motion", help="low / medium / high"),
         has_ref: bool = typer.Option(False, "--has-ref", help="Approved reference image exists"),
-        explicit: str = typer.Option("moderate", "--explicit", help="suggestive / moderate / explicit"),
+        explicit: str = typer.Option("moderate", "--explicit", help="suggestive / moderate (R-rated cap)"),
         duration: float = typer.Option(10.0, "--duration", "-d"),
     ):
         """Recommend image_prompt vs image_to_video vs video_prompt."""
+        _require_aup()
         shot = build_shot_context(
             shot_id,
             tier=shot_tier,
@@ -190,9 +234,10 @@ def register(nsfw_app: typer.Typer, extend_app: typer.Typer) -> None:
         reason: str = typer.Option("physics_failure", "--reason", "-r", help="Failure reason key"),
         score: float = typer.Option(None, "--score", help="QA score received"),
         attempts: int = typer.Option(0, "--attempts", help="Prior attempt count"),
-        shot_tier: str = typer.Option("key_explicit", "--tier"),
+        shot_tier: str = typer.Option("key_intimate", "--tier"),
     ):
         """Suggest retry strategy after insufficient quality."""
+        _require_aup()
         shot = build_shot_context(
             shot_id,
             tier=shot_tier,
@@ -216,7 +261,7 @@ def register(nsfw_app: typer.Typer, extend_app: typer.Typer) -> None:
     def nsfw_run(
         batch_name: str = typer.Argument(..., help="Batch slug or ID"),
         shot_id: str = typer.Argument(..., help="Shot ID to execute"),
-        dry_run: bool = typer.Option(False, "--dry-run"),
+        dry_run: bool = typer.Option(True, "--dry-run/--live", help="Default dry-run. Pass --live only after AUP attestation."),
         prompt: str = typer.Option(None, "--prompt", "-p", help="Override generation prompt"),
         strict_plate: bool = typer.Option(
             False,
@@ -235,6 +280,7 @@ def register(nsfw_app: typer.Typer, extend_app: typer.Typer) -> None:
         ),
     ):
         """Execute a batch shot via Imagine API (image / i2v / video)."""
+        _require_aup()
         from imagine_client import ImagineAPIError
 
         batch = load_batch(batch_name)
@@ -276,7 +322,7 @@ def register(nsfw_app: typer.Typer, extend_app: typer.Typer) -> None:
     def nsfw_session(
         batch_name: str = typer.Argument(..., help="Batch slug or ID"),
         count: int = typer.Option(3, "--count", "-n"),
-        dry_run: bool = typer.Option(False, "--dry-run"),
+        dry_run: bool = typer.Option(True, "--dry-run/--live", help="Default dry-run. Pass --live only after AUP attestation."),
         stop_on_fail: bool = typer.Option(True, "--stop-on-fail/--continue-on-fail"),
         strict_plate: bool = typer.Option(
             False,
@@ -295,6 +341,7 @@ def register(nsfw_app: typer.Typer, extend_app: typer.Typer) -> None:
         ),
     ):
         """Run automated NSFW session — execute next priority shots."""
+        _require_aup()
         summary = run_batch_session(
             batch_name,
             pipeline="nsfw",

--- a/tools/imagine_client.py
+++ b/tools/imagine_client.py
@@ -16,8 +16,10 @@ import urllib.request
 import uuid
 from typing import Any
 
+from aup_gate import gate_imagine_prompt
 from imagine_regions import (
     FAILOVER_STATUS_CODES,
+    POLICY_FAIL_CLOSED_CODES,
     get_failover_chain,
     record_region_used,
     region_payload_fields,
@@ -119,6 +121,14 @@ def _request(
                 status=exc.code,
                 body=body,
             )
+            if exc.code in POLICY_FAIL_CLOSED_CODES:
+                last_error = ImagineAPIError(
+                    f"Imagine API {method.upper()} {path} failed ({exc.code}) region={reg} "
+                    "— fail closed (no region hop on 403/429 policy or rate-limit)",
+                    status=exc.code,
+                    body=body,
+                )
+                raise last_error from exc
             if exc.code in FAILOVER_STATUS_CODES and idx < len(regions) - 1:
                 record_region_used(reg, failed=True)
                 continue
@@ -160,6 +170,7 @@ def generate_image(
     dry_run: bool | None = None,
 ) -> dict[str, Any]:
     """Generate image(s) from a text prompt."""
+    gate_imagine_prompt(prompt, nsfw=False, has_reference_image=False)
     slug = resolve_image_model(model or DEFAULT_IMAGINE_IMAGE_MODEL)
     payload: dict[str, Any] = {"model": slug, "prompt": prompt, "n": n}
     if aspect_ratio:
@@ -193,6 +204,7 @@ def edit_image(
     dry_run: bool | None = None,
 ) -> dict[str, Any]:
     """Edit a source image with a natural-language prompt (up to 3 refs)."""
+    gate_imagine_prompt(prompt, nsfw=False, has_reference_image=True)
     slug = resolve_image_model(model or DEFAULT_IMAGINE_IMAGE_MODEL)
     extras = [u for u in (extra_image_urls or []) if u]
     if len(extras) > 2:
@@ -232,6 +244,11 @@ def submit_video_generation(
     dry_run: bool | None = None,
 ) -> dict[str, Any]:
     """Start async text-to-video, image-to-video, or reference-to-video."""
+    gate_imagine_prompt(
+        prompt,
+        nsfw=False,
+        has_reference_image=bool(image_url or image_file_id or reference_image_urls),
+    )
     refs = [u for u in (reference_image_urls or []) if u]
     voices = [v for v in (reference_audios or []) if v]
     has_image = bool((image_url or "").strip() or (image_file_id or "").strip())

--- a/tools/imagine_regions.py
+++ b/tools/imagine_regions.py
@@ -19,7 +19,9 @@ IMAGINE_REGIONS: dict[str, dict[str, Any]] = {
 }
 
 DEFAULT_REGION = "us-east-1"
-FAILOVER_STATUS_CODES = frozenset({403, 429, 500, 502, 503, 504})
+# 403/429 are policy, geo, or rate-limit denies — do not hop regions (AUP).
+POLICY_FAIL_CLOSED_CODES = frozenset({403, 429})
+FAILOVER_STATUS_CODES = frozenset({500, 502, 503, 504})
 
 
 def default_imagine_settings() -> dict[str, Any]:

--- a/tools/nsfw_config.py
+++ b/tools/nsfw_config.py
@@ -22,11 +22,11 @@ SHOT_TIERS: dict[str, dict[str, Any]] = {
         "label": "Consistency Anchor",
         "description": "Identity lock reference frames — generate before dependent shots",
     },
-    "key_explicit": {
+    "key_intimate": {
         "priority": 3,
         "budget_share": 0.35,
-        "label": "Key Explicit Moment",
-        "description": "Narrative-critical intimate beats with explicit intent",
+        "label": "Key Intimate Beat",
+        "description": "Narrative-critical R-rated implied intimacy (not pornographic)",
     },
     "support": {
         "priority": 4,
@@ -123,7 +123,7 @@ NSFW_ASSET_MODEL_MAP: dict[str, dict[str, Any]] = {
         "video_model": DEFAULT_IMAGINE_VIDEO_MODEL,
         "image_quality": True,
     },
-    "key_explicit": {
+    "key_intimate": {
         "asset_tier": "hero",
         "image_model": DEFAULT_IMAGE_QUALITY_MODEL,
         "video_model": DEFAULT_IMAGINE_VIDEO_MODEL,
@@ -149,9 +149,33 @@ NSFW_ASSET_MODEL_MAP: dict[str, dict[str, Any]] = {
     },
 }
 
+TIER_ALIASES: dict[str, str] = {"key_explicit": "key_intimate"}
+NSFW_ASSET_MODEL_MAP["key_explicit"] = NSFW_ASSET_MODEL_MAP["key_intimate"]
+
+
+def canonical_tier(tier: str | None) -> str:
+    """Map deprecated aliases (key_explicit) to canonical R-rated tiers."""
+    raw = (tier or "support").strip()
+    mapped = TIER_ALIASES.get(raw, raw)
+    return mapped if mapped in SHOT_TIERS else "support"
+
+
 SHOT_TIER_OPTIONS: tuple[str, ...] = tuple(
     sorted(SHOT_TIERS.keys(), key=lambda t: SHOT_TIERS[t]["priority"])
 )
 RETRY_REASON_OPTIONS: tuple[str, ...] = tuple(RETRY_STRATEGIES.keys())
 MOTION_OPTIONS: tuple[str, ...] = ("low", "medium", "high")
-EXPLICIT_OPTIONS: tuple[str, ...] = ("suggestive", "moderate", "explicit")
+EXPLICIT_OPTIONS: tuple[str, ...] = ("suggestive", "moderate")
+
+
+def canonical_explicit_level(level: str | None) -> str:
+    """R-rated intensities only. Full explicit is refused."""
+    raw = (level or "moderate").strip().lower()
+    if not raw:
+        return "moderate"
+    if raw in EXPLICIT_OPTIONS:
+        return raw
+    raise ValueError(
+        "explicit_level must be 'suggestive' or 'moderate' (R-rated). "
+        f"Got {raw!r}. Full explicit is not allowed on SpaceXAI Imagine."
+    )

--- a/tools/nsfw_decisions.py
+++ b/tools/nsfw_decisions.py
@@ -20,6 +20,7 @@ from nsfw_config import (
     QUALITY_THRESHOLD_HERO,
     QUALITY_THRESHOLD_PASS,
     RETRY_STRATEGIES,
+    canonical_tier,
 )
 
 
@@ -63,7 +64,7 @@ def estimate_shot_cost(
 
 
 def _tier(shot: dict[str, Any]) -> str:
-    return shot.get("tier", "support")
+    return canonical_tier(shot.get("tier", "support"))
 
 
 def _has_ref(shot: dict[str, Any]) -> bool:
@@ -94,7 +95,7 @@ GENERATION_MODE_RULES: tuple[ModeRule, ...] = (
         0.92,
     ),
     (
-        lambda s, _: _tier(s) in ("hero", "key_explicit") and _has_ref(s),
+        lambda s, _: _tier(s) in ("hero", "key_intimate") and _has_ref(s),
         "image_to_video",
         "High-impact shot with reference — i2v for fidelity",
         0.88,

--- a/tools/nsfw_shots.py
+++ b/tools/nsfw_shots.py
@@ -13,7 +13,7 @@ from models import (
 )
 
 from aspect_presets import apply_aspect_to_shot, default_aspect_for_tier, normalize_aspect, parse_aspect_from_spec
-from nsfw_config import NSFW_ASSET_MODEL_MAP, SHOT_TIERS
+from nsfw_config import NSFW_ASSET_MODEL_MAP, SHOT_TIERS, canonical_explicit_level, canonical_tier
 from nsfw_decisions import decide_generation_mode, estimate_shot_cost
 from nsfw_util import now_iso
 
@@ -33,10 +33,10 @@ def build_shot_context(
     """Canonical shot dict for decide/retry flows (CLI + Web UI)."""
     ctx: dict[str, Any] = {
         "shot_id": shot_id,
-        "tier": tier if tier in SHOT_TIERS else "support",
+        "tier": canonical_tier(tier),
         "motion_complexity": motion,
         "has_reference": has_ref,
-        "explicit_level": explicit,
+        "explicit_level": canonical_explicit_level(explicit),
         "duration_seconds": duration,
         "consistency_required": consistency_required,
     }
@@ -60,7 +60,7 @@ def parse_inline_shot(spec: str) -> dict[str, Any]:
     else:
         tier, motion, desc = "support", "medium", spec
     shot = {
-        "tier": tier.strip(),
+        "tier": canonical_tier(tier),
         "description": desc.strip(),
         "motion_complexity": motion.strip(),
     }
@@ -70,7 +70,8 @@ def parse_inline_shot(spec: str) -> dict[str, Any]:
 
 def apply_reference_curator_models(shot: dict[str, Any]) -> dict[str, Any]:
     """Assign image/video model slugs per Reference & Asset Curator NSFW tier map."""
-    tier = shot.get("tier", "support")
+    tier = canonical_tier(shot.get("tier", "support"))
+    shot["tier"] = tier
     mapping = NSFW_ASSET_MODEL_MAP.get(tier, NSFW_ASSET_MODEL_MAP["support"])
     shot["asset_tier"] = mapping["asset_tier"]
     shot["image_model"] = mapping["image_model"]
@@ -102,8 +103,7 @@ def create_shot(
     explicit_level: str = "moderate",
     image_quality: bool = False,
 ) -> dict[str, Any]:
-    if tier not in SHOT_TIERS:
-        tier = "support"
+    tier = canonical_tier(tier)
     sid = shot_id or f"shot_{tier[:3]}_{datetime.now().strftime('%H%M%S')}"
     shot = {
         "shot_id": sid,
@@ -113,7 +113,7 @@ def create_shot(
         "has_reference": has_reference,
         "consistency_required": consistency_required,
         "motion_complexity": motion_complexity,
-        "explicit_level": explicit_level,
+        "explicit_level": canonical_explicit_level(explicit_level),
         "image_quality": image_quality,
         "status": "pending",
         "attempts": [],

--- a/web_ui/lib/nsfw_runtime.py
+++ b/web_ui/lib/nsfw_runtime.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from aup_gate import gate_nsfw_batch, gate_nsfw_shot
 from nsfw_orchestrator import (
     EXPLICIT_OPTIONS,
     MOTION_OPTIONS,
@@ -52,7 +53,14 @@ def plan_and_save_batch(
     budget_credits: float | None = None,
     fast_mode: bool = False,
 ) -> tuple[dict[str, Any], str]:
-    batch = plan_batch(title, shots, tier=tier, budget_credits=budget_credits, fast_mode=fast_mode)
+    normalized: list[dict[str, Any]] = []
+    for item in shots:
+        if isinstance(item, str):
+            normalized.append(parse_inline_shot(item))
+        else:
+            normalized.append(item)
+    gate_nsfw_batch(title, normalized)
+    batch = plan_batch(title, normalized, tier=tier, budget_credits=budget_credits, fast_mode=fast_mode)
     path = save_batch(batch)
     return batch, str(path)
 
@@ -80,6 +88,7 @@ def mode_decision(
         explicit=explicit,
         duration=duration,
     )
+    gate_nsfw_shot(shot)
     if budget_remaining is None:
         budget_remaining = load_project_state().get("quota", {}).get("budget_remaining")
     return decide_generation_mode(shot, budget_remaining=budget_remaining)

--- a/web_ui/pages/settings.py
+++ b/web_ui/pages/settings.py
@@ -150,11 +150,38 @@ def render() -> None:
     )
 
     st.divider()
-    st.subheader("🔞 NSFW pipelines")
-    st.session_state.nsfw_opt_in = st.checkbox(
-        "Enable NSFW planning tools",
-        value=st.session_state.nsfw_opt_in,
-        help="Unlocks the NSFW page. Explicit ErosForge activation still required in Grok.",
+    st.subheader("🔞 NSFW pipelines (18+ / SpaceXAI AUP)")
+    st.markdown(
+        "Limited **R-rated fictional adult** material of **imaginary adults** only. "
+        "Not affiliated with xAI / SpaceXAI. Policy: "
+        "[Acceptable Use Policy](https://x.ai/legal/acceptable-use-policy)"
     )
-    if st.session_state.nsfw_opt_in:
-        st.caption("Open the **NSFW** page to plan batches and extensions.")
+    age_ok = st.checkbox("I am 18 or older", value=False, key="aup_age")
+    imag_ok = st.checkbox("Subjects are fictional imaginary adults", value=False, key="aup_imaginary")
+    real_ok = st.checkbox("I will not use real-person photos or likenesses", value=False, key="aup_not_real")
+    aup_ok = st.checkbox("I acknowledge the SpaceXAI Acceptable Use Policy", value=False, key="aup_ack")
+    can_enable = age_ok and imag_ok and real_ok and aup_ok
+    if not can_enable:
+        st.session_state.nsfw_opt_in = False
+        st.caption("All four attestations are required. A Settings checkbox alone is not enough.")
+    else:
+        from aup_gate import write_attestation
+
+        try:
+            write_attestation(
+                age_18_plus=True,
+                imaginary_adults_only=True,
+                not_a_real_person=True,
+                aup_acknowledged=True,
+            )
+        except Exception as exc:
+            st.error(str(exc))
+            st.session_state.nsfw_opt_in = False
+        else:
+            st.session_state.nsfw_opt_in = st.checkbox(
+                "Enable NSFW planning tools",
+                value=st.session_state.nsfw_opt_in,
+                help="Unlocks the NSFW page after AUP attestation.",
+            )
+            if st.session_state.nsfw_opt_in:
+                st.caption("Open the **NSFW** page. Live Imagine calls still default to dry-run.")


### PR DESCRIPTION
## Summary

Ports the SpaceXAI AUP fail-closed layer onto **current `main` (v3.11.0)**.

Supersedes #35, which was cut from v3.6.5 and was ~533 commits behind (`mergeable_state: dirty`). #35 is closed.

Policy: https://x.ai/legal/acceptable-use-policy

Unofficial third-party studio — not affiliated with xAI or SpaceXAI.

## What landed

- `tools/aup_gate.py` — 18+ local attestation, imaginary adults only, no real-person refs, R-rated cap, CSAM-stub refuse
- `nsfw attest` + plan/run/session require attestation; `nsfw run`/`session` default **dry-run** (`--live` to generate)
- Imagine **403/429 do not hop regions**
- Shot tier `key_explicit` → `key_intimate` (alias kept); full-explicit intensity refused at shot build
- v3.11 modular pack `grok-imagine-nsfw` described as 18+ AUP opt-in (runtime gates still apply even if the full suite is installed)
- README third-party disclaimer; Web UI four-checkbox attestation

## Tests

- `tests/test_aup_gate.py`
- CLI smoke (help IA includes `nsfw attest`)
- `nsfw plan` without attestation exits 1

## Out of scope

Termux overlay files are still untracked.