### PR TITLE
fix(docs): leftover 3.11.1 fallbacks and guides

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -14,7 +14,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio.git",
-        "sha": "433999c22566cee541740fe2bc904864d462ceef"
+        "sha": "c1a6d1223ff087827bd727cd67824e3ebf6e6416"
       },
       "homepage": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio",
       "keywords": [
@@ -31,7 +31,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio.git",
-        "sha": "433999c22566cee541740fe2bc904864d462ceef"
+        "sha": "c1a6d1223ff087827bd727cd67824e3ebf6e6416"
       },
       "homepage": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio",
       "keywords": [
@@ -49,7 +49,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio.git",
-        "sha": "433999c22566cee541740fe2bc904864d462ceef"
+        "sha": "c1a6d1223ff087827bd727cd67824e3ebf6e6416"
       },
       "homepage": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio",
       "keywords": [
@@ -69,7 +69,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio.git",
-        "sha": "433999c22566cee541740fe2bc904864d462ceef"
+        "sha": "c1a6d1223ff087827bd727cd67824e3ebf6e6416"
       },
       "homepage": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio",
       "keywords": [
@@ -89,7 +89,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio.git",
-        "sha": "433999c22566cee541740fe2bc904864d462ceef"
+        "sha": "c1a6d1223ff087827bd727cd67824e3ebf6e6416"
       },
       "homepage": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio",
       "keywords": [
@@ -109,7 +109,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio.git",
-        "sha": "433999c22566cee541740fe2bc904864d462ceef"
+        "sha": "c1a6d1223ff087827bd727cd67824e3ebf6e6416"
       },
       "homepage": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio",
       "keywords": [

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -308,7 +308,7 @@
           }
         ]
       },
-      "sha": "433999c22566cee541740fe2bc904864d462ceef"
+      "sha": "c1a6d1223ff087827bd727cd67824e3ebf6e6416"
     },
     "grok-imagine-cinematic-core": {
       "components": {
@@ -445,7 +445,7 @@
           }
         ]
       },
-      "sha": "433999c22566cee541740fe2bc904864d462ceef"
+      "sha": "c1a6d1223ff087827bd727cd67824e3ebf6e6416"
     },
     "grok-imagine-camera-image": {
       "components": {
@@ -496,7 +496,7 @@
           }
         ]
       },
-      "sha": "433999c22566cee541740fe2bc904864d462ceef"
+      "sha": "c1a6d1223ff087827bd727cd67824e3ebf6e6416"
     },
     "grok-imagine-sequence-narrative": {
       "components": {
@@ -579,7 +579,7 @@
           }
         ]
       },
-      "sha": "433999c22566cee541740fe2bc904864d462ceef"
+      "sha": "c1a6d1223ff087827bd727cd67824e3ebf6e6416"
     },
     "grok-imagine-nsfw": {
       "components": {
@@ -608,7 +608,7 @@
           }
         ]
       },
-      "sha": "433999c22566cee541740fe2bc904864d462ceef"
+      "sha": "c1a6d1223ff087827bd727cd67824e3ebf6e6416"
     },
     "grok-imagine-delivery-post": {
       "components": {
@@ -649,7 +649,7 @@
           }
         ]
       },
-      "sha": "433999c22566cee541740fe2bc904864d462ceef"
+      "sha": "c1a6d1223ff087827bd727cd67824e3ebf6e6416"
     }
   }
 }

--- a/docs/guides/UPGRADE_GUIDE.md
+++ b/docs/guides/UPGRADE_GUIDE.md
@@ -1,11 +1,20 @@
 # Grok Imagine Cinematic Studio — UPGRADE GUIDE
 
-**Current target:** **v3.11.0** — unified **Grok 4.6** cinematic+Build (`grok-4.5` aliases wrap 4.6) · Grok Build ≥ **1.0.5** · Model Layer v4.5 (v9-4p5 / `grok-4-auto`) · optional **Grok 4.3** 1M · Imagine Agent Mode Handoff · Identity Continuity · **64 skills** · packs + `full_suite_wins`
+**Current target:** **v3.11.1** — SpaceXAI AUP fail-closed gates · CLI help IA · unified **Grok 4.6** cinematic+Build (`grok-4.5` aliases wrap 4.6) · Grok Build ≥ **1.0.5** · Model Layer v4.5 (v9-4p5 / `grok-4-auto`) · optional **Grok 4.3** 1M · Imagine Agent Mode Handoff · Identity Continuity · **64 skills** · packs + `full_suite_wins`
 
