### PR TITLE
fix(aup): fail-closed gate on video edit and extend

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -14,7 +14,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio.git",
-        "sha": "c1a6d1223ff087827bd727cd67824e3ebf6e6416"
+        "sha": "493141b6000e877097141316286603dc2e10eb26"
       },
       "homepage": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio",
       "keywords": [
@@ -31,7 +31,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio.git",
-        "sha": "c1a6d1223ff087827bd727cd67824e3ebf6e6416"
+        "sha": "493141b6000e877097141316286603dc2e10eb26"
       },
       "homepage": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio",
       "keywords": [
@@ -49,7 +49,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio.git",
-        "sha": "c1a6d1223ff087827bd727cd67824e3ebf6e6416"
+        "sha": "493141b6000e877097141316286603dc2e10eb26"
       },
       "homepage": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio",
       "keywords": [
@@ -69,7 +69,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio.git",
-        "sha": "c1a6d1223ff087827bd727cd67824e3ebf6e6416"
+        "sha": "493141b6000e877097141316286603dc2e10eb26"
       },
       "homepage": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio",
       "keywords": [
@@ -89,7 +89,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio.git",
-        "sha": "c1a6d1223ff087827bd727cd67824e3ebf6e6416"
+        "sha": "493141b6000e877097141316286603dc2e10eb26"
       },
       "homepage": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio",
       "keywords": [
@@ -109,7 +109,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio.git",
-        "sha": "c1a6d1223ff087827bd727cd67824e3ebf6e6416"
+        "sha": "493141b6000e877097141316286603dc2e10eb26"
       },
       "homepage": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio",
       "keywords": [

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -308,7 +308,7 @@
           }
         ]
       },
-      "sha": "c1a6d1223ff087827bd727cd67824e3ebf6e6416"
+      "sha": "493141b6000e877097141316286603dc2e10eb26"
     },
     "grok-imagine-cinematic-core": {
       "components": {
@@ -445,7 +445,7 @@
           }
         ]
       },
-      "sha": "c1a6d1223ff087827bd727cd67824e3ebf6e6416"
+      "sha": "493141b6000e877097141316286603dc2e10eb26"
     },
     "grok-imagine-camera-image": {
       "components": {
@@ -496,7 +496,7 @@
           }
         ]
       },
-      "sha": "c1a6d1223ff087827bd727cd67824e3ebf6e6416"
+      "sha": "493141b6000e877097141316286603dc2e10eb26"
     },
     "grok-imagine-sequence-narrative": {
       "components": {
@@ -579,7 +579,7 @@
           }
         ]
       },
-      "sha": "c1a6d1223ff087827bd727cd67824e3ebf6e6416"
+      "sha": "493141b6000e877097141316286603dc2e10eb26"
     },
     "grok-imagine-nsfw": {
       "components": {
@@ -608,7 +608,7 @@
           }
         ]
       },
-      "sha": "c1a6d1223ff087827bd727cd67824e3ebf6e6416"
+      "sha": "493141b6000e877097141316286603dc2e10eb26"
     },
     "grok-imagine-delivery-post": {
       "components": {
@@ -649,7 +649,7 @@
           }
         ]
       },
-      "sha": "c1a6d1223ff087827bd727cd67824e3ebf6e6416"
+      "sha": "493141b6000e877097141316286603dc2e10eb26"
     }
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to Grok Imagine Cinematic Studio will be documented in this 
 
 ## [Unreleased]
 
+### Fixed
+- **AUP on video edit/extend** — `submit_video_edit` and `submit_video_extension` now run the same fail-closed Imagine prompt gate as generate/edit/i2v (CSAM always; attestation when intimate). Sequence extend and `imagine submit` video_edit/video_extend can no longer skip AUP.
+
 ## [3.11.1] - 2026-09-02
 
 ### Added

--- a/tests/test_aup_gate.py
+++ b/tests/test_aup_gate.py
@@ -234,6 +234,54 @@ def test_sfw_dna_with_refs_still_allowed() -> None:
     )
 
 
