### PR TITLE
fix(academy): unblock CI validate after #55

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -14,7 +14,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio.git",
-        "sha": "b7e786ddd75433d34981083e0fd0c8ab678056d5"
+        "sha": "0d7bab679d4c74a93496b4efbb1d0d6b4fce5c4d"
       },
       "homepage": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio",
       "keywords": [
@@ -31,7 +31,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio.git",
-        "sha": "b7e786ddd75433d34981083e0fd0c8ab678056d5"
+        "sha": "0d7bab679d4c74a93496b4efbb1d0d6b4fce5c4d"
       },
       "homepage": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio",
       "keywords": [
@@ -49,7 +49,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio.git",
-        "sha": "b7e786ddd75433d34981083e0fd0c8ab678056d5"
+        "sha": "0d7bab679d4c74a93496b4efbb1d0d6b4fce5c4d"
       },
       "homepage": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio",
       "keywords": [
@@ -69,7 +69,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio.git",
-        "sha": "b7e786ddd75433d34981083e0fd0c8ab678056d5"
+        "sha": "0d7bab679d4c74a93496b4efbb1d0d6b4fce5c4d"
       },
       "homepage": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio",
       "keywords": [
@@ -89,7 +89,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio.git",
-        "sha": "b7e786ddd75433d34981083e0fd0c8ab678056d5"
+        "sha": "0d7bab679d4c74a93496b4efbb1d0d6b4fce5c4d"
       },
       "homepage": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio",
       "keywords": [
@@ -109,7 +109,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio.git",
-        "sha": "b7e786ddd75433d34981083e0fd0c8ab678056d5"
+        "sha": "0d7bab679d4c74a93496b4efbb1d0d6b4fce5c4d"
       },
       "homepage": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio",
       "keywords": [

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -324,7 +324,7 @@
           }
         ]
       },
-      "sha": "b7e786ddd75433d34981083e0fd0c8ab678056d5"
+      "sha": "0d7bab679d4c74a93496b4efbb1d0d6b4fce5c4d"
     },
     "grok-imagine-cinematic-core": {
       "components": {
@@ -473,7 +473,7 @@
           }
         ]
       },
-      "sha": "b7e786ddd75433d34981083e0fd0c8ab678056d5"
+      "sha": "0d7bab679d4c74a93496b4efbb1d0d6b4fce5c4d"
     },
     "grok-imagine-camera-image": {
       "components": {
@@ -528,7 +528,7 @@
           }
         ]
       },
-      "sha": "b7e786ddd75433d34981083e0fd0c8ab678056d5"
+      "sha": "0d7bab679d4c74a93496b4efbb1d0d6b4fce5c4d"
     },
     "grok-imagine-sequence-narrative": {
       "components": {
@@ -611,7 +611,7 @@
           }
         ]
       },
-      "sha": "b7e786ddd75433d34981083e0fd0c8ab678056d5"
+      "sha": "0d7bab679d4c74a93496b4efbb1d0d6b4fce5c4d"
     },
     "grok-imagine-nsfw": {
       "components": {
@@ -640,7 +640,7 @@
           }
         ]
       },
-      "sha": "b7e786ddd75433d34981083e0fd0c8ab678056d5"
+      "sha": "0d7bab679d4c74a93496b4efbb1d0d6b4fce5c4d"
     },
     "grok-imagine-delivery-post": {
       "components": {
@@ -681,7 +681,7 @@
           }
         ]
       },
-      "sha": "b7e786ddd75433d34981083e0fd0c8ab678056d5"
+      "sha": "0d7bab679d4c74a93496b4efbb1d0d6b4fce5c4d"
     }
   }
 }

