### PR TITLE
chore: re-vendor Template Library worlds + recipes

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -14,7 +14,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio.git",
-        "sha": "6884b50edba3e24677ea0fda20bfdafb4d8bc3d0"
+        "sha": "04777b13e0c40f24a2654b08a92af00f7d7e371a"
       },
       "homepage": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio",
       "keywords": [
@@ -31,7 +31,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio.git",
-        "sha": "6884b50edba3e24677ea0fda20bfdafb4d8bc3d0"
+        "sha": "04777b13e0c40f24a2654b08a92af00f7d7e371a"
       },
       "homepage": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio",
       "keywords": [
@@ -49,7 +49,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio.git",
-        "sha": "6884b50edba3e24677ea0fda20bfdafb4d8bc3d0"
+        "sha": "04777b13e0c40f24a2654b08a92af00f7d7e371a"
       },
       "homepage": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio",
       "keywords": [
@@ -69,7 +69,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio.git",
-        "sha": "6884b50edba3e24677ea0fda20bfdafb4d8bc3d0"
+        "sha": "04777b13e0c40f24a2654b08a92af00f7d7e371a"
       },
       "homepage": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio",
       "keywords": [
@@ -89,7 +89,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio.git",
-        "sha": "6884b50edba3e24677ea0fda20bfdafb4d8bc3d0"
+        "sha": "04777b13e0c40f24a2654b08a92af00f7d7e371a"
       },
       "homepage": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio",
       "keywords": [
@@ -109,7 +109,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio.git",
-        "sha": "6884b50edba3e24677ea0fda20bfdafb4d8bc3d0"
+        "sha": "04777b13e0c40f24a2654b08a92af00f7d7e371a"
       },
       "homepage": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio",
       "keywords": [

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -324,7 +324,7 @@
           }
         ]
       },
-      "sha": "6884b50edba3e24677ea0fda20bfdafb4d8bc3d0"
+      "sha": "04777b13e0c40f24a2654b08a92af00f7d7e371a"
     },
     "grok-imagine-cinematic-core": {
       "components": {
@@ -473,7 +473,7 @@
           }
         ]
       },
-      "sha": "6884b50edba3e24677ea0fda20bfdafb4d8bc3d0"
+      "sha": "04777b13e0c40f24a2654b08a92af00f7d7e371a"
     },
     "grok-imagine-camera-image": {
       "components": {
@@ -528,7 +528,7 @@
           }
         ]
       },
-      "sha": "6884b50edba3e24677ea0fda20bfdafb4d8bc3d0"
+      "sha": "04777b13e0c40f24a2654b08a92af00f7d7e371a"
     },
     "grok-imagine-sequence-narrative": {
       "components": {
@@ -611,7 +611,7 @@
           }
         ]
       },
-      "sha": "6884b50edba3e24677ea0fda20bfdafb4d8bc3d0"
+      "sha": "04777b13e0c40f24a2654b08a92af00f7d7e371a"
     },
     "grok-imagine-nsfw": {
       "components": {
@@ -640,7 +640,7 @@
           }
         ]
       },
-      "sha": "6884b50edba3e24677ea0fda20bfdafb4d8bc3d0"
+      "sha": "04777b13e0c40f24a2654b08a92af00f7d7e371a"
     },
     "grok-imagine-delivery-post": {
       "components": {
@@ -681,7 +681,7 @@
           }
         ]
       },
-      "sha": "6884b50edba3e24677ea0fda20bfdafb4d8bc3d0"
+      "sha": "04777b13e0c40f24a2654b08a92af00f7d7e371a"
     }
   }
 }

--- a/imagine-template-library/CATALOG.md
+++ b/imagine-template-library/CATALOG.md
@@ -69,9 +69,16 @@
 
 
 ## Worlds
-| Slug | Title | Notes |
+| Slug | Title | Style |
 |------|-------|-------|
