### PR TITLE
docs: Imagine models map (incl. Agent Mode)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -62,6 +62,7 @@ Interactive learning app + ship checklist for cinematography track beginners:
 |---------|----------|
 | Role Cards & Agent Index | [`references/agents/AGENT_INDEX.md`](../references/agents/AGENT_INDEX.md) |
 | Model Layer | [`references/agents/MODEL_LAYER_v4.5.md`](../references/agents/MODEL_LAYER_v4.5.md) |
+| Imagine models map (Agent Mode) | [`docs/guides/IMAGINE_MODELS_MAP.md`](guides/IMAGINE_MODELS_MAP.md) |
 | Imagine Agent Mode Handoff | [`references/agents/IMAGINE_AGENT_MODE_HANDOFF_v3.7.1.md`](../references/agents/IMAGINE_AGENT_MODE_HANDOFF_v3.7.1.md) |
 | Identity Continuity Protocol | [`references/agents/IDENTITY_CONTINUITY_PROTOCOL_v3.8.md`](../references/agents/IDENTITY_CONTINUITY_PROTOCOL_v3.8.md) |
 | Parallel Brief Protocol | [`references/agents/Parallel_Brief_Protocol.md`](../references/agents/Parallel_Brief_Protocol.md) |

--- a/docs/guides/IMAGINE_MODELS_MAP.md
+++ b/docs/guides/IMAGINE_MODELS_MAP.md
@@ -1,0 +1,94 @@
+# Imagine models map (incl. Agent Mode)
+
+**Pin this.** Canonical product slugs + where Agent Mode fits.  
+Studio is an independent community project — not affiliated with xAI.
+
+Deeper references:
+- Surfaces / API / pricing: [`references/agents/IMAGINE_SURFACES.md`](../../references/agents/IMAGINE_SURFACES.md)
+- Studio handoff protocol: [`references/agents/IMAGINE_AGENT_MODE_HANDOFF_v3.7.1.md`](../../references/agents/IMAGINE_AGENT_MODE_HANDOFF_v3.7.1.md)
+- Overrides skill: `.grok/skills/imagine-model-overrides`
+- Official: https://docs.x.ai/docs/guides/image-generations · https://docs.x.ai/docs/models · https://grok.com/imagine
+
+There is **no** `grok-imagine-video-2.0`. **2.0 is Image only.**
+
+---
+
+## Image models
+
+| UI / role | Wire slug | Notes |
+|-----------|-----------|-------|
+| **Fast Mode** (draft) | `grok-imagine-image` | Volume / storyboard; up to **3** edit refs |
+| **Quality Mode** (hero) | `grok-imagine-image-2.0` | Typography, faces, detail; API `quality` = `low` \| `medium` \| `auto`; up to **5** edit refs |
+| Legacy Quality / Pro | `grok-imagine-image-quality` | **Retired 2026-11-02** — rewrite spend to **2.0** + `quality=low` |
+
+Aliases (examples): `2.0` / `image-2.0` / `quality-mode` → Image 2.0; `1.0` / `fast` / `draft` → Image 1.0.
+
+---
+
+## Video models
+
+| UI / role | Wire slug | Native audio | Edit / extend |
+|-----------|-----------|--------------|---------------|
+| Video **1.0** | `grok-imagine-video` | no | **yes** (required) |
+| Video **1.5** | `grok-imagine-video-1.5` | yes (Sound Layer) | **no** |
+
+---
+
+## Presets (overrides skill)
+
+| Preset | Image | Video | Use |
+|--------|-------|-------|-----|
+| `hero` | 2.0 `medium` | 1.5 | Finals |
+| `balanced` | 2.0 `auto` | 1.0 | Default |
+| `draft` | 1.0 | 1.0 | Quota save |
+| `audio-final` | 2.0 `medium` | 1.5 | Locked plate → i2v + audio |
+| `edit-extend` | keep plate | **1.0 only** | Edit / extend |
+
+```text
+ACTIVATE IMAGINE_MODEL_OVERRIDES hero
+```
+
+---
+
+## Agent Mode — two meanings (do not conflate)
+
+### 1) Consumer **Imagine Agent Mode** (grok.com/imagine, beta)
+
+| | |
+|--|--|
+| **What** | Infinite-canvas **workflow agent** on the web Imagine product |
+| **Not** | A separate public API model slug (no `grok-imagine-agent` in docs) |
+| **Templates** | Create Worlds · Short Film · UGC Product Stories · Brand Identity |
+| **Does** | Plan → batch stills → i2v → stitch short clips → edit/export on one canvas |
+| **Models underneath** | Same Imagine stack: Quality/Fast stills + Video 1.0/1.5; planning uses chat-model quota |
+| **Access** | Web / paid Grok (beta); treat as **orchestration UI**, then pin outputs with the tables above |
+
+### 2) Studio **Agent Mode handoff** (this repo)
+
+Routing from planning agents into execution surfaces:
+
+| ID | `target_surface` | Generation runs via |
+|----|------------------|---------------------|
+| A | `grok_build_tools` | Build session tools (`image_gen`, i2v, …) |
+| B | `grok_agent_acp` | `grok agent` / IDE ACP |
+| C | `grok_com_imagine` | Manual paste on grok.com/imagine (Quality = Image 2.0) |
+| D | `xai_api` | REST `imagine submit` / sequence |
+| E | `xai_responses_tool` | Responses `image_generation` (Image 2.0 stills) |
+
+```bash
+python tools/cinematic_studio_cli.py imagine agent-handoff \
+  --batch <slug> --shot <id> --surface xai_api --format markdown
+```
+
+---
+
+## Quick routing
+
+1. Hero still → Quality / `grok-imagine-image-2.0`  
+2. Draft spam → Fast / `grok-imagine-image`  
+3. Final + audio → Video **1.5**  
+4. Edit / extend → Video **1.0** only  
+5. Multi-step film / brand pack on web → **Consumer Agent Mode**, then lock plates with 2.0 / 1.0 / 1.5 rules  
+6. Studio pipeline → handoff packet → surfaces A–E (not a new Imagine slug)
+
+Coding / Grok Build chat stays on **`grok-4.6`** — never select `grok-imagine-*` for code.

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -3,6 +3,7 @@
 | Guide | Description |
 |-------|-------------|
 | [docs/guides/Quick_Start_Guide.md](Quick_Start_Guide.md) | Onboarding and first production |