--- a/.grok/skills/character-dna-extractor/SKILL.md
+++ b/.grok/skills/character-dna-extractor/SKILL.md
@@ -20,6 +20,13 @@ Chat / agent routing for this skill (not Imagine slugs):
 | Quick single-ref pass | **Fast** or **Auto** | `grok-4.6` |
 
 ```yaml
+model_compatibility:
+  - grok-4.6
+  - grok-imagine-image-2.0
+  - grok-imagine-image
+  - grok-imagine-video
+  - grok-imagine-video-1.5
+preferred_model: grok-4.6
 stack_default: grok-4.6
 chat_modes: [Auto, Fast, Expert, Heavy, Build]
 preferred_chat_mode: Expert

--- a/.grok/skills/characters-props-locations-refs/SKILL.md
+++ b/.grok/skills/characters-props-locations-refs/SKILL.md
@@ -19,6 +19,14 @@ metadata:
 
 # Characters / Props / Locations — Auto Reference Images
 
+```yaml
+model_compatibility:
+  - grok-4.6
+  - grok-imagine-image-2.0
+  - grok-imagine-image
+preferred_model: grok-imagine-image-2.0
+```
+
 Canonical skill to **automatically create** reusable Imagine reference plates
 (Characters · Props · Locations) before motion.
 

--- a/.grok/skills/grok-chat-model-map/SKILL.md
+++ b/.grok/skills/grok-chat-model-map/SKILL.md
@@ -20,6 +20,12 @@ metadata:
 
 # Grok Chat Model Map
 
+```yaml
+model_compatibility:
+  - grok-4.6
+preferred_model: grok-4.6
+```
+
 Canonical **Chat mode** skill for [grok.com](https://grok.com) Chat (also iOS / Android / X Grok).
 
 **Verified picker (2026-09-06 ET):** `Auto` · `Fast` · `Expert` · `Heavy` · `Build`
@@ -81,7 +87,7 @@ Full tables: `references/mode-catalog.md`.
 Chat thread          → Auto | Fast | Expert | Heavy
 Chat picker → Build  → Grok Build coding agent
 Sidebar Imagine      → Imagine image/video models
-api.x.ai / SDK       → grok-4.6, grok-4.5, …
+api.x.ai / SDK       → grok-4.6 (grok-4.5 is a resolve alias that wraps 4.6), …
 Grok Build TUI       → /model aliases (host config)
 Studio registry      → tools/models.py (separate)
 ```

--- a/.grok/skills/grok-chat-model-map/references/CHEAT_SHEET.md
+++ b/.grok/skills/grok-chat-model-map/references/CHEAT_SHEET.md
@@ -41,7 +41,7 @@ Models docs: https://docs.x.ai/developers/models · Grok 4.6: https://docs.x.ai/
 | Surface | What you pick |
 |---------|----------------|
 | grok.com **Chat** | Auto / Fast / Expert / Heavy (/ Build) |
-| **api.x.ai** | `grok-4.6`, `grok-4.5`, … — never send `Auto` or `Expert` as `model` |
+| **api.x.ai** | `grok-4.6` (legacy `grok-4.5` alias wraps 4.6), … — never send `Auto` or `Expert` as `model` |
 | **Grok Build** TUI | Host `/model` aliases; default coding ≈ `grok-4.6` |
 | **Imagine** | Quality = **Image 2.0** (`grok-imagine-image-2.0`) · Fast = 1.0 · Video 1.0/1.5 → `imagine-model-overrides` |
 | Cinematic Studio | `tools/models.py` registry (different map) |