-| snow_archer | Snow Archer One World | Official Image 2.0 demo board; refs/image-2.0-one-world/ |
+| snow_archer | Snow Archer | Official One World demo |
+| mara_neon | Mara Neon | rainy tech-noir |
+| clara_house | Clara House | aster folk dread |
+| maya_attic | Maya Attic | gerwig warm pastel |
+| jax_midnight | Jax Midnight | nolan wet-night |
+| mira_signal | Mira Signal | clinical horror |
+| thorne_eldrath | Thorne Eldrath | earth mystic gold |
+
 
 ## Official Image 2.0 templates
 Source extract: grok.com/imagine agent-skills + x.ai news Image 2.0

--- a/imagine-template-library/README.md
+++ b/imagine-template-library/README.md
@@ -5,12 +5,15 @@ Reusable packs for Grok Imagine — characters, locations, styles, shots — plu
 ## Layout
 - `characters/<slug>/` — PACK.md + dna.json
 - `locations/<slug>/` — PACK.md (establish + coverage)
+- `props/<slug>/` — PACK.md (hero / reverse / detail)
 - `styles/<slug>/` — grade/look prompts
 - `shots/<slug>/` — framing add-ons
-- `product-templates/` — paste-ready Create Template recipes
-  - `photo-style-edit/`
+- `worlds/<slug>/` — One World kits (7); see `worlds/INDEX.md`
+- `official-templates/` — Image 2.0 xAI templates
+- `product-templates/` — paste-ready Create Template recipes (~47); see `product-templates/INDEX.md`
+  - `photo-style-edit/` (incl. `world_*`)
   - `photo-video/`
-  - `photo-edit-video/`
+  - `photo-edit-video/` (incl. `world_*` Live)
 - `_templates/` — blank scaffolds
 - `CATALOG.md` — index
 

--- a/imagine-template-library/product-templates/INDEX.md
+++ b/imagine-template-library/product-templates/INDEX.md
@@ -1,0 +1,12 @@
+# Create Template recipes
+
+## photo-style-edit/
+Pack looks, official Imagine templates (`official_*`), world kits (`world_*`).
+
+## photo-video/
+Living locations (e.g. rainy_downtown, nexus9_storm).
+
+## photo-edit-video/
+Character-in-world motion (`world_*` Live recipes).
+
+Map to Imagine UI: Type → Prompts → Test → Preview.

--- a/imagine-template-library/product-templates/photo-edit-video/world_jax_midnight/RECIPE.md
+++ b/imagine-template-library/product-templates/photo-edit-video/world_jax_midnight/RECIPE.md
@@ -1,0 +1,5 @@
+name: World · Jax Midnight Live
+type: edit-then-video
+world: jax_midnight
+edit: Restyle as Jax Rivera with 1969 Mustang on wet downtown night avenue
+video: Tracking along wet avenue, rain streaks, neon flicker, car idle micro-motion, no people crowd, keep night grade

--- a/imagine-template-library/product-templates/photo-edit-video/world_mara_neon/RECIPE.md
+++ b/imagine-template-library/product-templates/photo-edit-video/world_mara_neon/RECIPE.md
@@ -1,0 +1,5 @@
+name: World · Mara Neon Live
+type: edit-then-video
+world: mara_neon
+edit: Restyle as Mara Chen at neon pier night with courier satchel, magenta-cyan neon rainy bokeh, identity lock
+video: Soft rain drift, neon flicker, jacket and satchel micro-movement, Mara identity locked, no hard cuts

--- a/imagine-template-library/product-templates/photo-edit-video/world_snow_archer/RECIPE.md
+++ b/imagine-template-library/product-templates/photo-edit-video/world_snow_archer/RECIPE.md
@@ -1,0 +1,5 @@
+name: World · Snow Archer Live
+type: edit-then-video
+world: snow_archer
+edit: Restyle as Snow Archer in northern saga snow, braid scarred cheek
+video: Gentle blizzard drift, breath fog, soft camera push, identity locked, cold saga grade

--- a/imagine-template-library/product-templates/photo-style-edit/world_clara_house/RECIPE.md
+++ b/imagine-template-library/product-templates/photo-style-edit/world_clara_house/RECIPE.md
@@ -1,0 +1,5 @@
+name: World · Clara House
+type: style-edit
+world: clara_house
+desc: Restyle into Clara at the childhood house with key
+prompt: Restyle as Clara Voss at overgrown childhood house porch, dark circles gentle fraying, old brass house key, sickly golden hour folk dread, keep composition, Image 2.0 Quality