+| [IMAGINE_MODELS_MAP.md](IMAGINE_MODELS_MAP.md) | Imagine image/video slugs + Agent Mode (consumer vs Studio handoff) |
 | [docs/guides/UPGRADE_GUIDE.md](UPGRADE_GUIDE.md) | Migrating between studio versions |
 | [installation_guide.md](installation_guide.md) | Install CLI, plugin, Grok Build config |
 | [install_comfyui_grok_build.md](install_comfyui_grok_build.md) | Use Grok Build to install and set up ComfyUI |

--- a/references/agents/IMAGINE_SURFACES.md
+++ b/references/agents/IMAGINE_SURFACES.md
@@ -60,6 +60,12 @@ CLI: `cinematic-studio imagine submit image|image_edit|video|video_edit|video_ex
 
 ## Agent Mode / operator surfaces
 
+### Consumer Imagine Agent Mode (grok.com/imagine)
+
+Web beta **infinite canvas** (Create Worlds · Short Film · UGC Product Stories · Brand Identity).
+It is a **workflow UI**, not a separate public Imagine API slug. Still pin generations with
+Image 1.0 / 2.0 and Video 1.0 / 1.5 above. One-pager: [`docs/guides/IMAGINE_MODELS_MAP.md`](../../docs/guides/IMAGINE_MODELS_MAP.md).
+
 Studio `target_surface` values for `imagine_agent_mode_handoff`:
 
 | ID | Surface | How generation runs |


### PR DESCRIPTION
## Summary
- New pin-friendly [IMAGINE_MODELS_MAP.md](docs/guides/IMAGINE_MODELS_MAP.md): all Imagine image/video slugs + presets.
- Clarifies **consumer Agent Mode** (infinite canvas) vs **Studio Agent Mode handoff** (surfaces A–E).
- Linked from guides index, docs README, and IMAGINE_SURFACES.

## Test plan
- [x] Skim the new guide on GitHub
- [ ] Confirm links from docs/README and IMAGINE_SURFACES