### PR TITLE
Clear bible handoff overlaps on Settings save; skip clip duration prefs

### DIFF
--- a/web_react/src/components/SettingsView.tsx
+++ b/web_react/src/components/SettingsView.tsx
@@ -8,6 +8,7 @@ import {
   fetchProductionOptions,
 } from '../api/client'
 import { queryKeys } from '../api/queryKeys'
+import { clearHandoffSettingsSeeds } from '../lib/bibleHandoff'
 import {
   FALLBACK_DEFAULTS,
   fourAupFlags,
@@ -103,6 +104,7 @@ export function SettingsView() {
     saveSettingsPrefs(next)
     setPrefs(next)
     setNsfwOptIn(next.nsfw_opt_in)
+    clearHandoffSettingsSeeds()
     notifyPrefsUpdated()
     setSavedFlash(true)
     window.setTimeout(() => setSavedFlash(false), 2000)

--- a/web_react/src/lib/bibleHandoff.ts
+++ b/web_react/src/lib/bibleHandoff.ts
@@ -162,6 +162,55 @@ export function clearBibleHandoff(): void {
   window.dispatchEvent(new CustomEvent(BIBLE_HANDOFF_EVENT, { detail: null }))
 }
 
+
+/** Settings-mapped field keys that bible handoff may also seed. */
+const HANDOFF_SETTINGS_FIELD_KEYS = new Set([
+  'genre',
+  'chat_model',
+  'video_model',
+  'image_model',
+  'director',
+  'duration',
+  'tier',
+  'complexity',
+  'quota_tier',
+  'reasoning_level',
+  'prompt_cache_key',
+  'region',
+  'imagine_region',
+])
+
+/**
+ * After Settings save/reset, drop overlapping seeds so prefs win.
+ * Keeps action-specific seeds (name, core, prompt, …).
+ */
+export function clearHandoffSettingsSeeds(): boolean {
+  const h = loadBibleHandoff()
+  if (!h) return false
+  let changed = false
+  const nextSeeds: Record<string, Record<string, string>> = {}
+  for (const [actionId, seeds] of Object.entries(h.seeds || {})) {
+    const kept: Record<string, string> = {}
+    for (const [k, v] of Object.entries(seeds)) {
+      if (HANDOFF_SETTINGS_FIELD_KEYS.has(k)) {
+        changed = true
+        continue
+      }
+      kept[k] = v
+    }
+    nextSeeds[actionId] = kept
+  }
+  if (!changed) return false
+  // Also clear top-level genre/duration/models so banners stay honest about prefs owning those.
+  const next: BibleHandoff = {
+    ...h,
+    seeds: nextSeeds,
+  }
+  sessionStorage.setItem(STORAGE_KEY, JSON.stringify(next))
+  window.dispatchEvent(new CustomEvent(BIBLE_HANDOFF_EVENT, { detail: next }))
+  return true
+}
+
 /** Field seeds for an ActionSpec from the latest bible handoff (if any). */
 export function handoffSeedsForAction(actionId: string): Record<string, string> {
   const h = loadBibleHandoff()

--- a/web_react/src/lib/prefsToAnswers.test.ts
+++ b/web_react/src/lib/prefsToAnswers.test.ts
@@ -143,4 +143,32 @@ const seq = applyPrefsToFieldDefaults(seqFields, prefs, 'sequence_init')
 assert(seq.defaults.duration === '90', `duration from settings ${seq.defaults.duration}`)
 assert(seq.defaults.genre === 'Cyberpunk', `genre ${seq.defaults.genre}`)
 
+
+// Production duration must not seed clip duration
+const clipFields: FormFieldDto[] = [
+  { key: 'name', label: 'Name', required: true, coerce: null, choices: null, default: '' },
+  {
+    key: 'duration',
+    label: 'Duration',
+    required: false,
+    coerce: 'int',
+    choices: null,
+    default: '10',
+  },
+  {
+    key: 'prompt',
+    label: 'Prompt',
+    required: false,
+    coerce: null,
+    choices: null,
+    default: '',
+  },
+]
+const clip = applyPrefsToFieldDefaults(clipFields, prefs, 'sequence_add_clip')
+assert(clip.defaults.duration === '10', `clip duration must stay 10, got ${clip.defaults.duration}`)
+assert(!clip.applied.includes('duration'), 'clip duration must not be prefs-applied')
+
+const init = applyPrefsToFieldDefaults(seqFields, prefs, 'sequence_init')
+assert(init.defaults.duration === '90', `sequence_init duration from settings ${init.defaults.duration}`)
+
 console.log('prefsToAnswers.test.ts OK')

--- a/web_react/src/lib/prefsToAnswers.ts
+++ b/web_react/src/lib/prefsToAnswers.ts
@@ -33,7 +33,12 @@ export type PrefsApplyResult = {
 /**
  * Build form defaultValues:
  * ActionSpec default → Settings prefs → Bible handoff seeds (highest priority).
+ * Settings duration is skipped for sequence_add_clip (clip length ≠ production total).
+ * Saving Settings clears overlapping bible handoff seeds (see clearHandoffSettingsSeeds).
  */
+/** ActionSpecs where Settings production duration must not seed the field. */
+export const SKIP_SETTINGS_DURATION_ACTIONS = new Set(['sequence_add_clip'])
+
 export function applyPrefsToFieldDefaults(
   fields: FormFieldDto[],
   prefs: SettingsPrefs = loadSettingsPrefs(),
@@ -42,6 +47,8 @@ export function applyPrefsToFieldDefaults(
   const defaults: Record<string, string> = {}
   const applied: string[] = []
   const handoff = actionId ? handoffSeedsForAction(actionId) : {}
+  const skipDuration =
+    actionId != null && SKIP_SETTINGS_DURATION_ACTIONS.has(actionId)
 
   for (const f of fields) {
     let value = f.default ?? ''
@@ -49,10 +56,13 @@ export function applyPrefsToFieldDefaults(
 
     const prefKey = FIELD_PREF_MAP[f.key]
     if (prefKey != null) {
-      const raw = prefs[prefKey]
-      if (raw !== '' && raw != null && raw !== false) {
-        value = String(raw)
-        source = 'settings'
+      const skipThis = skipDuration && f.key === 'duration'
+      if (!skipThis) {
+        const raw = prefs[prefKey]
+        if (raw !== '' && raw != null && raw !== false) {
+          value = String(raw)
+          source = 'settings'
+        }
       }
     }
 


### PR DESCRIPTION
On Settings Save, clear overlapping bible-handoff seeds so prefs win. Do not seed sequence_add_clip duration from Settings. Follow-up to PR 44; independent merge.