-**Quick path to current:** pull `main` → `models verify` → reinstall plugin if local clone is stale → activate `Activate Grok Imagine Cinematic Studio v3.11.0`  
+**Quick path to current:** pull `main` → `models verify` → reinstall plugin if local clone is stale → activate `Activate Grok Imagine Cinematic Studio v3.11.1`  
 **Day-to-day docs:** `docs/guides/Quick_Start_Guide.md` · `docs/guides/installation_guide.md` · `references/agents/MODEL_LAYER_v4.5.md`
 
-**Date:** August 22, 2026 (header); sections below retain historical upgrade notes from earlier 3.7.x / 3.8.x / 3.9.x waves.
+**Date:** September 2, 2026 (header); sections below retain historical upgrade notes from earlier 3.7.x / 3.8.x / 3.9.x / 3.11.0 waves.
+
+---
+
+## Upgrade to v3.11.1 (from 3.11.0)
+
+1. Pull / reinstall: `git pull` or `bash scripts/cinematic_studio.sh update` / `grok plugin update grok-imagine-cinematic-studio`
+2. Confirm `VERSION` is **3.11.1** and `python tools/cinematic_studio_cli.py models verify` still shows Grok **4.6** cinematic+Build and CLI min **1.0.5**
+3. NSFW spend requires `cinematic-studio nsfw attest` (18+ / imaginary adults / R-rated / AUP)
+4. Activation: `Activate Grok Imagine Cinematic Studio v3.11.1`
 
 ---
 
@@ -15,7 +24,7 @@
 2. Confirm `VERSION` is **3.11.0** and `python tools/cinematic_studio_cli.py models verify` shows Grok **4.6** cinematic+Build and CLI min **1.0.5**
 3. Set `~/.grok/config.toml`: `[models] default = "grok-4.6"` · `[ui] fork_secondary_model = "grok-build"` (or `grok-4.6`). `grok-4.5` aliases still wrap 4.6
 4. Upgrade Grok Build binary: `cinematic-studio grok ensure` (or `grok update`) until `grok --version` is ≥ **1.0.5**
-5. Activation: `Activate Grok Imagine Cinematic Studio v3.11.0`
+5. Activation: `Activate Grok Imagine Cinematic Studio v3.11.1`
 6. Contributors: content commit → `bash scripts/release_plugin_catalog.sh` → commit only `.grok-plugin/` → `bash scripts/verify_plugins.sh --release`
 
 ---
@@ -25,7 +34,7 @@
 1. Pull / reinstall: `git pull` or `bash scripts/cinematic_studio.sh update` / reinstall Method B from clone if `plugin update` no-ops on local installs
 2. Confirm `VERSION` is **3.10.0** and `python tools/cinematic_studio_cli.py models verify` shows Grok **4.5** cinematic+Build (3.11.0 locks **4.6**)
 3. Hero stills / Quality Mode / Identity plates route to **Image 2.0** (`grok-imagine-image-2.0`). There is **no Video 2.0**.
-4. Activation (current): `Activate Grok Imagine Cinematic Studio v3.11.0`
+4. Activation (current): `Activate Grok Imagine Cinematic Studio v3.11.1`
 5. Surfaces: `references/agents/IMAGINE_SURFACES.md` (Agent Mode A–E, including `xai_responses_tool`)
 6. REST: `cinematic-studio imagine submit` now covers `video_edit` / `video_extend` / `reference_to_video` plus `--resolution` `--quality` `--file-id` `--voice-id`
 7. Contributors: content commit → `bash scripts/release_plugin_catalog.sh` → commit only `.grok-plugin/` → `bash scripts/verify_plugins.sh --release`
