### PR TITLE
feat(skills): add imagine-model-overrides for grok.com/imagine

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -18,6 +18,7 @@
     "character-dna"
   ],
   "skills": [
-    ".grok/skills/grok-imagine-cinematic-studio"
+    ".grok/skills/grok-imagine-cinematic-studio",
+    ".grok/skills/imagine-model-overrides"
   ]
 }

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -18,7 +18,6 @@
     "character-dna"
   ],
   "skills": [
-    ".grok/skills/grok-imagine-cinematic-studio",
-    ".grok/skills/imagine-model-overrides"
+    ".grok/skills/grok-imagine-cinematic-studio"
   ]
 }

--- a/.grok-plugin/plugin.json
+++ b/.grok-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "grok-imagine-cinematic-studio",
   "version": "3.11.5",
-  "description": "Independent community cinematic production suite v3.11.1 \u2014 25 Role-Card core agents, 64 skills, multi-surface control plane (CLI/TUI/Streamlit/NiceGUI/FastAPI). Grok Imagine Video 1.0/1.5, unified Grok 4.6 cinematic+Build stack, Grok Build \u2265 1.0.5. Not affiliated with or endorsed by xAI.",
+  "description": "Independent community cinematic production suite v3.11.1 \u2014 25 Role-Card core agents, 65 skills, multi-surface control plane (CLI/TUI/Streamlit/NiceGUI/FastAPI). Grok Imagine Video 1.0/1.5, unified Grok 4.6 cinematic+Build stack, Grok Build \u2265 1.0.5. Not affiliated with or endorsed by xAI.",
   "author": {
     "name": "FineComputer14451",
     "url": "https://github.com/FineComputer14451"

--- a/.grok-plugin/plugin.json
+++ b/.grok-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "grok-imagine-cinematic-studio",
-  "version": "3.11.4",
-  "description": "Independent community cinematic production suite v3.11.1 — 25 Role-Card core agents, 64 skills, multi-surface control plane (CLI/TUI/Streamlit/NiceGUI/FastAPI). Grok Imagine Video 1.0/1.5, unified Grok 4.6 cinematic+Build stack, Grok Build ≥ 1.0.5. Not affiliated with or endorsed by xAI.",
+  "version": "3.11.5",
+  "description": "Independent community cinematic production suite v3.11.1 \u2014 25 Role-Card core agents, 64 skills, multi-surface control plane (CLI/TUI/Streamlit/NiceGUI/FastAPI). Grok Imagine Video 1.0/1.5, unified Grok 4.6 cinematic+Build stack, Grok Build \u2265 1.0.5. Not affiliated with or endorsed by xAI.",
   "author": {
     "name": "FineComputer14451",
     "url": "https://github.com/FineComputer14451"
@@ -34,6 +34,7 @@
     ".grok/skills/costume-wardrobe-continuity",
     ".grok/skills/imagine-prompt-master",
     ".grok/skills/imagine-execution-bridge",
+    ".grok/skills/imagine-model-overrides",
     ".grok/skills/grok-imagine-image-tools",
     ".grok/skills/xai-grok-skill",
     ".grok/skills/handoff-packet-validator",

--- a/.grok/skills/imagine-model-overrides/DISCORD_POST.md
+++ b/.grok/skills/imagine-model-overrides/DISCORD_POST.md
@@ -1,0 +1,34 @@
+**Imagine quality feeling soft / wrong? Use the model selector (Quality vs Fast)**
+
+A lot of “bad Imagine quality” is just being on **Fast Mode** (Image 1.0) when you wanted **Quality Mode** (Image **2.0**).
+
+### Quick map — https://grok.com/imagine
+• **Sharp stills / text / faces** → **Quality Mode** = `grok-imagine-image-2.0`
+• **Cheap drafts / volume** → **Fast Mode** = `grok-imagine-image`
+• **Final video + native audio** → Video **1.5** = `grok-imagine-video-1.5`
+• **Edit or extend a clip** → Video **1.0 only** = `grok-imagine-video` (there is **no** Video 2.0)
+
+### 3-step rescue when quality is struggling
+1. Open https://grok.com/imagine and check you’re on **Quality Mode** *before* Generate
+2. Regenerate once with the **same** prompt (don’t rewrite yet)
+3. Need audio / lip-sync → Video **1.5**; extending a clip → switch back to **1.0**
+
+### Free skill for Grok (pin presets)
+Ship **`imagine-model-overrides`** — Activate with:
+
+`ACTIVATE IMAGINE_MODEL_OVERRIDES`
+
+Presets: `hero` · `balanced` (default) · `draft` · `audio-final` · `edit-extend`
+
+Links:
+• Imagine UI: https://grok.com/imagine
+• Studio PR: https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio/pull/45
+• Skill folder: https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio/tree/feat/imagine-model-overrides-skill/.grok/skills/imagine-model-overrides
+• SKILL.md: https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio/blob/feat/imagine-model-overrides-skill/.grok/skills/imagine-model-overrides/SKILL.md
+• Official model names: https://docs.x.ai/docs/models
+• Image 2.0 notes: https://x.ai/news/grok-imagine-image-2
+• This Discord: https://discord.gg/grok-community
+
+Not affiliated with xAI — community tooling that mirrors public model names from docs.x.ai.
+
+If gens look muddy, drop a screenshot of your **Quality/Fast** toggle + image vs video and we can point you at the right preset.

--- a/.grok/skills/imagine-model-overrides/DISCORD_POST.md
+++ b/.grok/skills/imagine-model-overrides/DISCORD_POST.md
@@ -1,64 +1,30 @@
-# Discord post pack (2 messages — paste in order)
+# Discord post (#community-projects) — single message
 
-## Message 1
-**Imagine quality feeling soft / wrong? Use the model selector (Quality vs Fast)**
+**Imagine Model Selector — fix soft / muddy gens (Quality vs Fast)**
 
-A lot of “bad Imagine quality” is just being on **Fast Mode** (Image 1.0) when you wanted **Quality Mode** (Image **2.0**).
+A lot of “bad Imagine quality” is just **Fast Mode** (Image 1.0) when you wanted **Quality Mode** (Image **2.0**).
 
-### Quick map — https://grok.com/imagine
-• **Sharp stills / text / faces** → **Quality Mode** = `grok-imagine-image-2.0`
-• **Cheap drafts / volume** → **Fast Mode** = `grok-imagine-image`
-• **Final video + native audio** → Video **1.5** = `grok-imagine-video-1.5`
-• **Edit or extend a clip** → Video **1.0 only** = `grok-imagine-video` (**no** Video 2.0)
+**Quick map** — https://grok.com/imagine
+• Sharp stills / text / faces → **Quality Mode** = `grok-imagine-image-2.0`
+• Cheap drafts → **Fast Mode** = `grok-imagine-image`
+• Final video + native audio → Video **1.5** = `grok-imagine-video-1.5`
+• Edit / extend clip → Video **1.0 only** = `grok-imagine-video` (**no** Video 2.0)
 
-### 3-step rescue
-1. Open https://grok.com/imagine → confirm **Quality Mode** *before* Generate
-2. Regenerate once with the **same** prompt
-3. Need audio → Video **1.5**; extending → Video **1.0**
+**Cheat sheet**
+• Soft / plastic / broken text? You’re on **Fast** → switch to **Quality**, regenerate same prompt
+• Legacy “Image Quality / Pro” → Image **2.0** + `quality=low` (retires 2026-11-02)
+• Video **1.0** = silent / cheaper / edit+extend · **1.5** = native audio / finals
+• Don’t mix 1.0+1.5 in one chain without a continuity pass
 
-### Free skill
-`ACTIVATE IMAGINE_MODEL_OVERRIDES`
-Presets: `hero` · `balanced` · `draft` · `audio-final` · `edit-extend`
+**Presets** — `ACTIVATE IMAGINE_MODEL_OVERRIDES`
+`hero` (2.0 medium + 1.5) · `balanced` default (2.0 auto + 1.0) · `draft` (1.0+1.0) · `audio-final` · `edit-extend` (1.0 only)
 
+**3-step rescue:** (1) confirm Quality Mode before Generate (2) regenerate once unchanged (3) audio→1.5 / extend→1.0
+
+**Links**
 • PR: https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio/pull/45
 • Skill: https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio/tree/feat/imagine-model-overrides-skill/.grok/skills/imagine-model-overrides
-• SKILL.md: https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio/blob/feat/imagine-model-overrides-skill/.grok/skills/imagine-model-overrides/SKILL.md
-• Models: https://docs.x.ai/docs/models
-• Image 2.0: https://x.ai/news/grok-imagine-image-2
-• Discord: https://discord.gg/grok-community
+• Cheat sheet: https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio/blob/feat/imagine-model-overrides-skill/.grok/skills/imagine-model-overrides/references/CHEAT_SHEET.md
+• Models: https://docs.x.ai/docs/models · Image 2.0: https://x.ai/news/grok-imagine-image-2
 
-*(cheat sheet continues in next message ↓)*
-
----
-
-## Message 2 (cheat sheet)
-**📋 Imagine Model Selector Cheat Sheet** (full)
-
-**Quality vs Fast**
-• **Quality Mode** = Image **2.0** `grok-imagine-image-2.0` — hero stills, text, faces (up to 5 edit refs; API `quality`: low/medium/auto)
-• **Fast Mode** = Image **1.0** `grok-imagine-image` — drafts / volume (up to 3 edit refs)
-• Soft / plastic / broken text? You’re probably on **Fast** → switch to **Quality** on https://grok.com/imagine
-• Legacy “Image Quality / Pro” → use Image **2.0** + `quality=low` (legacy retires 2026-11-02)
-
-**Video 1.0 vs 1.5**
-• **1.0** `grok-imagine-video` — cheaper, silent, **required for edit/extend**
-• **1.5** `grok-imagine-video-1.5` — native audio / Sound Layer / finals
-• **No Video 2.0.** Don’t mix 1.0+1.5 in one chain without a continuity pass
-
-**Presets** (`ACTIVATE IMAGINE_MODEL_OVERRIDES <preset>`)
-• `hero` → 2.0 medium + Video 1.5
-• `balanced` *(default)* → 2.0 auto + Video 1.0
-• `draft` → Image 1.0 + Video 1.0
-• `audio-final` → 2.0 medium + Video 1.5 (locked plate → i2v)
-• `edit-extend` → Video **1.0 only**
-
-**Troubleshoot**
-1. Confirm Quality/Fast before Generate
-2. Change mode first, don’t rewrite the whole prompt yet
-3. Text in image → Quality Mode + quoted copy
-4. Never invent model slugs — stick to the map / https://docs.x.ai/docs/models
-
-Markdown cheat sheet: https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio/blob/feat/imagine-model-overrides-skill/.grok/skills/imagine-model-overrides/references/CHEAT_SHEET.md
-UI: https://grok.com/imagine · PR: https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio/pull/45
-
-Not affiliated with xAI — community guide mirroring public model names.
+Not affiliated with xAI — community project for #community-projects. Drop a Quality/Fast screenshot if still muddy.

--- a/.grok/skills/imagine-model-overrides/DISCORD_POST.md
+++ b/.grok/skills/imagine-model-overrides/DISCORD_POST.md
@@ -1,3 +1,6 @@
+# Discord post pack (2 messages — paste in order)
+
+## Message 1
 **Imagine quality feeling soft / wrong? Use the model selector (Quality vs Fast)**
 
 A lot of “bad Imagine quality” is just being on **Fast Mode** (Image 1.0) when you wanted **Quality Mode** (Image **2.0**).
@@ -6,29 +9,56 @@ A lot of “bad Imagine quality” is just being on **Fast Mode** (Image 1.0) wh
 • **Sharp stills / text / faces** → **Quality Mode** = `grok-imagine-image-2.0`
 • **Cheap drafts / volume** → **Fast Mode** = `grok-imagine-image`
 • **Final video + native audio** → Video **1.5** = `grok-imagine-video-1.5`
-• **Edit or extend a clip** → Video **1.0 only** = `grok-imagine-video` (there is **no** Video 2.0)
+• **Edit or extend a clip** → Video **1.0 only** = `grok-imagine-video` (**no** Video 2.0)
 
-### 3-step rescue when quality is struggling
-1. Open https://grok.com/imagine and check you’re on **Quality Mode** *before* Generate
-2. Regenerate once with the **same** prompt (don’t rewrite yet)
-3. Need audio / lip-sync → Video **1.5**; extending a clip → switch back to **1.0**
+### 3-step rescue
+1. Open https://grok.com/imagine → confirm **Quality Mode** *before* Generate
+2. Regenerate once with the **same** prompt
+3. Need audio → Video **1.5**; extending → Video **1.0**
 
-### Free skill for Grok (pin presets)
-Ship **`imagine-model-overrides`** — Activate with:
-
+### Free skill
 `ACTIVATE IMAGINE_MODEL_OVERRIDES`
+Presets: `hero` · `balanced` · `draft` · `audio-final` · `edit-extend`
 
-Presets: `hero` · `balanced` (default) · `draft` · `audio-final` · `edit-extend`
-
-Links:
-• Imagine UI: https://grok.com/imagine
-• Studio PR: https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio/pull/45
-• Skill folder: https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio/tree/feat/imagine-model-overrides-skill/.grok/skills/imagine-model-overrides
+• PR: https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio/pull/45
+• Skill: https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio/tree/feat/imagine-model-overrides-skill/.grok/skills/imagine-model-overrides
 • SKILL.md: https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio/blob/feat/imagine-model-overrides-skill/.grok/skills/imagine-model-overrides/SKILL.md
-• Official model names: https://docs.x.ai/docs/models
-• Image 2.0 notes: https://x.ai/news/grok-imagine-image-2
-• This Discord: https://discord.gg/grok-community
+• Models: https://docs.x.ai/docs/models
+• Image 2.0: https://x.ai/news/grok-imagine-image-2
+• Discord: https://discord.gg/grok-community
 
-Not affiliated with xAI — community tooling that mirrors public model names from docs.x.ai.
+*(cheat sheet continues in next message ↓)*
 
-If gens look muddy, drop a screenshot of your **Quality/Fast** toggle + image vs video and we can point you at the right preset.
+---
+
+## Message 2 (cheat sheet)
+**📋 Imagine Model Selector Cheat Sheet** (full)
+
+**Quality vs Fast**
+• **Quality Mode** = Image **2.0** `grok-imagine-image-2.0` — hero stills, text, faces (up to 5 edit refs; API `quality`: low/medium/auto)
+• **Fast Mode** = Image **1.0** `grok-imagine-image` — drafts / volume (up to 3 edit refs)
+• Soft / plastic / broken text? You’re probably on **Fast** → switch to **Quality** on https://grok.com/imagine
+• Legacy “Image Quality / Pro” → use Image **2.0** + `quality=low` (legacy retires 2026-11-02)
+
+**Video 1.0 vs 1.5**
+• **1.0** `grok-imagine-video` — cheaper, silent, **required for edit/extend**
+• **1.5** `grok-imagine-video-1.5` — native audio / Sound Layer / finals
+• **No Video 2.0.** Don’t mix 1.0+1.5 in one chain without a continuity pass
+
+**Presets** (`ACTIVATE IMAGINE_MODEL_OVERRIDES <preset>`)
+• `hero` → 2.0 medium + Video 1.5
+• `balanced` *(default)* → 2.0 auto + Video 1.0
+• `draft` → Image 1.0 + Video 1.0
+• `audio-final` → 2.0 medium + Video 1.5 (locked plate → i2v)
+• `edit-extend` → Video **1.0 only**
+
+**Troubleshoot**
+1. Confirm Quality/Fast before Generate
+2. Change mode first, don’t rewrite the whole prompt yet
+3. Text in image → Quality Mode + quoted copy
+4. Never invent model slugs — stick to the map / https://docs.x.ai/docs/models
+
+Markdown cheat sheet: https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio/blob/feat/imagine-model-overrides-skill/.grok/skills/imagine-model-overrides/references/CHEAT_SHEET.md
+UI: https://grok.com/imagine · PR: https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio/pull/45
+
+Not affiliated with xAI — community guide mirroring public model names.

--- a/.grok/skills/imagine-model-overrides/DISCORD_THREAD.md
+++ b/.grok/skills/imagine-model-overrides/DISCORD_THREAD.md
@@ -1,0 +1,96 @@
+# Create this Discord thread
+
+1. Open https://discord.gg/grok-community → Official Grok Community
+2. Go to a tips / Imagine / help channel that allows threads (or Forum if available)
+3. Click **Create Thread** / **New Post**
+4. **Thread title:** paste TITLE below
+5. **First message:** paste STARTER
+6. In the new thread, reply with CHEAT SHEET message
+7. Optional third reply: INSTALL
+
+---
+
+## TITLE
+Imagine Model Selector — Quality vs Fast (fix soft gens)
+
+---
+
+## STARTER (first message)
+**Imagine quality feeling soft / wrong? Use the model selector (Quality vs Fast)**
+
+A lot of “bad Imagine quality” is just being on **Fast Mode** (Image 1.0) when you wanted **Quality Mode** (Image **2.0**).
+
+### Quick map — https://grok.com/imagine
+• **Sharp stills / text / faces** → **Quality Mode** = `grok-imagine-image-2.0`
+• **Cheap drafts / volume** → **Fast Mode** = `grok-imagine-image`
+• **Final video + native audio** → Video **1.5** = `grok-imagine-video-1.5`
+• **Edit or extend a clip** → Video **1.0 only** = `grok-imagine-video` (**no** Video 2.0)
+
+### 3-step rescue
+1. Open https://grok.com/imagine → confirm **Quality Mode** *before* Generate
+2. Regenerate once with the **same** prompt
+3. Need audio → Video **1.5**; extending → Video **1.0**
+
+### Free skill
+`ACTIVATE IMAGINE_MODEL_OVERRIDES`
+Presets: `hero` · `balanced` · `draft` · `audio-final` · `edit-extend`
+
+• PR: https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio/pull/45
+• Skill: https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio/tree/feat/imagine-model-overrides-skill/.grok/skills/imagine-model-overrides
+• SKILL.md: https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio/blob/feat/imagine-model-overrides-skill/.grok/skills/imagine-model-overrides/SKILL.md
+• Cheat sheet (also next reply): https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio/blob/feat/imagine-model-overrides-skill/.grok/skills/imagine-model-overrides/references/CHEAT_SHEET.md
+• Models: https://docs.x.ai/docs/models
+• Image 2.0: https://x.ai/news/grok-imagine-image-2
+
+Not affiliated with xAI — community guide. Drop a Quality/Fast screenshot if gens still look muddy.
+Reply in-thread with image vs video + which mode you used.
+
+---
+
+## REPLY 1 — CHEAT SHEET
+**📋 Imagine Model Selector Cheat Sheet** (full)
+
+**Quality vs Fast**
+• **Quality Mode** = Image **2.0** `grok-imagine-image-2.0` — hero stills, text, faces (up to 5 edit refs; API `quality`: low/medium/auto)
+• **Fast Mode** = Image **1.0** `grok-imagine-image` — drafts / volume (up to 3 edit refs)
+• Soft / plastic / broken text? You’re probably on **Fast** → switch to **Quality** on https://grok.com/imagine
+• Legacy “Image Quality / Pro” → use Image **2.0** + `quality=low` (legacy retires 2026-11-02)
+
+**Video 1.0 vs 1.5**
+• **1.0** `grok-imagine-video` — cheaper, silent, **required for edit/extend**
+• **1.5** `grok-imagine-video-1.5` — native audio / Sound Layer / finals
+• **No Video 2.0.** Don’t mix 1.0+1.5 in one chain without a continuity pass
+
+**Presets** (`ACTIVATE IMAGINE_MODEL_OVERRIDES <preset>`)
+• `hero` → 2.0 medium + Video 1.5
+• `balanced` *(default)* → 2.0 auto + Video 1.0
+• `draft` → Image 1.0 + Video 1.0
+• `audio-final` → 2.0 medium + Video 1.5 (locked plate → i2v)
+• `edit-extend` → Video **1.0 only**
+
+**Troubleshoot**
+1. Confirm Quality/Fast before Generate
+2. Change mode first, don’t rewrite the whole prompt yet
+3. Text in image → Quality Mode + quoted copy
+4. Never invent model slugs — stick to the map / https://docs.x.ai/docs/models
+
+Markdown cheat sheet: https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio/blob/feat/imagine-model-overrides-skill/.grok/skills/imagine-model-overrides/references/CHEAT_SHEET.md
+UI: https://grok.com/imagine · PR: https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio/pull/45
+
+Not affiliated with xAI — community guide mirroring public model names.
+
+---
+
+## REPLY 2 — INSTALL (optional)
+**Install / Activate**
+
+```bash
+unzip imagine-model-overrides-skill.zip -d ~/.grok/skills
+```
+
+New Grok session → `ACTIVATE IMAGINE_MODEL_OVERRIDES` (or `… hero` / `… draft`)
+
+• Skill zip + files: https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio/tree/feat/imagine-model-overrides-skill/.grok/skills/imagine-model-overrides
+• Studio PR: https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio/pull/45
+• UI: https://grok.com/imagine
+• Server invite: https://discord.gg/grok-community

--- a/.grok/skills/imagine-model-overrides/SKILL.md
+++ b/.grok/skills/imagine-model-overrides/SKILL.md
@@ -1,0 +1,168 @@
+---
+name: imagine-model-overrides
+description: >-
+  Select and pin Grok Imagine image/video model overrides for grok.com/imagine
+  and Studio handoffs. Use when choosing Quality vs Fast, Image 2.0 vs 1.0,
+  Video 1.5 vs 1.0, legacy quality redirects, or when emitting model_stack /
+  VIDEO_PIPELINE_SPEC for paste packets. Activate with ACTIVATE IMAGINE_MODEL_OVERRIDES
+  or /imagine-model-overrides.
+when-to-use: >-
+  ACTIVATE IMAGINE_MODEL_OVERRIDES; override Imagine models; Quality Mode;
+  Fast Mode; Image 2.0; Video 1.5; model_stack; pin imagine image/video model;
+  grok.com/imagine model pick
+argument-hint: "[preset|image-slug|video-slug]"
+user-invocable: true
+metadata:
+  author: FineComputer14451
+  short-description: Pin Imagine image/video models for grok.com/imagine
+---
+
+# Imagine Model Overrides
+
+Canonical **select + pin** skill for Imagine models on [grok.com/imagine](https://grok.com/imagine) and Studio handoffs to surface `grok_com_imagine`.
+
+Aligned with **Grok Imagine Cinematic Studio** `tools/models.py` (v3.11.4+) and xAI docs pricing table (Sep 2026).
+
+Begin: **"Imagine model overrides locked…"** then emit the chosen preset.
+
+
+## Model Layer (Grok 4.6 / v9-4p5)
+
+| Task type | Preferred model | Reasoning |
+|-----------|-----------------|-----------|
+| Model pin / handoff synthesis | `grok-v9-4p5-chat-expert` | high |
+| Multi-agent routing of presets | `grok-v9-4p5-multi` | high |
+| Quick preset refresh | `grok-4-auto` | medium |
+
+```yaml
+model_compatibility:
+  - grok-v9-4p5-chat-expert
+  - grok-v9-4p5-multi
+  - grok-4-auto
+preferred_model: grok-v9-4p5-chat-expert
+```
+
+## Hard rules
+
+1. **Never invent model slugs.** Only use the catalog below.
+2. **There is no Video 2.0.** Video choices are `grok-imagine-video` (1.0) or `grok-imagine-video-1.5`.
+3. **Hero stills** use Image **2.0** (`grok-imagine-image-2.0`) = grok.com/imagine **Quality Mode**.
+4. **Draft / volume stills** use Image **1.0** (`grok-imagine-image`) = **Fast Mode**.
+5. Legacy `grok-imagine-image-quality` **retires 2026-11-02** → rewrite to `grok-imagine-image-2.0` with `quality=low`.
+6. **Edit / extend video** must stay on Video **1.0** (`grok-imagine-video`). Do not send 1.5 for edit/extend.
+7. On surface **C** (`grok_com_imagine`), speak in UI terms (Quality / Fast / Video 1.5) and keep paste packets plain-text friendly.
+
+## Catalog (canonical)
+
+### Image
+
+| Slug | UI / role | Notes |
+|------|-----------|-------|
+| `grok-imagine-image-2.0` | **Quality Mode** · hero | `quality`: `low` \| `medium` \| `auto` (default auto). Up to **5** edit refs. |
+| `grok-imagine-image` | **Fast Mode** · default draft | Cheaper volume stills. Up to **3** edit refs. |
+| `grok-imagine-image-quality` | Legacy Quality | **Deprecated.** Redirect → `grok-imagine-image-2.0` + `quality=low`. |
+
+Aliases → 2.0: `2.0`, `image-2.0`, `imagine-image-2.0`, `hero`, `quality-mode`  
+Aliases → 1.0: `1.0`, `image`, `fast`, `fast-mode`, `draft`  
+Aliases → legacy (then redirect): `quality`, `pro`, `image-quality`
+
+### Video
+
+| Slug | UI / role | Notes |
+|------|-----------|-------|
+| `grok-imagine-video` | Video **1.0** · cost default | Silent. **Required** for edit + extend. Max 720p. |
+| `grok-imagine-video-1.5` | Video **1.5 Native** | Native audio. Prefer for final motion / Sound Layer. 1080p on t2v/i2v. |
+
+Aliases → 1.0: `1.0`, `video`, `edit-extend`  
+Aliases → 1.5: `1.5`, `native-audio`, `video-1.5`
+
+## Presets (select these)
+
+| Preset id | Image | Video | When |
+|-----------|-------|-------|------|
+| `hero` | `grok-imagine-image-2.0` (`quality=medium`) | `grok-imagine-video-1.5` | Final plates + final motion with audio |
+| `balanced` | `grok-imagine-image-2.0` (`quality=auto`) | `grok-imagine-video` | Hero stills, cost-aware video |
+| `draft` | `grok-imagine-image` | `grok-imagine-video` | Volume / pre-viz / quota save |
+| `audio-final` | `grok-imagine-image-2.0` (`quality=medium`) | `grok-imagine-video-1.5` | Locked plate → i2v with Sound Layer |
+| `edit-extend` | (n/a or keep current plate) | `grok-imagine-video` | Video edit or extend only |
+
+Default when user is vague: **`balanced`**.
+
+## Activation
+
+```text
+ACTIVATE IMAGINE_MODEL_OVERRIDES
+ACTIVATE IMAGINE_MODEL_OVERRIDES hero
+ACTIVATE IMAGINE_MODEL_OVERRIDES draft
+/imagine-model-overrides balanced
+```
+
+Also fire when the user asks to override / pin / select Imagine models for grok.com/imagine.
+
+## What to emit
+
+### A) Model stack block (always)
+
+```yaml
+model_stack:
+  imagine_image: <slug>
+  image_quality: <low|medium|auto|null>   # only for 2.0; null for 1.0
+  imagine_video: <slug>
+  ui_image_mode: Quality Mode | Fast Mode
+  ui_video_note: Video 1.0 | Video 1.5 Native
+  preset: <preset id>
+```
+
+### B) grok.com/imagine paste steps (surface C)
+
+```text
+=== IMAGINE MODEL OVERRIDE (grok.com/imagine) ===
+Preset: <id>
+Image UI: <Quality Mode | Fast Mode>  →  <slug>  [quality=<…>]
+Video UI: <Video 1.0 | Video 1.5 Native>  →  <slug>
+
+Steps:
+1. Open https://grok.com/imagine
+2. For stills: select <Quality Mode | Fast Mode> before generate
+3. For video: prefer <1.0 | 1.5>; if native audio / Sound Layer needed → 1.5
+4. Edit or extend a clip → stay on Video 1.0
+5. After generate, save result and return to Studio / record path
+
+Do not invent other model names in the UI.
+=== END OVERRIDE ===
+```
+
+### C) VIDEO_PIPELINE_SPEC (when video)
+
+**1.0**
+```text
+[VIDEO_PIPELINE_SPEC: model="grok-imagine-video", version="1.0", resolution="720p", clip_length="8-12s preferred", native_audio=false, reference_image_fidelity=high, extend_protocol="LAST_FRAME + MOTION_VECTOR", stitch_priority=high, audio_momentum=false]
+```
+
+**1.5**
+```text
+[VIDEO_PIPELINE_SPEC: model="grok-imagine-video-1.5", version="1.5", resolution="720p", clip_length="8-12s preferred", native_audio=true, reference_image_fidelity=high, extend_protocol="LAST_FRAME + MOTION_VECTOR + AUDIO_CUE", stitch_priority=high, audio_momentum=true]
+```
+
+## Decision cheat sheet
+
+| User says… | Pin |
+|------------|-----|
+| Quality / hero / sharp text / typography | Image 2.0 + `quality=medium` |
+| Fast / cheap / many drafts | Image 1.0 |
+| Native audio / lip sync / Sound Layer | Video 1.5 |
+| Edit clip / extend clip | Video 1.0 only |
+| "Old quality model" / pro / image-quality | Rewrite → Image 2.0 + `quality=low` |
+| Mixed chain 1.0 + 1.5 | Warn; need Continuity Guardian approval |
+
+## Pairing
+
+- Web paste packets → also `imagine-execution-bridge` / `ACTIVATE IMAGINE_BRIDGE`
+- Full multi-surface handoff → `ACTIVATE IMAGINE_AGENT_MODE_HANDOFF`
+- Registry source of truth → Studio `tools/models.py` (do not drift)
+
+## References
+
+- `references/model-catalog.md` — full alias + redirect table
+- Official pricing / names: https://docs.x.ai/docs/models
+- Surface C bridge: Studio `GROK_COM_IMAGINE_BRIDGE.md`

--- a/.grok/skills/imagine-model-overrides/references/CHEAT_SHEET.md
+++ b/.grok/skills/imagine-model-overrides/references/CHEAT_SHEET.md
@@ -1,0 +1,92 @@
+# Imagine Model Selector Cheat Sheet
+**For https://grok.com/imagine — when Quality looks weak, muddy, or “wrong model”**
+
+Quick pin skill: `ACTIVATE IMAGINE_MODEL_OVERRIDES`  
+Studio PR: https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio/pull/45  
+Skill folder: https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio/tree/feat/imagine-model-overrides-skill/.grok/skills/imagine-model-overrides  
+Official models list: https://docs.x.ai/docs/models  
+Grok Community Discord: https://discord.gg/grok-community
+
+---
+
+## 30-second fix
+
+| You want… | Click / use on [grok.com/imagine](https://grok.com/imagine) | Wire model |
+|-----------|-----------------------------------------------|------------|
+| Sharp hero stills, text, faces, detail | **Quality Mode** | `grok-imagine-image-2.0` |
+| Cheap drafts / volume | **Fast Mode** | `grok-imagine-image` |
+| Final video + native audio | Video **1.5** | `grok-imagine-video-1.5` |
+| Cheap / silent / **edit or extend** | Video **1.0** | `grok-imagine-video` |
+
+**There is no Video 2.0.** Edit/extend must stay on Video **1.0**.
+
+Image 2.0 announcement: https://x.ai/news/grok-imagine-image-2
+
+---
+
+## Quality Mode vs Fast Mode
+
+| | **Quality Mode** (Image 2.0) | **Fast Mode** (Image 1.0) |
+|--|------------------------------|---------------------------|
+| Best for | Hero plates, typography, client stills | Thumbnails, storyboard spam |
+| Detail / text | Higher | Softer / cheaper |
+| Edit refs | Up to **5** | Up to **3** |
+| Quality param (API) | `low` \| `medium` \| `auto` | n/a |
+| Hero tip | Prefer `quality=medium` for finals | Use for drafts only |
+
+If stills look soft, plastic, or text is broken → you are probably on **Fast**. Switch to **Quality Mode** on https://grok.com/imagine and regenerate.
+
+Legacy “Image Quality / Pro” → treat as **Image 2.0** with `quality=low` (legacy slug retires **2026-11-02**).
+
+---
+
+## Video 1.0 vs 1.5
+
+| | **1.0** | **1.5 Native** |
+|--|---------|----------------|
+| Audio | Silent | Native audio / Sound Layer |
+| Cost | Lower | Higher |
+| Edit / extend | **Yes — required** | **No** |
+| Final motion | Draft / pre-viz | Finals with dialogue/SFX |
+
+---
+
+## Presets (skill)
+
+| Preset | Image | Video | Use when |
+|--------|-------|-------|----------|
+| `hero` | 2.0 `medium` | 1.5 | Finals |
+| `balanced` *(default)* | 2.0 `auto` | 1.0 | Hero stills, thrifty video |
+| `draft` | 1.0 | 1.0 | Volume / quota save |
+| `audio-final` | 2.0 `medium` | 1.5 | Locked plate → i2v + audio |
+| `edit-extend` | keep plate | **1.0 only** | Edit / extend |
+
+```text
+ACTIVATE IMAGINE_MODEL_OVERRIDES hero
+ACTIVATE IMAGINE_MODEL_OVERRIDES draft
+```
+
+Skill markdown: https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio/blob/feat/imagine-model-overrides-skill/.grok/skills/imagine-model-overrides/SKILL.md
+
+---
+
+## Troubleshooting “struggling quality”
+
+1. **Confirm mode** on https://grok.com/imagine — Quality vs Fast *before* Generate
+2. **One change at a time** — switch mode first; don’t rewrite the whole prompt yet
+3. **Hero stills** — Quality Mode + shorter, concrete prompt; add 1–2 refs first (up to 5 on 2.0)
+4. **Text in image** — Quality Mode; put exact copy in quotes; avoid Fast
+5. **Video soft / mute** — need audio → **1.5**; editing → **1.0**
+6. **Don’t mix** 1.0 and 1.5 in one continuous chain without a continuity pass
+7. **Never invent slugs** — only the table above / https://docs.x.ai/docs/models
+
+---
+
+## Install
+
+```bash
+unzip imagine-model-overrides-skill.zip -d ~/.grok/skills
+# new Grok session → ACTIVATE IMAGINE_MODEL_OVERRIDES
+```
+
+Or browse the skill on the PR branch: https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio/tree/feat/imagine-model-overrides-skill/.grok/skills/imagine-model-overrides

--- a/.grok/skills/imagine-model-overrides/references/model-catalog.md
+++ b/.grok/skills/imagine-model-overrides/references/model-catalog.md
@@ -1,0 +1,69 @@
+# Imagine model catalog (overrides)
+
+Source of truth: FineComputer14451/Grok-Imagine-Cinematic-Studio `tools/models.py` + docs.x.ai Models (Sep 2026).
+
+## Image slugs
+
+| Canonical | Default role | Deprecated | Redirect |
+|-----------|--------------|------------|----------|
+| `grok-imagine-image` | Draft / Fast Mode | no | — |
+| `grok-imagine-image-2.0` | Hero / Quality Mode | no | — |
+| `grok-imagine-image-quality` | Legacy Quality | yes (retire 2026-11-02) | → `grok-imagine-image-2.0` + `quality=low` |
+
+### Image 2.0 quality param
+
+Allowed: `low` | `medium` | `auto`  
+Omit on Image 1.0.
+
+### Image aliases
+
+```
+2.0, image-2.0, imagine-image-2.0, grok-imagine-image-2, image-2, hero, quality-mode
+  → grok-imagine-image-2.0
+
+1.0, image, imagine-image, image-1.0, fast, fast-mode, draft
+  → grok-imagine-image
+
+quality, pro, image-quality, imagine-image-quality, grok-imagine-image-pro,
+grok-imagine-image-quality-latest, grok-imagine-image-quality-20260403
+  → grok-imagine-image-quality (then redirect to 2.0 + quality=low)
+```
+
+## Video slugs
+
+| Canonical | Default role | Native audio | Edit/extend |
+|-----------|--------------|--------------|-------------|
+| `grok-imagine-video` | Cost default / draft | no | **yes** |
+| `grok-imagine-video-1.5` | Final / audio | yes | **no** |
+
+### Video aliases
+
+```
+1.0, video, imagine-video, video-1.0, edit-extend
+  → grok-imagine-video
+
+1.5, video-1.5, imagine-video-1.5, native-audio, 1.5-preview,
+grok-imagine-video-1.5-preview, grok-imagine-video-1.5-2026-05-30
+  → grok-imagine-video-1.5
+```
+
+## Studio role defaults (do not invent)
+
+```
+imagine_image default = grok-imagine-image
+imagine_image hero    = grok-imagine-image-2.0
+imagine_video default = grok-imagine-video
+imagine_video audio   = grok-imagine-video-1.5
+edit/extend video     = grok-imagine-video
+```
+
+## grok.com/imagine UI mapping
+
+| UI control | Wire slug |
+|------------|-----------|
+| Quality Mode | `grok-imagine-image-2.0` |
+| Fast Mode | `grok-imagine-image` |
+| Video without native-audio emphasis | `grok-imagine-video` |
+| Video with native audio / Sound Layer | `grok-imagine-video-1.5` |
+
+There is **no** public "pick arbitrary slug" control on the consumer UI — overrides are expressed as **Quality/Fast + 1.0/1.5**, and as `model_stack` / `VIDEO_PIPELINE_SPEC` in Studio packets.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [3.11.5] — 2026-09-06
+
+### Added
+- Skill `imagine-model-overrides` — select/pin Imagine image+video models for grok.com/imagine (Quality/Fast, Image 2.0/1.0, Video 1.5/1.0) and emit `model_stack` + paste steps + `VIDEO_PIPELINE_SPEC`. Activate with `ACTIVATE IMAGINE_MODEL_OVERRIDES`.
+
+
 All notable changes to Grok Imagine Cinematic Studio will be documented in this file.
 
 ## [Unreleased]

--- a/scripts/required_skills.manifest
+++ b/scripts/required_skills.manifest
@@ -1,4 +1,4 @@
-# Grok Imagine Cinematic Studio v3.11.4 — skill manifest (64 skills; matches .grok/skills + plugin.json)
+# Grok Imagine Cinematic Studio v3.11.4 — skill manifest (65 skills; matches .grok/skills + plugin.json)
 # One skill per line. Append " # core" for skills required by verify.
 
 grok-imagine-cinematic-studio # core
@@ -33,6 +33,7 @@ i2i-cinematic-refiner
 i2i-refiner
 image-to-video-specialist
 imagine-execution-bridge
+imagine-model-overrides
 grok-imagine-image-tools
 xai-grok-skill
 imagine-prompt-master


### PR DESCRIPTION
## Summary
- Adds `.grok/skills/imagine-model-overrides` to select/pin Imagine image+video models for [grok.com/imagine](https://grok.com/imagine)
- Maps Quality Mode → `grok-imagine-image-2.0`, Fast → `grok-imagine-image`, Video 1.0 / 1.5, legacy quality redirect
- Emits `model_stack`, paste steps, and `VIDEO_PIPELINE_SPEC`
- Registers skill in `scripts/required_skills.manifest`, `.grok-plugin/plugin.json`, `.codex-plugin/plugin.json` (65 skills)
- Activate: `ACTIVATE IMAGINE_MODEL_OVERRIDES` (presets: `hero` / `balanced` / `draft` / `audio-final` / `edit-extend`)

## Test plan
- [x] `bash .grok/skills/cinematic-skill-creator/scripts/validate_skill.sh .grok/skills/imagine-model-overrides/`
- [x] Confirm skill appears in plugin skill list / manifest
- [x] In Grok: `ACTIVATE IMAGINE_MODEL_OVERRIDES balanced` emits Quality Mode + Video 1.0 stack