--- a/.grok/skills/grok-chat-model-map/references/mode-catalog.md
+++ b/.grok/skills/grok-chat-model-map/references/mode-catalog.md
@@ -29,7 +29,7 @@ Do **not** invent extra picker tiles (no “Grok 4.6” depth mode in verified s
 | API id | Role vs Chat |
 |--------|----------------|
 | `grok-4.6` | Recommended Chat + Code on API; Expert/Auto sit on this generation |
-| `grok-4.5` | Prior flagship |
+| `grok-4.5` | Resolve alias that wraps grok-4.6 (prior flagship label) |
 | `grok-4.3` | Long-context / alternate |
 | `grok-4.20-0309-reasoning` | Reasoning variant |
 | `grok-4.20-0309-non-reasoning` | Non-reasoning / faster analogue |

--- a/.grok/skills/grok-imagine-template-library/SKILL.md
+++ b/.grok/skills/grok-imagine-template-library/SKILL.md
@@ -20,6 +20,16 @@ metadata:
 
 # Grok Imagine Template Library
 
+```yaml
+model_compatibility:
+  - grok-4.6
+  - grok-imagine-image-2.0
+  - grok-imagine-image
+  - grok-imagine-video
+  - grok-imagine-video-1.5
+preferred_model: grok-imagine-image-2.0
+```
+
 **Canonical library path (repo root):** `imagine-template-library/`
 
 Begin: **"Template library locked — loading packs from `imagine-template-library/`…"**

--- a/.grok/skills/imagine-model-overrides/SKILL.md
+++ b/.grok/skills/imagine-model-overrides/SKILL.md
@@ -39,6 +39,13 @@ Begin: **"Imagine model overrides locked…"** then emit the chosen preset.
 | Edit / extend | `grok-imagine-video` |
 
 ```yaml
+model_compatibility:
+  - grok-4.6
+  - grok-imagine-image-2.0
+  - grok-imagine-image
+  - grok-imagine-video
+  - grok-imagine-video-1.5
+preferred_model: grok-imagine-image-2.0
 stack_default_chat: grok-4.6
 hero_image: grok-imagine-image-2.0
 draft_image: grok-imagine-image

--- a/.grok/skills/imagine-model-overrides/references/model-catalog.md
+++ b/.grok/skills/imagine-model-overrides/references/model-catalog.md
@@ -27,8 +27,8 @@ Omit on Image 1.0. Hero finals: prefer `quality=medium`.
   → grok-imagine-image
 
 quality, pro, image-quality, imagine-image-quality, grok-imagine-image-pro,
-grok-imagine-image-quality-latest, grok-imagine-image-quality-20260403
-  → grok-imagine-image-quality (then redirect to 2.0 + quality=low)
+grok-imagine-image-quality-latest, grok-imagine-image-quality-20260403 (retired aliases)
+  → grok-imagine-image-quality (retired; then redirect to 2.0 + quality=low)
 ```
 
 ## Video slugs

--- a/web_academy/src/data/api-docs.ts
+++ b/web_academy/src/data/api-docs.ts
@@ -1,6 +1,6 @@
 export type ApiEndpoint = {
   id: string;
-  method: "GET" | "POST";
+  method: "GET" | "POST" | "DELETE";
   path: string;
   title: string;
   summary: string;
@@ -78,16 +78,16 @@ export const GROK_PRICING: {
       blurb: "Published list rates per million tokens.",
       rows: [
         {
-          model: "grok-4.5",
+          model: "grok-4.6",
           unit: "Input / 1M tokens",
           price: "$2.00",
-          note: "List price",
+          note: "Live chat default (grok-4.5 is a resolve alias that wraps 4.6)",
         },
         {
-          model: "grok-4.5",
+          model: "grok-4.6",
           unit: "Output / 1M tokens",
           price: "$6.00",
-          note: "List price",
+          note: "Live chat default (grok-4.5 is a resolve alias that wraps 4.6)",
         },
       ],
     },
@@ -140,7 +140,7 @@ export const GROK_PRICING: {
           note: "Up to 5 edit sources. Billed per input image.",
         },
         {
-          model: "grok-imagine-image-quality",
+          model: "grok-imagine-image-quality (retired)",
           unit: "Output / image (1K / 2K)",
           price: "$0.05 / $0.07",
           note: "Retires Nov 2 → 2.0 quality low. Do not leave in templates.",
@@ -275,7 +275,7 @@ export const GROK_PRICING: {
     {
       label: "Prompt craft (chat)",
       estimate: "≪ $0.01",
-      detail: "Small grok-4.5 call with capped max_tokens — illustrative",
+      detail: "Small grok-4.6 call with capped max_tokens — illustrative",
       kind: "example",
     },
   ],
@@ -346,7 +346,7 @@ export const askGrok = createServerFn({ method: "POST" })
         Authorization: \`Bearer \${apiKey}\`,
       },
       body: JSON.stringify({
-        model: "grok-4.5",
+        model: "grok-4.6",
         messages: [{ role: "user", content: data.prompt }],
       }),
     });
@@ -487,11 +487,11 @@ Authorization: Bearer $XAI_API_KEY`,
         path: "/v1/chat/completions",
         title: "Chat completions",
         summary:
-          "OpenAI-compatible chat. grok-4.5 list: $2 input / $6 output per 1M tokens.",
+          "OpenAI-compatible chat. grok-4.6 list: $2 input / $6 output per 1M tokens (grok-4.5 is a resolve alias that wraps 4.6).",
         request: `POST https://api.x.ai/v1/chat/completions
 
 {
-  "model": "grok-4.5",
+  "model": "grok-4.6",
   "messages": [
     { "role": "system", "content": "You are a cinematic production assistant." },
     { "role": "user", "content": "Write a 3-shot neon alley brief." }
@@ -525,7 +525,7 @@ Authorization: Bearer $XAI_API_KEY`,
     id: "imagine-image",
     title: "Imagine — images",
     intro:
-      "1.0 for cheap iteration. 2.0 with quality low | medium | auto for plates. quality auto currently serves low on generation and medium on edits. Bill at the quality served. After November 2, grok-imagine-image-quality is 2.0-low.",
+      "1.0 for cheap iteration. 2.0 with quality low | medium | auto for plates. quality auto currently serves low on generation and medium on edits. Bill at the quality served. After November 2, retired slug grok-imagine-image-quality is 2.0-low — do not send it as the live hero.",
     endpoints: [
       {
         id: "images-generations",
@@ -587,7 +587,7 @@ Authorization: Bearer $XAI_API_KEY`,
 // auto quality currently serves medium for edits`,
         response: `{
   "data": [
-    { "url": "https://…" }
+    { "url": "https://…", "file_id": "file_…" }
   ],
   "model": "grok-imagine-image-2.0"
 }`,
@@ -595,6 +595,7 @@ Authorization: Bearer $XAI_API_KEY`,
           "Ideal for plate polish before video spend.",
           "Keep identity locks in the edit prompt when Character DNA is required.",
           "2.0 adds 21:9 / 5:2 cinematic ratios — prefer native 21:9 over a 16:9 crop.",
+          "JSON body only — images.edit() multipart is NOT supported (use image / images[] with URL, data URI, or file_id).",
         ],
       },
     ],
@@ -608,14 +609,17 @@ Authorization: Bearer $XAI_API_KEY`,
       {
         id: "video-start",
         method: "POST",
-        path: "/v1/videos (async start)",
+        path: "/v1/videos/generations",
         title: "Start video generation",
         summary:
           "Kick off grok-imagine-video-1.5 (hero) or grok-imagine-video (draft); poll the request id.",
-        request: `// Hero: grok-imagine-video-1.5  480p $0.08/s · 720p $0.14/s · 1080p $0.25/s
+        request: `POST https://api.x.ai/v1/videos/generations
+Authorization: Bearer $XAI_API_KEY
+
+// Hero: grok-imagine-video-1.5  480p $0.08/s · 720p $0.14/s · 1080p $0.25/s
 // Draft: grok-imagine-video     480p $0.05/s · 720p $0.07/s
 // Duration: up to ~15 seconds on 1.5
-// Flow: POST start → poll status with returned id → download result
+// Flow: POST /v1/videos/generations → GET /v1/videos/{request_id} until status done
 
 {
   "model": "grok-imagine-video-1.5",
@@ -638,15 +642,15 @@ Authorization: Bearer $XAI_API_KEY`,
         method: "GET",
         path: "/v1/videos/{request_id}",
         title: "Poll video job",
-        summary: "Check status until complete; then fetch the clip URL.",
-        request: `GET https://api.x.ai/v1/…/{request_id}
+        summary: "Check status until done; then fetch the clip URL.",
+        request: `GET https://api.x.ai/v1/videos/{request_id}
 Authorization: Bearer $XAI_API_KEY`,
         response: `{
-  "status": "completed" | "pending" | "failed",
-  "url": "https://…/clip.mp4"
+  "status": "done",
+  "video": { "url": "https://…/clip.mp4", "file_id": "file_…" }
 }`,
         notes: [
-          "Exact paths and fields: docs.x.ai → Imagine Video.",
+          "Poll until status is done (not completed). Other values: pending | failed | expired.",
           "Retry failed jobs at most once.",
         ],
       },
@@ -706,13 +710,13 @@ Authorization: Bearer $XAI_API_KEY`,
         path: "chat → images",
         title: "Prompt Master → Imagine still",
         summary: "LLM writes the packet; images API renders the plate.",
-        request: `// 1) Chat: craft cinematic prompt (grok-4.5)
+        request: `// 1) Chat: craft cinematic prompt (grok-4.6; grok-4.5 is a resolve alias that wraps 4.6)
 // 2) Images: POST /v1/images/generations with that prompt
 // 3) Optional edit: POST /v1/images/edits for plate lock
 
 {
   "pipeline": ["chat.completions", "images.generations"],
-  "models": ["grok-4.5", "grok-imagine-image-2.0"],
+  "models": ["grok-4.6", "grok-imagine-image-2.0"],
   "image_quality": "medium"
 }`,
         notes: [
@@ -753,7 +757,7 @@ export const API_STATUS_CODES = [
   { code: "429", meaning: "Rate limited or quota pressure — back off" },
   { code: "5xx", meaning: "Server error — retry at most once, then surface" },
   { code: "pending", meaning: "Async video job still running — keep polling" },
-  { code: "completed", meaning: "Async video ready — fetch URL" },
+  { code: "done", meaning: "Async video ready — fetch URL (status done, not completed)" },
   { code: "failed", meaning: "Async job failed — show error, optional single retry" },
 ];
 
@@ -776,7 +780,7 @@ export const API_ERRORS = [
   },
   {
     error: "RETIRED_IMAGE_QUALITY_SLUG",
-    fix: "Replace grok-imagine-image-quality with grok-imagine-image-2.0 and pin quality (low | medium). After Nov 2 the old slug is 2.0-low.",
+    fix: "Do not send grok-imagine-image-quality; replace with grok-imagine-image-2.0 and pin quality (low | medium). After Nov 2 the retired slug is 2.0-low.",
   },
   {
     error: "RETRY_STORM",

--- a/web_academy/src/data/scenarios.ts
+++ b/web_academy/src/data/scenarios.ts
@@ -198,7 +198,7 @@ On No-Go: repair plan only — do not rewrite Production Bible.`,
       "Quota Optimizer: hero vs draft still order before any video.",
       "Trailer Director: 15–30s beat sheet using approved plates only.",
     ],
-    activation: `Activate Grok Imagine Cinematic Studio v3.9.1
+    activation: `Activate Grok Imagine Cinematic Studio v3.11.4
 ACTIVATE STUDIO_DIRECTOR
 ACTIVATE MEGA_PRODUCTION_ARCHITECT
 ACTIVATE DOP

--- a/web_academy/src/routes/docs.tsx
+++ b/web_academy/src/routes/docs.tsx
@@ -39,6 +39,7 @@ export const Route = createFileRoute("/docs")({
 const METHOD_STYLE: Record<ApiEndpoint["method"], string> = {
   GET: "border-teal/40 bg-teal/10 text-teal",
   POST: "border-amber/40 bg-amber/10 text-amber",
+  DELETE: "border-rose/40 bg-rose/10 text-rose",
 };
 
 function DocsPage() {


### PR DESCRIPTION
## Summary
- Align Academy / agent-facing copy with current product truth: **v3.11.4**, live chat **grok-4.6**, hero stills **grok-imagine-image-2.0**, and official Files/Imagine REST (`/v1/videos/generations`, poll `status: done`, `file_id`).
- Declare `model_compatibility` on skills that lacked it (`character-dna-extractor`, `characters-props-locations-refs`, `grok-chat-model-map`, `grok-imagine-template-library`, `imagine-model-overrides`).
- Refresh marketplace catalog pin to the content commit.

## Fixes the 8 known validate failures
1. `test_no_stale_v39_activation` — scenarios activation → v3.11.4
2. `test_grok_45_not_live_default` — Academy api-docs recommend grok-4.6
3. `test_quality_slug_not_live_hero` — quality slug only with retirement language
4. `test_no_stale_v39_version_stamps` — remove leftover v3.9.1 stamp
5. `test_academy_api_docs_official_files_imagine_surface` — official video path + `done` + `file_id` + multipart denial + DELETE style
6. `test_skills_declare_model_compatibility` — add metadata to 5 skills
7. `test_agent_facing_copy_does_not_recommend_grok_45` — alias/wrap language in chat model map
8. `test_agent_facing_copy_does_not_recommend_quality_slug` — retired alias wording in model catalog

## Test plan
- [x] `pytest tests/test_academy_copy.py tests/test_agents_registry.py tests/test_chat_46_copy.py tests/test_image_quality_retirement_copy.py -q` → 34 passed
- [x] `bash scripts/verify_plugins.sh --release` → green
- [ ] CI validate job on this PR
- Note: local full `pytest -q` still shows 1 env-only failure on Python 3.13 (`tests/test_studio_api.py::test_files_inbox_upload` pydantic UploadFile); CI uses 3.12 and this is unrelated to these copy fixes.

Do not merge until validate is green. GrokHunter untouched.