+def test_video_extend_csam_refused() -> None:
+    from imagine_client import submit_video_extension
+
+    try:
+        submit_video_extension(
+            "underage character study",
+            video_url="https://example.invalid/clip.mp4",
+            dry_run=True,
+        )
+        raise AssertionError("expected AUPGateError")
+    except AUPGateError as exc:
+        assert "minor-coded" in str(exc) or "CSAM" in str(exc)
+
+
+def test_video_edit_intimate_requires_attestation() -> None:
+    from imagine_client import submit_video_edit
+
+    os.environ[ATTESTATION_ENV] = "/nonexistent-aup-attestation.json"
+    try:
+        try:
+            submit_video_edit(
+                "erotic candlelit two-shot",
+                video_url="https://example.invalid/clip.mp4",
+                dry_run=True,
+            )
+            raise AssertionError("expected AUPGateError")
+        except AUPGateError as exc:
+            assert "attest" in str(exc)
+    finally:
+        os.environ.pop(ATTESTATION_ENV, None)
+
+
+def test_video_extend_attested_intimate_allowed() -> None:
+    from imagine_client import submit_video_extension
+
+    path, _ = _attest_env()
+    try:
+        resp = submit_video_extension(
+            "erotic clothing-on R-rated continuation",
+            video_url="https://example.invalid/clip.mp4",
+            dry_run=True,
+        )
+        assert resp.get("dry_run") is True
+        assert resp.get("mode") == "video_extend"
+    finally:
+        _cleanup(path)
+
+
 def test_imagine_edit_intimate_plus_source_image_refused() -> None:
     path, _ = _attest_env()
     try:

--- a/tools/imagine_client.py
+++ b/tools/imagine_client.py
@@ -159,6 +159,11 @@ def _media_object(*, url: str | None = None, file_id: str | None = None) -> dict
     raise ImagineAPIError("url or file_id required")
 
 
+def _gate_spend(prompt: str, *, has_reference_image: bool = False) -> None:
+    """Fail-closed AUP on every Imagine spend path (CSAM always; attest if intimate)."""
+    gate_imagine_prompt(prompt, nsfw=False, has_reference_image=has_reference_image)
+
+
 def generate_image(
     prompt: str,
     *,
@@ -170,7 +175,7 @@ def generate_image(
     dry_run: bool | None = None,
 ) -> dict[str, Any]:
     """Generate image(s) from a text prompt."""
-    gate_imagine_prompt(prompt, nsfw=False, has_reference_image=False)
+    _gate_spend(prompt, has_reference_image=False)
     slug = resolve_image_model(model or DEFAULT_IMAGINE_IMAGE_MODEL)
     payload: dict[str, Any] = {"model": slug, "prompt": prompt, "n": n}
     if aspect_ratio:
@@ -204,7 +209,7 @@ def edit_image(
     dry_run: bool | None = None,
 ) -> dict[str, Any]:
     """Edit a source image with a natural-language prompt (up to 3 refs)."""
-    gate_imagine_prompt(prompt, nsfw=False, has_reference_image=True)
+    _gate_spend(prompt, has_reference_image=True)
     slug = resolve_image_model(model or DEFAULT_IMAGINE_IMAGE_MODEL)
     extras = [u for u in (extra_image_urls or []) if u]
     if len(extras) > 2:
@@ -244,9 +249,8 @@ def submit_video_generation(
     dry_run: bool | None = None,
 ) -> dict[str, Any]:
     """Start async text-to-video, image-to-video, or reference-to-video."""
-    gate_imagine_prompt(
+    _gate_spend(
         prompt,
-        nsfw=False,
         has_reference_image=bool(image_url or image_file_id or reference_image_urls),
     )
     refs = [u for u in (reference_image_urls or []) if u]
@@ -312,6 +316,8 @@ def submit_video_edit(
     dry_run: bool | None = None,
 ) -> dict[str, Any]:
     """Edit an existing clip (Video 1.0 only — 1.5 returns failed_precondition)."""
+    # Source clip is studio media, not a still-ref nudify path.
+    _gate_spend(prompt, has_reference_image=False)
     slug = resolve_video_model(model or EDIT_EXTEND_VIDEO_MODEL)
     if not video_supports_mode(slug, "edit"):
         slug = resolve_video_model(EDIT_EXTEND_VIDEO_MODEL)
@@ -347,6 +353,8 @@ def submit_video_extension(
     dry_run: bool | None = None,
 ) -> dict[str, Any]:
     """Start async video extension from an existing clip (Video 1.0)."""
+    # Sequence extend must still refuse CSAM / unattested intimate prompts.
+    _gate_spend(prompt, has_reference_image=False)
     slug = resolve_video_model(model or EDIT_EXTEND_VIDEO_MODEL)
     if not video_supports_mode(slug, "extend"):
         slug = resolve_video_model(EDIT_EXTEND_VIDEO_MODEL)


### PR DESCRIPTION
## Gap
`submit_video_edit` and `submit_video_extension` posted to xAI with **no** `aup_gate` call. `sequence run` extend and `imagine submit` `video_edit` / `video_extend` could spend without CSAM or attestation checks.

## Patch
- All Imagine spend functions go through `_gate_spend` (CSAM always; attest when intimate).
- Source-clip edit/extend does **not** use the still-ref nudify block, so attested R-rated sequence extend still works.
- Tests: CSAM on extend, intimate edit without attest, attested intimate extend dry-run.

Harper: AUP suite **19/19**. Catalog pin SHA `493141b`.