@@ -37,7 +46,7 @@
 1. Pull / reinstall: `git pull` or `bash scripts/cinematic_studio.sh update` / reinstall Method B from clone if `plugin update` no-ops on local installs  
 2. Confirm `VERSION` is **3.8.7** and `python tools/cinematic_studio_cli.py models verify` shows Grok **4.5** cinematic+Build  
 3. Set `~/.grok/config.toml`: `[models] default = "grok-4.6"` · `[ui] fork_secondary_model = "grok-build"`  
-4. Activation: `Activate Grok Imagine Cinematic Studio v3.11.0`  
+4. Activation: `Activate Grok Imagine Cinematic Studio v3.11.1`  
 5. Model Layer: `references/agents/MODEL_LAYER_v4.5.md` (not the archived `MODEL_LAYER_v3.7.1.md`)  
 6. Contributors: content commit → `bash scripts/release_plugin_catalog.sh` → commit only `.grok-plugin/` → `bash scripts/verify_plugins.sh --release`
 
@@ -48,7 +57,7 @@
 1. Pull / reinstall the repo or run `bash scripts/cinematic_studio.sh update` / `grok plugin update grok-imagine-cinematic-studio`
 2. Confirm models verify shows Grok **4.5** cinematic+Build
 3. Set `~/.grok/config.toml` defaults: `[models] default = "grok-4.6"` · `[ui] fork_secondary_model = "grok-build"`
-4. Activation phrase: `Activate Grok Imagine Cinematic Studio v3.11.0` (current) — historical 3.7.1 phrase is obsolete
+4. Activation phrase: `Activate Grok Imagine Cinematic Studio v3.11.1` (current) — historical 3.7.1 phrase is obsolete
 5. Prefer `references/agents/MODEL_LAYER_v4.5.md` and `IMAGINE_AGENT_MODE_HANDOFF_v3.7.1.md` (handoff feature still current under studio 3.8.7)
 6. Re-pin plugin catalog after skill edits: `bash scripts/release_plugin_catalog.sh`
 
@@ -161,7 +170,7 @@ python tools/cinematic_studio_cli.py models verify
 ### Step 2: Activate the New Studio
 In a new **Grok 4.5** chat (default) or **Grok 4.3** for very long Bibles, paste `MASTER_PROMPT.md` and type:
 ```
-Activate Grok Imagine Cinematic Studio v3.11.0
+Activate Grok Imagine Cinematic Studio v3.11.1
 ```
 
 Or use the powerful new mode:
@@ -216,7 +225,7 @@ Free-text logline/characters/world/tech notes roll into `notes`. Stages live in 
 
 ## Recommended New Workflow (v3.7.1)
 
-1. **Primary Activation** — `Activate Grok Imagine Cinematic Studio v3.11.0` or `ACTIVATE IMAGINE_VIDEO_1.5_FULL`
+1. **Primary Activation** — `Activate Grok Imagine Cinematic Studio v3.11.1` or `ACTIVATE IMAGINE_VIDEO_1.5_FULL`
 2. **Production Bible** — `create-bible "Title"` (scripts) or `create-bible --wizard` (guided TTY) / Web Guided Bible Creator
 3. **Use VIDEO_PIPELINE_SPEC** — 1.0 cost default; 1.5 when native audio is required
 4. **Activate Sonic Architect early** when native audio is important

--- a/docs/guides/USER_GUIDE.md
+++ b/docs/guides/USER_GUIDE.md
@@ -1,12 +1,12 @@
 # User Guide
-## Grok Imagine Cinematic Studio v3.11.0
+## Grok Imagine Cinematic Studio v3.11.1
 
 Complete end-to-end guide for creators — from first Activate through delivery.
 
 > [!NOTE]
 > **Grok Imagine Cinematic Studio** is an **independent community project**. It is **not affiliated with, endorsed by, sponsored by, or officially connected to xAI**. Full notice: [DISCLAIMER.md](../../DISCLAIMER.md).
 
-**Version:** 3.10.0 · **Last updated:** August 2026  
+**Version:** 3.11.1 · **Last updated:** September 2026  
 **Suite:** 25+ Role-Card agents · **64 skills** · full suite + 5 packs  
 **Canonical manual:** [OFFICIAL_DOCUMENTATION.md](../OFFICIAL_DOCUMENTATION.md)
 