--- a/imagine-template-library/product-templates/photo-style-edit/world_jax_midnight/RECIPE.md
+++ b/imagine-template-library/product-templates/photo-style-edit/world_jax_midnight/RECIPE.md
@@ -1,0 +1,5 @@
+name: World · Jax Midnight
+type: style-edit
+world: jax_midnight
+desc: Restyle into Jax with Mustang on rainy downtown
+prompt: Restyle as Jax Rivera beside 1969 Mustang on rainy downtown avenue night, tense focus wet chrome neon reflections, cool high contrast, keep composition, Image 2.0 Quality

--- a/imagine-template-library/product-templates/photo-style-edit/world_mara_neon/RECIPE.md
+++ b/imagine-template-library/product-templates/photo-style-edit/world_mara_neon/RECIPE.md
@@ -1,0 +1,5 @@
+name: World · Mara Neon
+type: style-edit
+world: mara_neon
+desc: Restyle into Mara at neon pier with courier satchel
+prompt: Restyle as Mara Chen at neon pier night, beauty mark blunt bangs charcoal courier jacket courier satchel, magenta-cyan neon rainy bokeh, keep composition, Image 2.0 Quality

--- a/imagine-template-library/product-templates/photo-style-edit/world_maya_attic/RECIPE.md
+++ b/imagine-template-library/product-templates/photo-style-edit/world_maya_attic/RECIPE.md
@@ -1,0 +1,5 @@
+name: World · Maya Attic
+type: style-edit
+world: maya_attic
+desc: Restyle into Maya in the golden attic with letters
+prompt: Restyle as Maya Chen in dusty attic golden afternoon, warm smile, ribbon-tied letter bundle steamer trunk, soft pastel film grain, keep composition, Image 2.0 Quality

--- a/imagine-template-library/product-templates/photo-style-edit/world_mira_signal/RECIPE.md
+++ b/imagine-template-library/product-templates/photo-style-edit/world_mira_signal/RECIPE.md
@@ -1,0 +1,5 @@
+name: World · Mira Signal
+type: style-edit
+world: mira_signal
+desc: Restyle into Mira Kane in the signal facility
+prompt: Restyle as Dr Mira Kane in sterile underground facility with research tablet, clinical white sickly green, detached calm, keep composition, Image 2.0 Quality

--- a/imagine-template-library/product-templates/photo-style-edit/world_snow_archer/RECIPE.md
+++ b/imagine-template-library/product-templates/photo-style-edit/world_snow_archer/RECIPE.md
@@ -1,0 +1,5 @@
+name: World · Snow Archer
+type: style-edit
+world: snow_archer
+desc: Restyle into official One World snow archer saga
+prompt: Restyle as Snow Archer braid scarred cheek northern saga, snowbound grade muted steel rune wood, keep composition, Image 2.0 Quality

--- a/imagine-template-library/product-templates/photo-style-edit/world_thorne_eldrath/RECIPE.md
+++ b/imagine-template-library/product-templates/photo-style-edit/world_thorne_eldrath/RECIPE.md
@@ -1,0 +1,5 @@
+name: World · Thorne Eldrath
+type: style-edit
+world: thorne_eldrath
+desc: Restyle into Thorne in Eldrath forest with crown
+prompt: Restyle as Sir Thorne Blackwood in Eldrath Forest with Crown of Eldrath, scarred haunted knight, god rays moss, painterly earth-gold, keep composition, Image 2.0 Quality

--- a/imagine-template-library/worlds/INDEX.md
+++ b/imagine-template-library/worlds/INDEX.md
@@ -1,0 +1,13 @@
+# World kits
+
+Official pattern: character + locations + props, one style across plates (Image 2.0 One World).
+
+| Slug | Title | Style |
+|------|-------|-------|
+| snow_archer | Snow Archer | northern saga (official demo refs) |
+| mara_neon | Mara Neon | rainy tech-noir |
+| clara_house | Clara House | aster folk dread |
+| maya_attic | Maya Attic | gerwig warm pastel |
+| jax_midnight | Jax Midnight | nolan wet-night |
+| mira_signal | Mira Signal | clinical horror |
+| thorne_eldrath | Thorne Eldrath | earth mystic gold |

