### PR TITLE
test(aup): run video edit/extend gates from file harness

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -14,7 +14,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio.git",
-        "sha": "493141b6000e877097141316286603dc2e10eb26"
+        "sha": "ce0fa9863befd51d36bd6d9ca95fcf47630f4188"
       },
       "homepage": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio",
       "keywords": [
@@ -31,7 +31,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio.git",
-        "sha": "493141b6000e877097141316286603dc2e10eb26"
+        "sha": "ce0fa9863befd51d36bd6d9ca95fcf47630f4188"
       },
       "homepage": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio",
       "keywords": [
@@ -49,7 +49,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio.git",
-        "sha": "493141b6000e877097141316286603dc2e10eb26"
+        "sha": "ce0fa9863befd51d36bd6d9ca95fcf47630f4188"
       },
       "homepage": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio",
       "keywords": [
@@ -69,7 +69,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio.git",
-        "sha": "493141b6000e877097141316286603dc2e10eb26"
+        "sha": "ce0fa9863befd51d36bd6d9ca95fcf47630f4188"
       },
       "homepage": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio",
       "keywords": [
@@ -89,7 +89,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio.git",
-        "sha": "493141b6000e877097141316286603dc2e10eb26"
+        "sha": "ce0fa9863befd51d36bd6d9ca95fcf47630f4188"
       },
       "homepage": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio",
       "keywords": [
@@ -109,7 +109,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio.git",
-        "sha": "493141b6000e877097141316286603dc2e10eb26"
+        "sha": "ce0fa9863befd51d36bd6d9ca95fcf47630f4188"
       },
       "homepage": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio",
       "keywords": [

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -308,7 +308,7 @@
           }
         ]
       },
-      "sha": "493141b6000e877097141316286603dc2e10eb26"
+      "sha": "ce0fa9863befd51d36bd6d9ca95fcf47630f4188"
     },
     "grok-imagine-cinematic-core": {
       "components": {
@@ -445,7 +445,7 @@
           }
         ]
       },
-      "sha": "493141b6000e877097141316286603dc2e10eb26"
+      "sha": "ce0fa9863befd51d36bd6d9ca95fcf47630f4188"
     },
     "grok-imagine-camera-image": {
       "components": {
@@ -496,7 +496,7 @@
           }
         ]
       },
-      "sha": "493141b6000e877097141316286603dc2e10eb26"
+      "sha": "ce0fa9863befd51d36bd6d9ca95fcf47630f4188"
     },
     "grok-imagine-sequence-narrative": {
       "components": {
@@ -579,7 +579,7 @@
           }
         ]
       },
-      "sha": "493141b6000e877097141316286603dc2e10eb26"
+      "sha": "ce0fa9863befd51d36bd6d9ca95fcf47630f4188"
     },
     "grok-imagine-nsfw": {
       "components": {
@@ -608,7 +608,7 @@
           }
         ]
       },
-      "sha": "493141b6000e877097141316286603dc2e10eb26"
+      "sha": "ce0fa9863befd51d36bd6d9ca95fcf47630f4188"
     },
     "grok-imagine-delivery-post": {
       "components": {
@@ -649,7 +649,7 @@
           }
         ]
       },
-      "sha": "493141b6000e877097141316286603dc2e10eb26"
+      "sha": "ce0fa9863befd51d36bd6d9ca95fcf47630f4188"
     }
   }
 }

--- a/tests/test_aup_gate.py
+++ b/tests/test_aup_gate.py
@@ -282,6 +282,55 @@ def test_video_extend_attested_intimate_allowed() -> None:
         _cleanup(path)
 
 
+
+def test_video_edit_csam_refused() -> None:
+    from imagine_client import submit_video_edit
+
+    try:
+        submit_video_edit(
+            "underage character study",
+            video_url="https://example.invalid/clip.mp4",
+            dry_run=True,
+        )
+        raise AssertionError("expected AUPGateError")
+    except AUPGateError as exc:
+        assert "minor-coded" in str(exc) or "CSAM" in str(exc)
+
+
+def test_video_extend_intimate_requires_attestation() -> None:
+    from imagine_client import submit_video_extension
+
+    os.environ[ATTESTATION_ENV] = "/nonexistent-aup-attestation.json"
+    try:
+        try:
+            submit_video_extension(
+                "erotic candlelit two-shot",
+                video_url="https://example.invalid/clip.mp4",
+                dry_run=True,
+            )
+            raise AssertionError("expected AUPGateError")
+        except AUPGateError as exc:
+            assert "attest" in str(exc)
+    finally:
+        os.environ.pop(ATTESTATION_ENV, None)
+
+
+def test_video_edit_attested_intimate_allowed() -> None:
+    from imagine_client import submit_video_edit
+
+    path, _ = _attest_env()
+    try:
+        resp = submit_video_edit(
+            "erotic clothing-on R-rated continuation",
+            video_url="https://example.invalid/clip.mp4",
+            dry_run=True,
+        )
+        assert resp.get("dry_run") is True
+        assert resp.get("mode") == "video_edit"
+    finally:
+        _cleanup(path)
+
+
 def test_imagine_edit_intimate_plus_source_image_refused() -> None:
     path, _ = _attest_env()
     try:
@@ -388,6 +437,12 @@ if __name__ == "__main__":
     test_nsfw_batch_allows_r_rated_imaginary()
     test_dna_intimate_requires_imaginary_adult_no_photo()
     test_sfw_dna_with_refs_still_allowed()
+    test_video_extend_csam_refused()
+    test_video_edit_intimate_requires_attestation()
+    test_video_extend_attested_intimate_allowed()
+    test_video_edit_csam_refused()
+    test_video_extend_intimate_requires_attestation()
+    test_video_edit_attested_intimate_allowed()
     test_imagine_edit_intimate_plus_source_image_refused()
     test_403_429_not_in_failover()
     test_execute_nsfw_shot_requires_attestation()


### PR DESCRIPTION
## Why
Post-merge review of #39: `python tests/test_aup_gate.py` still skipped the new video-gate tests, and CSAM vs attestation coverage was split across edit/extend.

## What
- Call all video edit/extend AUP tests from the file harness (`__main__`).
- Mirror CSAM refuse + intimate-without-attest refuse + attested intimate allowed on **both** `submit_video_edit` and `submit_video_extension`.
- No production gate changes.

## Test plan
- [ ] `python tests/test_aup_gate.py` runs the new tests and prints success
- [ ] CI validate/scan green