@@ -17,7 +17,7 @@ Complete end-to-end guide for creators — from first Activate through delivery.
 ### Primary (any Grok chat)
 
 ```text
-Activate Grok Imagine Cinematic Studio v3.11.0
+Activate Grok Imagine Cinematic Studio v3.11.1
 ```
 
 Alternative triggers:
@@ -48,7 +48,7 @@ Exit cinematic studio
 
 ### Phase 1 — Project Setup
 
-1. Activate the Studio (**v3.11.0**).
+1. Activate the Studio (**v3.11.1**).
 2. Create / lock the **Production Bible**  
    (`cinematic-studio create-bible --wizard` or ask Studio Director / Guided Bible in Streamlit).
 3. Declare **`model_stack`** + **`VIDEO_PIPELINE_SPEC`**:
@@ -110,7 +110,7 @@ Orient → Health → Produce → Gate → Converge & Deliver
 | **Gate** | Identity · plate/motion · chain QA · `handoff validate` |
 | **Deliver** | Convergence checklist · Wave A briefs · polish/deliver readiness · bridge preview |
 
-**TUI density (v3.11.0):** `1` compact · `2` ops · `3` full · `Tab` cycle · `p` pause refresh.
+**TUI density:** `1` compact · `2` ops · `3` full · `Tab` cycle · `p` pause refresh.
 
 **Deep dive:** [OPERATOR_CONTROL_PLANE.md](OPERATOR_CONTROL_PLANE.md).
 
@@ -170,7 +170,7 @@ cinematic-studio wave-a validate
 
 | Intent | Command |
 |--------|---------|
-| Start Studio | `Activate Grok Imagine Cinematic Studio v3.11.0` |
+| Start Studio | `Activate Grok Imagine Cinematic Studio v3.11.1` |
 | New project / Bible | Ask Studio Director or CLI wizard |
 | Lock character | `ACTIVATE IDENTITY_LOCK` / DNA tools |
 | Wardrobe lock | `ACTIVATE COSTUME_WARDROBE` |
@@ -261,4 +261,4 @@ See [CLI_REFERENCE.md](../CLI_REFERENCE.md) for the full command set (including 
 
 *You are the director. The Studio exists to execute your vision with professional discipline.*
 
-*Grok Imagine Cinematic Studio v3.11.0 — User Guide · Independent community project · Not affiliated with xAI*
+*Grok Imagine Cinematic Studio v3.11.1 — User Guide · Independent community project · Not affiliated with xAI*

--- a/studio_api/app.py
+++ b/studio_api/app.py
@@ -17,9 +17,9 @@ if str(_TOOLS) not in sys.path:
 def _studio_version() -> str:
     vf = _ROOT / "VERSION"
     try:
-        return vf.read_text(encoding="utf-8").strip() or "3.10.0"
+        return vf.read_text(encoding="utf-8").strip() or "3.11.1"
     except OSError:
-        return "3.10.0"
+        return "3.11.1"
 
 
 def _execute_body_model():

--- a/web_ui/lib/runtime.py
+++ b/web_ui/lib/runtime.py
@@ -17,7 +17,7 @@ sys.path.insert(0, str(ROOT / "tools"))
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-STUDIO_VERSION = "3.11.0"
+STUDIO_VERSION = "3.11.1"
 ACTIVATION_PHRASE = f"Activate Grok Imagine Cinematic Studio v{STUDIO_VERSION}"
 AGENTS_DIR = ROOT / "references" / "agents"
 ROLE_CARD_PREVIEW_CHARS = 4000


### PR DESCRIPTION
Follow-up to v3.11.1. Four stamps still said 3.11.0 / 3.10.0 after the tag.

- `web_ui/lib/runtime.py` — Streamlit fallback `STUDIO_VERSION` **3.11.1** (live path still imports CLI `VERSION`)
- `studio_api/app.py` — missing-`VERSION` fallback **3.11.1** (was 3.10.0)
- `docs/guides/UPGRADE_GUIDE.md` — current target + new 3.11.1 upgrade section
- `docs/guides/USER_GUIDE.md` — header, activation, footer

No catalog pin (docs/fallback only).