--- a/imagine-template-library/worlds/clara_house/WORLD.md
+++ b/imagine-template-library/worlds/clara_house/WORLD.md
@@ -1,0 +1,23 @@
+# World kit: Clara House
+
+**Slug:** `clara_house`  
+**Style lock:** aster folk dread · sickly golden hour · domestic wrongness  
+**Style pack:** `aster_folk_dread`
+
+## Board
+| Kind | Slug |
+|------|------|
+| Character | `clara_voss` |
+| Location | `childhood_house` |
+| Prop | `house_key` |
+
+## Multi-ref recipe
+1. clara_voss hero
+2. childhood_house establish
+3. house_key hero
+4. Hold folk-dread golden hour — no neon
+
+## Scene still prompt seed
+```
+cinematic still, Clara Voss at overgrown childhood house porch, dark circles, gentle fraying, old brass house key, golden hour dread, Imagine Quality Mode
+```

--- a/imagine-template-library/worlds/jax_midnight/WORLD.md
+++ b/imagine-template-library/worlds/jax_midnight/WORLD.md
@@ -1,0 +1,24 @@
+# World kit: Jax Midnight
+
+**Slug:** `jax_midnight`  
+**Style lock:** nolan high contrast · wet night · cool blue / sodium orange  
+**Style pack:** `nolan_high_contrast`  
+**Official bridges:** Smart Resize 16:9 · Photo → Video (`rainy_downtown`)
+
+## Board
+| Kind | Slug |
+|------|------|
+| Character | `jax_rivera` |
+| Location | `rainy_downtown` |
+| Prop | `mustang_69` |
+
+## Multi-ref recipe
+1. jax_rivera hero
+2. rainy_downtown establish
+3. mustang_69 hero
+4. Hold wet-night chase grade
+
+## Scene still prompt seed
+```
+cinematic still, Jax Rivera beside 1969 Mustang on rainy downtown avenue night, tense focus, wet chrome, neon reflections, Imagine Quality Mode
+```

--- a/imagine-template-library/worlds/mara_neon/WORLD.md
+++ b/imagine-template-library/worlds/mara_neon/WORLD.md
@@ -1,0 +1,29 @@
+# World kit: Mara Neon
+
+**Slug:** `mara_neon`  
+**Style lock:** rainy tech-noir · magenta/cyan neon · wet asphalt · courier grit  
+**Official bridges:** Reimagine · BG Removal · Photo → Edit → Video (`product-templates/.../mara_neon`)
+
+## Board
+| Kind | Slug | Notes |
+|------|------|-------|
+| Character | `mara_chen` | neon courier DNA + plates |
+| Location | `neon_pier` | establish + coverage |
+| Location | `rain_noir_alley` | optional B-location |
+| Location | `rooftop_dawn` | optional cold contrast beat |
+| Prop | `courier_satchel` | hero / reverse / detail |
+
+## Multi-ref recipe (≤5)
+1. mara_chen hero
+2. neon_pier establish
+3. courier_satchel hero
+4. optional: rain_noir_alley establish OR satchel detail
+5. Hold neon rainy grade — no warm golden hour
+
+## Scene still prompt seed
+```
+cinematic still, Mara Chen at neon pier night, beauty mark, blunt bangs, charcoal courier jacket, courier satchel, magenta-cyan neon, rainy bokeh, identity lock, Imagine Quality Mode
+```
+
+## Video bridge
+Photo → Edit → Video: restyle into Mara@pier, then soft rain + neon flicker micro-motion.

--- a/imagine-template-library/worlds/maya_attic/WORLD.md
+++ b/imagine-template-library/worlds/maya_attic/WORLD.md
@@ -1,0 +1,25 @@
+# World kit: Maya Attic
+
+**Slug:** `maya_attic`  
+**Style lock:** gerwig warm pastel · golden dust · tender nostalgia  
+**Style pack:** `gerwig_warm_pastel`
+
+## Board
+| Kind | Slug |
+|------|------|
+| Character | `maya_chen` |
+| Location | `attic_golden` |
+| Prop | `unsent_letter_bundle` |
+| Prop | `steamer_trunk` |
+
+## Multi-ref recipe
+1. maya_chen hero
+2. attic_golden establish
+3. unsent_letter_bundle hero
+4. optional steamer_trunk
+5. Hold warm pastel — no cold teal
+
+## Scene still prompt seed
+```
+cinematic still, Maya Chen in dusty attic golden afternoon, warm smile, ribbon-tied letter bundle, steamer trunk, soft film grain, Imagine Quality Mode
+```

--- a/imagine-template-library/worlds/mira_signal/WORLD.md
+++ b/imagine-template-library/worlds/mira_signal/WORLD.md
@@ -1,0 +1,23 @@
+# World kit: Mira Signal
+
+**Slug:** `mira_signal`  
+**Style lock:** clinical horror white · sickly green · sterile dread  
+**Style pack:** `clinical_horror_white`
+
+## Board
+| Kind | Slug |
+|------|------|
+| Character | `mira_kane` |
+| Location | `signal_facility` |
+| Prop | `signal_tablet` |
+
+## Multi-ref recipe
+1. mira_kane hero
+2. signal_facility establish
+3. signal_tablet hero
+4. Hold sterile clinical grade — no warm nostalgia
+
+## Scene still prompt seed
+```
+cinematic still, Dr Mira Kane in sterile underground facility corridor, research tablet, clinical white sickly green, detached calm, Imagine Quality Mode
+```

--- a/imagine-template-library/worlds/thorne_eldrath/WORLD.md
+++ b/imagine-template-library/worlds/thorne_eldrath/WORLD.md
@@ -1,0 +1,25 @@
+# World kit: Thorne Eldrath
+
+**Slug:** `thorne_eldrath`  
+**Style lock:** earth mystic gold · forest greens · painterly myth  
+**Style pack:** `earth_mystic_gold`
+
+## Board
+| Kind | Slug |
+|------|------|
+| Character | `thorne_blackwood` |
+| Character | `elowen` (optional co-lead) |
+| Location | `eldrath_forest` |
+| Location | `ruined_hall` |
+| Prop | `eldrath_crown` |
+
+## Multi-ref recipe
+1. thorne_blackwood hero (or elowen)
+2. eldrath_forest OR ruined_hall establish
+3. eldrath_crown hero
+4. Hold mythic earth-gold — no neon
+
+## Scene still prompt seed
+```
+cinematic still, Sir Thorne Blackwood in Eldrath Forest, scarred haunted knight, Crown of Eldrath, god rays moss, painterly earth-gold grade, Imagine Quality Mode
+```


### PR DESCRIPTION
## Summary
Follow-up to #58: re-vendor the Imagine Template Library so the remaining **world kits** and `world_*` Create Template recipes land on main.

### Worlds (7 kits + INDEX)
- `snow_archer` (already present from #58; kept in sync)
- `mara_neon`
- `clara_house`
- `maya_attic`
- `jax_midnight`
- `mira_signal`
- `thorne_eldrath`
- `worlds/INDEX.md`

### Recipes
- `product-templates/photo-style-edit/world_*` — 7
- `product-templates/photo-edit-video/world_*` — 3 (`mara_neon`, `jax_midnight`, `snow_archer`)
- `product-templates/INDEX.md`
- Library total **~47** `RECIPE.md` files after full `rsync -a --delete` from agent library source

### Docs
- Light `imagine-template-library/README.md` Layout refresh (worlds / props / official / recipe index paths + counts)

### Validate fix (same class as #58)
- PR #58 validate failed on `test_live_repo_release_pin_passes` (content landed without catalog re-pin). Main went green after auto-pin `b2708b7`.
- This PR includes an explicit pin-only follow-up commit so the PR tip stays release-pin green.
- Local: **`pytest -q` → 708 passed**

## Test plan
- [x] Full library rsync from source → `imagine-template-library/`
- [x] Local `pytest -q` green
- [x] `plugin catalog check --release` green on pin tip
- [ ] CI validate on this PR