### PR TITLE
chore: re-vendor fantasy six world kits (Aetheris–Crystallis)

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -14,7 +14,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio.git",
-        "sha": "6884b50edba3e24677ea0fda20bfdafb4d8bc3d0"
+        "sha": "66d755a70924acbf0a486e4b910a8dc67f461b32"
       },
       "homepage": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio",
       "keywords": [
@@ -31,7 +31,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio.git",
-        "sha": "6884b50edba3e24677ea0fda20bfdafb4d8bc3d0"
+        "sha": "66d755a70924acbf0a486e4b910a8dc67f461b32"
       },
       "homepage": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio",
       "keywords": [
@@ -49,7 +49,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio.git",
-        "sha": "6884b50edba3e24677ea0fda20bfdafb4d8bc3d0"
+        "sha": "66d755a70924acbf0a486e4b910a8dc67f461b32"
       },
       "homepage": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio",
       "keywords": [
@@ -69,7 +69,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio.git",
-        "sha": "6884b50edba3e24677ea0fda20bfdafb4d8bc3d0"
+        "sha": "66d755a70924acbf0a486e4b910a8dc67f461b32"
       },
       "homepage": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio",
       "keywords": [
@@ -89,7 +89,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio.git",
-        "sha": "6884b50edba3e24677ea0fda20bfdafb4d8bc3d0"
+        "sha": "66d755a70924acbf0a486e4b910a8dc67f461b32"
       },
       "homepage": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio",
       "keywords": [
@@ -109,7 +109,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio.git",
-        "sha": "6884b50edba3e24677ea0fda20bfdafb4d8bc3d0"
+        "sha": "66d755a70924acbf0a486e4b910a8dc67f461b32"
       },
       "homepage": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio",
       "keywords": [

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -324,7 +324,7 @@
           }
         ]
       },
-      "sha": "6884b50edba3e24677ea0fda20bfdafb4d8bc3d0"
+      "sha": "66d755a70924acbf0a486e4b910a8dc67f461b32"
     },
     "grok-imagine-cinematic-core": {
       "components": {
@@ -473,7 +473,7 @@
           }
         ]
       },
-      "sha": "6884b50edba3e24677ea0fda20bfdafb4d8bc3d0"
+      "sha": "66d755a70924acbf0a486e4b910a8dc67f461b32"
     },
     "grok-imagine-camera-image": {
       "components": {
@@ -528,7 +528,7 @@
           }
         ]
       },
-      "sha": "6884b50edba3e24677ea0fda20bfdafb4d8bc3d0"
+      "sha": "66d755a70924acbf0a486e4b910a8dc67f461b32"
     },
     "grok-imagine-sequence-narrative": {
       "components": {
@@ -611,7 +611,7 @@
           }
         ]
       },
-      "sha": "6884b50edba3e24677ea0fda20bfdafb4d8bc3d0"
+      "sha": "66d755a70924acbf0a486e4b910a8dc67f461b32"
     },
     "grok-imagine-nsfw": {
       "components": {
@@ -640,7 +640,7 @@
           }
         ]
       },
-      "sha": "6884b50edba3e24677ea0fda20bfdafb4d8bc3d0"
+      "sha": "66d755a70924acbf0a486e4b910a8dc67f461b32"
     },
     "grok-imagine-delivery-post": {
       "components": {
@@ -681,7 +681,7 @@
           }
         ]
       },
-      "sha": "6884b50edba3e24677ea0fda20bfdafb4d8bc3d0"
+      "sha": "66d755a70924acbf0a486e4b910a8dc67f461b32"
     }
   }
 }

--- a/imagine-template-library/CATALOG.md
+++ b/imagine-template-library/CATALOG.md
@@ -69,9 +69,24 @@
 
 
 ## Worlds
-| Slug | Title | Notes |
+Official pattern: character + locations + props, one style across plates.
+
+| Slug | Title | Style |
 |------|-------|-------|
-| snow_archer | Snow Archer One World | Official Image 2.0 demo board; refs/image-2.0-one-world/ |
+| snow_archer | Snow Archer | northern saga (official demo) |
+| mara_neon | Mara Neon | rainy tech-noir |
+| clara_house | Clara House | aster folk dread |
+| maya_attic | Maya Attic | gerwig warm pastel |
+| jax_midnight | Jax Midnight | nolan wet-night |
+| mira_signal | Mira Signal | clinical horror |
+| thorne_eldrath | Thorne Eldrath | earth mystic gold |
+| aetheris | Aetheris | Floating Realms / golden hour |
+| thalassara | Thalassara | Abyssal Lumina / biolum deep |
+| neonexus | Neonexus | Wasteland Grid / neon desert |
+| eldergrove | Eldergrove | Living Weave / sentient forest |
+| steamforge | Steamforge | Clockwork Dominion / brass |
+| crystallis | Crystallis | Prismatic Veil / aurora crystal |
+
 
 ## Official Image 2.0 templates
 Source extract: grok.com/imagine agent-skills + x.ai news Image 2.0

--- a/imagine-template-library/README.md
+++ b/imagine-template-library/README.md
@@ -3,14 +3,17 @@
 Reusable packs for Grok Imagine — characters, locations, styles, shots — plus Create Template recipes.
 
 ## Layout
-- `characters/<slug>/` — PACK.md + dna.json
-- `locations/<slug>/` — PACK.md (establish + coverage)
+- `characters/<slug>/` — PACK.md + dna.json (20)
+- `locations/<slug>/` — PACK.md (establish + coverage) (21)
+- `props/<slug>/` — PACK.md (hero / reverse / detail) (19)
 - `styles/<slug>/` — grade/look prompts
 - `shots/<slug>/` — framing add-ons
-- `product-templates/` — paste-ready Create Template recipes
-  - `photo-style-edit/`
+- `worlds/<slug>/` — One World kits (13, incl. fantasy six Aetheris–Crystallis); see `worlds/INDEX.md`
+- `official-templates/` — Image 2.0 xAI templates
+- `product-templates/` — paste-ready Create Template recipes (53); see `product-templates/INDEX.md`
+  - `photo-style-edit/` (incl. `world_*`)
   - `photo-video/`
-  - `photo-edit-video/`
+  - `photo-edit-video/` (incl. `world_*` Live)
 - `_templates/` — blank scaffolds
 - `CATALOG.md` — index
 

--- a/imagine-template-library/characters/chrome_nomad/PACK.md
+++ b/imagine-template-library/characters/chrome_nomad/PACK.md
@@ -1,0 +1,16 @@
+# Character pack: Chrome Nomad
+
+**Slug:** `chrome_nomad`  
+**World:** `neonexus`  
+**Status:** dna-ready (LOCKED in Studio source)  
+**Type:** Photo Style Edit
+
+## DNA
+- Chrome cybernetic arm; neon pink-cyan implants; dust goggles on forehead; scrap-metal jacket; desert cloak; weathered rugged face.
+- World palette: Neon pink-cyan lights and implants, neon nights/scorching days, desert dust, holographic billboards, electrical buzz and distant sandstorm.
+
+## Prompts
+front: Chrome Nomad, Chrome cybernetic arm; neon pink-cyan implants; dust goggles on forehead; scrap-metal jacket; desert cloak; weathered rugged face., Neon pink-cyan lights and implants, neon nights/scorching days, desert dust, holographic billboards, electrical buzz and distant sandstorm., Imagine Quality Mode
+three_quarter: Chrome Nomad, Chrome cybernetic arm; neon pink-cyan implants; dust goggles on forehead; scrap-metal jacket; desert cloak; weathered rugged face., three-quarter, same world grade, Imagine Quality Mode
+profile: Chrome Nomad, profile lock, Chrome cybernetic arm; neon pink-cyan implants; dust goggles on forehead; scrap-metal jacket; desert cloak; weathered rugged face., Imagine Quality Mode
+full: Chrome Nomad, full body, Chrome cybernetic arm; neon pink-cyan implants; dust goggles on forehead; scrap-metal jacket; desert cloak; weathered rugged face., Cyberpunk Desert Megacity Street Market bokeh, Imagine Quality Mode

--- a/imagine-template-library/characters/chrome_nomad/dna.json
+++ b/imagine-template-library/characters/chrome_nomad/dna.json
@@ -1,0 +1,11 @@
+{
+  "schema": "1.0",
+  "name": "Chrome Nomad",
+  "slug": "chrome_nomad",
+  "world": "neonexus",
+  "version": 1,
+  "status": "dna-ready",
+  "locked": true,
+  "anchors": "Chrome cybernetic arm; neon pink-cyan implants; dust goggles on forehead; scrap-metal jacket; desert cloak; weathered rugged face.",
+  "source": "fantasy-worlds-extract"
+}

--- a/imagine-template-library/characters/cogborn_engineer/PACK.md
+++ b/imagine-template-library/characters/cogborn_engineer/PACK.md
@@ -1,0 +1,16 @@
+# Character pack: Cogborn Engineer
+
+**Slug:** `cogborn_engineer`  
+**World:** `steamforge`  
+**Status:** dna-ready (LOCKED in Studio source)  
+**Type:** Photo Style Edit
+
+## DNA
+- Brass goggles; leather apron over shirt/waistcoat; mechanical prosthetic hand; copper tools; focused expression.
+- World palette: Brass/copper metal, steam haze, industrial reflections, boiler warmth and airship skies.
+
+## Prompts
+front: Cogborn Engineer, Brass goggles; leather apron over shirt/waistcoat; mechanical prosthetic hand; copper tools; focused expression., Brass/copper metal, steam haze, industrial reflections, boiler warmth and airship skies., Imagine Quality Mode
+three_quarter: Cogborn Engineer, Brass goggles; leather apron over shirt/waistcoat; mechanical prosthetic hand; copper tools; focused expression., three-quarter, same world grade, Imagine Quality Mode
+profile: Cogborn Engineer, profile lock, Brass goggles; leather apron over shirt/waistcoat; mechanical prosthetic hand; copper tools; focused expression., Imagine Quality Mode
+full: Cogborn Engineer, full body, Brass goggles; leather apron over shirt/waistcoat; mechanical prosthetic hand; copper tools; focused expression., Brass Forge-City Plaza bokeh, Imagine Quality Mode

--- a/imagine-template-library/characters/cogborn_engineer/dna.json
+++ b/imagine-template-library/characters/cogborn_engineer/dna.json
@@ -1,0 +1,11 @@
+{
+  "schema": "1.0",
+  "name": "Cogborn Engineer",
+  "slug": "cogborn_engineer",
+  "world": "steamforge",
+  "version": 1,
+  "status": "dna-ready",
+  "locked": true,
+  "anchors": "Brass goggles; leather apron over shirt/waistcoat; mechanical prosthetic hand; copper tools; focused expression.",
+  "source": "fantasy-worlds-extract"
+}

--- a/imagine-template-library/characters/crystalborn_lightweaver/PACK.md
+++ b/imagine-template-library/characters/crystalborn_lightweaver/PACK.md
@@ -1,0 +1,16 @@
+# Character pack: Crystalborn Lightweaver
+
+**Slug:** `crystalborn_lightweaver`  
+**World:** `crystallis`  
+**Status:** dna-ready (LOCKED in Studio source)  
+**Type:** Photo Style Edit
+
+## DNA
+- Translucent prismatic/refracting skin; pure light-fabric robes; crystal diadem; glowing geometric tattoos.
+- World palette: Rainbow/prismatic refraction, living crystal light, aurora-lit night, faceted city glow, high shimmer and long crystal tails.
+
+## Prompts
+front: Crystalborn Lightweaver, Translucent prismatic/refracting skin; pure light-fabric robes; crystal diadem; glowing geometric tattoos., Rainbow/prismatic refraction, living crystal light, aurora-lit night, faceted city glow, high shimmer and long crystal tails., Imagine Quality Mode
+three_quarter: Crystalborn Lightweaver, Translucent prismatic/refracting skin; pure light-fabric robes; crystal diadem; glowing geometric tattoos., three-quarter, same world grade, Imagine Quality Mode
+profile: Crystalborn Lightweaver, profile lock, Translucent prismatic/refracting skin; pure light-fabric robes; crystal diadem; glowing geometric tattoos., Imagine Quality Mode
+full: Crystalborn Lightweaver, full body, Translucent prismatic/refracting skin; pure light-fabric robes; crystal diadem; glowing geometric tattoos., Crystalline Mountain & Prism Bridge bokeh, Imagine Quality Mode

--- a/imagine-template-library/characters/crystalborn_lightweaver/dna.json
+++ b/imagine-template-library/characters/crystalborn_lightweaver/dna.json
@@ -1,0 +1,11 @@
+{
+  "schema": "1.0",
+  "name": "Crystalborn Lightweaver",
+  "slug": "crystalborn_lightweaver",
+  "world": "crystallis",
+  "version": 1,
+  "status": "dna-ready",
+  "locked": true,
+  "anchors": "Translucent prismatic/refracting skin; pure light-fabric robes; crystal diadem; glowing geometric tattoos.",
+  "source": "fantasy-worlds-extract"
+}

--- a/imagine-template-library/characters/merfolk_luminae/PACK.md
+++ b/imagine-template-library/characters/merfolk_luminae/PACK.md
@@ -1,0 +1,16 @@
+# Character pack: Merfolk Luminae
+
+**Slug:** `merfolk_luminae`  
+**World:** `thalassara`  
+**Status:** dna-ready (LOCKED in Studio source)  
+**Type:** Photo Style Edit
+
+## DNA
+- Iridescent teal-cyan skin; bioluminescent fins and hair; coral jewelry; translucent scale armor; luminous cyan eyes.
+- World palette: Eternal midnight, teal/cyan bioluminescence, coral/crystal glow, luminous fish and giant jellyfish; underwater-filtered darkness.
+
+## Prompts
+front: Merfolk Luminae, Iridescent teal-cyan skin; bioluminescent fins and hair; coral jewelry; translucent scale armor; luminous cyan eyes., Eternal midnight, teal/cyan bioluminescence, coral/crystal glow, luminous fish and giant jellyfish; underwater-filtered darkness., Imagine Quality Mode
+three_quarter: Merfolk Luminae, Iridescent teal-cyan skin; bioluminescent fins and hair; coral jewelry; translucent scale armor; luminous cyan eyes., three-quarter, same world grade, Imagine Quality Mode
+profile: Merfolk Luminae, profile lock, Iridescent teal-cyan skin; bioluminescent fins and hair; coral jewelry; translucent scale armor; luminous cyan eyes., Imagine Quality Mode
+full: Merfolk Luminae, full body, Iridescent teal-cyan skin; bioluminescent fins and hair; coral jewelry; translucent scale armor; luminous cyan eyes., Bioluminescent Underwater Plaza bokeh, Imagine Quality Mode

--- a/imagine-template-library/characters/merfolk_luminae/dna.json
+++ b/imagine-template-library/characters/merfolk_luminae/dna.json
@@ -1,0 +1,11 @@
+{
+  "schema": "1.0",
+  "name": "Merfolk Luminae",
+  "slug": "merfolk_luminae",
+  "world": "thalassara",
+  "version": 1,
+  "status": "dna-ready",
+  "locked": true,
+  "anchors": "Iridescent teal-cyan skin; bioluminescent fins and hair; coral jewelry; translucent scale armor; luminous cyan eyes.",
+  "source": "fantasy-worlds-extract"
+}

--- a/imagine-template-library/characters/sylvan_kin/PACK.md
+++ b/imagine-template-library/characters/sylvan_kin/PACK.md
@@ -1,0 +1,16 @@
+# Character pack: Sylvan Kin
+
+**Slug:** `sylvan_kin`  
+**World:** `eldergrove`  
+**Status:** dna-ready (LOCKED in Studio source)  
+**Type:** Photo Style Edit
+
+## DNA
+- Bark-textured green-brown skin; leafy hair and moss; flowering living vine clothing; glowing emerald eyes.
+- World palette: Eternal spring mist, emerald/organic glow, luminous roots, canopy greens, floating seed pods and soft forest atmosphere.
+
+## Prompts
+front: Sylvan Kin, Bark-textured green-brown skin; leafy hair and moss; flowering living vine clothing; glowing emerald eyes., Eternal spring mist, emerald/organic glow, luminous roots, canopy greens, floating seed pods and soft forest atmosphere., Imagine Quality Mode
+three_quarter: Sylvan Kin, Bark-textured green-brown skin; leafy hair and moss; flowering living vine clothing; glowing emerald eyes., three-quarter, same world grade, Imagine Quality Mode
+profile: Sylvan Kin, profile lock, Bark-textured green-brown skin; leafy hair and moss; flowering living vine clothing; glowing emerald eyes., Imagine Quality Mode
+full: Sylvan Kin, full body, Bark-textured green-brown skin; leafy hair and moss; flowering living vine clothing; glowing emerald eyes., Living Canopy City bokeh, Imagine Quality Mode

--- a/imagine-template-library/characters/sylvan_kin/dna.json
+++ b/imagine-template-library/characters/sylvan_kin/dna.json
@@ -1,0 +1,11 @@
+{
+  "schema": "1.0",
+  "name": "Sylvan Kin",
+  "slug": "sylvan_kin",
+  "world": "eldergrove",
+  "version": 1,
+  "status": "dna-ready",
+  "locked": true,
+  "anchors": "Bark-textured green-brown skin; leafy hair and moss; flowering living vine clothing; glowing emerald eyes.",
+  "source": "fantasy-worlds-extract"
+}

--- a/imagine-template-library/characters/winged_skyfolk/PACK.md
+++ b/imagine-template-library/characters/winged_skyfolk/PACK.md
@@ -1,0 +1,16 @@
+# Character pack: Winged Skyfolk
+
+**Slug:** `winged_skyfolk`  
+**World:** `aetheris`  
+**Status:** dna-ready (LOCKED in Studio source)  
+**Type:** Photo Style Edit
+
+## DNA
+- Blue-gold gradient wings; golden/amber eyes; long golden-blonde hair; white-gold aether robes with crystal accents; tall elegant build.
+- World palette: Perpetual golden hour, golden-white aether glow, volumetric light, blue-gold wings, cloud/sky atmosphere and waterfall spray.
+
+## Prompts
+front: Winged Skyfolk, Blue-gold gradient wings; golden/amber eyes; long golden-blonde hair; white-gold aether robes with crystal accents; tall elegant build., Perpetual golden hour, golden-white aether glow, volumetric light, blue-gold wings, cloud/sky atmosphere and waterfall spray., Imagine Quality Mode
+three_quarter: Winged Skyfolk, Blue-gold gradient wings; golden/amber eyes; long golden-blonde hair; white-gold aether robes with crystal accents; tall elegant build., three-quarter, same world grade, Imagine Quality Mode
+profile: Winged Skyfolk, profile lock, Blue-gold gradient wings; golden/amber eyes; long golden-blonde hair; white-gold aether robes with crystal accents; tall elegant build., Imagine Quality Mode
+full: Winged Skyfolk, full body, Blue-gold gradient wings; golden/amber eyes; long golden-blonde hair; white-gold aether robes with crystal accents; tall elegant build., Floating Island Sky City Plaza bokeh, Imagine Quality Mode

--- a/imagine-template-library/characters/winged_skyfolk/dna.json
+++ b/imagine-template-library/characters/winged_skyfolk/dna.json
@@ -1,0 +1,11 @@
+{
+  "schema": "1.0",
+  "name": "Winged Skyfolk",
+  "slug": "winged_skyfolk",
+  "world": "aetheris",
+  "version": 1,
+  "status": "dna-ready",
+  "locked": true,
+  "anchors": "Blue-gold gradient wings; golden/amber eyes; long golden-blonde hair; white-gold aether robes with crystal accents; tall elegant build.",
+  "source": "fantasy-worlds-extract"
+}

--- a/imagine-template-library/locations/biolum_plaza/PACK.md
+++ b/imagine-template-library/locations/biolum_plaza/PACK.md
@@ -1,0 +1,16 @@
+# Location pack: Bioluminescent Underwater Plaza
+
+**Slug:** `biolum_plaza`  
+**World:** `thalassara`  
+**Status:** establish-ready  
+**Type:** Photo Style Edit
+
+## Bible
+- bioluminescent underwater plaza, giant jellyfish, luminous fish, eternal midnight
+- Palette: Eternal midnight, teal/cyan bioluminescence, coral/crystal glow, luminous fish and giant jellyfish; underwater-filtered darkness.
+- Characters: none on establish plates
+
+## Prompts
+establish: wide bioluminescent underwater plaza, giant jellyfish, luminous fish, eternal midnight, empty of characters, Imagine Quality Mode
+cov_a: mid coverage same location grade, empty of characters, Imagine Quality Mode
+cov_b: detail landmark coverage same grade, empty of characters, Imagine Quality Mode

--- a/imagine-template-library/locations/brass_forge_plaza/PACK.md
+++ b/imagine-template-library/locations/brass_forge_plaza/PACK.md
@@ -1,0 +1,16 @@
+# Location pack: Brass Forge-City Plaza
+
+**Slug:** `brass_forge_plaza`  
+**World:** `steamforge`  
+**Status:** establish-ready  
+**Type:** Photo Style Edit
+
+## Bible
+- brass forge-city plaza, steam haze, Victorian industrial airships
+- Palette: Brass/copper metal, steam haze, industrial reflections, boiler warmth and airship skies.
+- Characters: none on establish plates
+
+## Prompts
+establish: wide brass forge-city plaza, steam haze, Victorian industrial airships, empty of characters, Imagine Quality Mode
+cov_a: mid coverage same location grade, empty of characters, Imagine Quality Mode
+cov_b: detail landmark coverage same grade, empty of characters, Imagine Quality Mode

--- a/imagine-template-library/locations/desert_megacity_market/PACK.md
+++ b/imagine-template-library/locations/desert_megacity_market/PACK.md
@@ -1,0 +1,16 @@
+# Location pack: Cyberpunk Desert Megacity Street Market
+
+**Slug:** `desert_megacity_market`  
+**World:** `neonexus`  
+**Status:** establish-ready  
+**Type:** Photo Style Edit
+
+## Bible
+- neon desert megacity street market, holographic billboards, sand dust
+- Palette: Neon pink-cyan lights and implants, neon nights/scorching days, desert dust, holographic billboards, electrical buzz and distant sandstorm.
+- Characters: none on establish plates
+
+## Prompts
+establish: wide neon desert megacity street market, holographic billboards, sand dust, empty of characters, Imagine Quality Mode
+cov_a: mid coverage same location grade, empty of characters, Imagine Quality Mode
+cov_b: detail landmark coverage same grade, empty of characters, Imagine Quality Mode

--- a/imagine-template-library/locations/living_canopy_city/PACK.md
+++ b/imagine-template-library/locations/living_canopy_city/PACK.md
@@ -1,0 +1,16 @@
+# Location pack: Living Canopy City
+
+**Slug:** `living_canopy_city`  
+**World:** `eldergrove`  
+**Status:** establish-ready  
+**Type:** Photo Style Edit
+
+## Bible
+- living canopy city in colossal trees, glowing root highways, eternal spring mist
+- Palette: Eternal spring mist, emerald/organic glow, luminous roots, canopy greens, floating seed pods and soft forest atmosphere.
+- Characters: none on establish plates
+
+## Prompts
+establish: wide living canopy city in colossal trees, glowing root highways, eternal spring mist, empty of characters, Imagine Quality Mode
+cov_a: mid coverage same location grade, empty of characters, Imagine Quality Mode
+cov_b: detail landmark coverage same grade, empty of characters, Imagine Quality Mode

--- a/imagine-template-library/locations/prism_bridge/PACK.md
+++ b/imagine-template-library/locations/prism_bridge/PACK.md
@@ -1,0 +1,16 @@
+# Location pack: Crystalline Mountain & Prism Bridge
+
+**Slug:** `prism_bridge`  
+**World:** `crystallis`  
+**Status:** establish-ready  
+**Type:** Photo Style Edit
+
+## Bible
+- prism bridge between glowing crystal peaks, aurora-lit night
+- Palette: Rainbow/prismatic refraction, living crystal light, aurora-lit night, faceted city glow, high shimmer and long crystal tails.
+- Characters: none on establish plates
+
+## Prompts
+establish: wide prism bridge between glowing crystal peaks, aurora-lit night, empty of characters, Imagine Quality Mode
+cov_a: mid coverage same location grade, empty of characters, Imagine Quality Mode
+cov_b: detail landmark coverage same grade, empty of characters, Imagine Quality Mode

--- a/imagine-template-library/locations/sky_city_plaza/PACK.md
+++ b/imagine-template-library/locations/sky_city_plaza/PACK.md
@@ -1,0 +1,16 @@
+# Location pack: Floating Island Sky City Plaza
+
+**Slug:** `sky_city_plaza`  
+**World:** `aetheris`  
+**Status:** establish-ready  
+**Type:** Photo Style Edit
+
+## Bible
+- perpetual golden hour sky-city plaza, floating continents, aether light-bridges
+- Palette: Perpetual golden hour, golden-white aether glow, volumetric light, blue-gold wings, cloud/sky atmosphere and waterfall spray.
+- Characters: none on establish plates
+
+## Prompts
+establish: wide perpetual golden hour sky-city plaza, floating continents, aether light-bridges, empty of characters, Imagine Quality Mode
+cov_a: mid coverage same location grade, empty of characters, Imagine Quality Mode
+cov_b: detail landmark coverage same grade, empty of characters, Imagine Quality Mode

--- a/imagine-template-library/product-templates/INDEX.md
+++ b/imagine-template-library/product-templates/INDEX.md
@@ -1,0 +1,12 @@
+# Create Template recipes
+
+## photo-style-edit/
+Pack looks, official Imagine templates (`official_*`), world kits (`world_*`).
+
+## photo-video/
+Living locations (e.g. rainy_downtown, nexus9_storm).
+
+## photo-edit-video/
+Character-in-world motion (`world_*` Live recipes).
+
+Map to Imagine UI: Type → Prompts → Test → Preview.

--- a/imagine-template-library/product-templates/photo-edit-video/world_jax_midnight/RECIPE.md
+++ b/imagine-template-library/product-templates/photo-edit-video/world_jax_midnight/RECIPE.md
@@ -1,0 +1,5 @@
+name: World · Jax Midnight Live
+type: edit-then-video
+world: jax_midnight
+edit: Restyle as Jax Rivera with 1969 Mustang on wet downtown night avenue
+video: Tracking along wet avenue, rain streaks, neon flicker, car idle micro-motion, no people crowd, keep night grade

--- a/imagine-template-library/product-templates/photo-edit-video/world_mara_neon/RECIPE.md
+++ b/imagine-template-library/product-templates/photo-edit-video/world_mara_neon/RECIPE.md
@@ -1,0 +1,5 @@
+name: World · Mara Neon Live
+type: edit-then-video
+world: mara_neon
+edit: Restyle as Mara Chen at neon pier night with courier satchel, magenta-cyan neon rainy bokeh, identity lock
+video: Soft rain drift, neon flicker, jacket and satchel micro-movement, Mara identity locked, no hard cuts

--- a/imagine-template-library/product-templates/photo-edit-video/world_snow_archer/RECIPE.md
+++ b/imagine-template-library/product-templates/photo-edit-video/world_snow_archer/RECIPE.md
@@ -1,0 +1,5 @@
+name: World · Snow Archer Live
+type: edit-then-video
+world: snow_archer
+edit: Restyle as Snow Archer in northern saga snow, braid scarred cheek
+video: Gentle blizzard drift, breath fog, soft camera push, identity locked, cold saga grade

--- a/imagine-template-library/product-templates/photo-style-edit/world_aetheris/RECIPE.md
+++ b/imagine-template-library/product-templates/photo-style-edit/world_aetheris/RECIPE.md
@@ -1,0 +1,5 @@
+name: World · Aetheris
+type: style-edit
+world: aetheris
+desc: Restyle into Winged Skyfolk / Floating Island Sky City Plaza / Windweaving Staff
+prompt: Restyle as Winged Skyfolk in Floating Island Sky City Plaza with Windweaving Staff, Blue-gold gradient wings; golden/amber eyes; long golden-blonde hair; white-gold aether robes with crystal accents; tall elegant build., Perpetual golden hour, golden-white aether glow, volumetric light, blue-gold wings, cloud/sky atmosphere and waterfall spray., keep composition, Image 2.0 Quality

--- a/imagine-template-library/product-templates/photo-style-edit/world_clara_house/RECIPE.md
+++ b/imagine-template-library/product-templates/photo-style-edit/world_clara_house/RECIPE.md
@@ -1,0 +1,5 @@
+name: World · Clara House
+type: style-edit
+world: clara_house
+desc: Restyle into Clara at the childhood house with key
+prompt: Restyle as Clara Voss at overgrown childhood house porch, dark circles gentle fraying, old brass house key, sickly golden hour folk dread, keep composition, Image 2.0 Quality

--- a/imagine-template-library/product-templates/photo-style-edit/world_crystallis/RECIPE.md
+++ b/imagine-template-library/product-templates/photo-style-edit/world_crystallis/RECIPE.md
@@ -1,0 +1,5 @@
+name: World · Crystallis
+type: style-edit
+world: crystallis
+desc: Restyle into Crystalborn Lightweaver / Crystalline Mountain & Prism Bridge / Harmonic Prism Crystal
+prompt: Restyle as Crystalborn Lightweaver in Crystalline Mountain & Prism Bridge with Harmonic Prism Crystal, Translucent prismatic/refracting skin; pure light-fabric robes; crystal diadem; glowing geometric tattoos., Rainbow/prismatic refraction, living crystal light, aurora-lit night, faceted city glow, high shimmer and long crystal tails., keep composition, Image 2.0 Quality

--- a/imagine-template-library/product-templates/photo-style-edit/world_eldergrove/RECIPE.md
+++ b/imagine-template-library/product-templates/photo-style-edit/world_eldergrove/RECIPE.md
@@ -1,0 +1,5 @@
+name: World · Eldergrove
+type: style-edit
+world: eldergrove
+desc: Restyle into Sylvan Kin / Living Canopy City / Living Root Wand
+prompt: Restyle as Sylvan Kin in Living Canopy City with Living Root Wand, Bark-textured green-brown skin; leafy hair and moss; flowering living vine clothing; glowing emerald eyes., Eternal spring mist, emerald/organic glow, luminous roots, canopy greens, floating seed pods and soft forest atmosphere., keep composition, Image 2.0 Quality

--- a/imagine-template-library/product-templates/photo-style-edit/world_jax_midnight/RECIPE.md
+++ b/imagine-template-library/product-templates/photo-style-edit/world_jax_midnight/RECIPE.md
@@ -1,0 +1,5 @@
+name: World · Jax Midnight
+type: style-edit
+world: jax_midnight
+desc: Restyle into Jax with Mustang on rainy downtown
+prompt: Restyle as Jax Rivera beside 1969 Mustang on rainy downtown avenue night, tense focus wet chrome neon reflections, cool high contrast, keep composition, Image 2.0 Quality

--- a/imagine-template-library/product-templates/photo-style-edit/world_mara_neon/RECIPE.md
+++ b/imagine-template-library/product-templates/photo-style-edit/world_mara_neon/RECIPE.md
@@ -1,0 +1,5 @@
+name: World · Mara Neon
+type: style-edit
+world: mara_neon
+desc: Restyle into Mara at neon pier with courier satchel
+prompt: Restyle as Mara Chen at neon pier night, beauty mark blunt bangs charcoal courier jacket courier satchel, magenta-cyan neon rainy bokeh, keep composition, Image 2.0 Quality

--- a/imagine-template-library/product-templates/photo-style-edit/world_maya_attic/RECIPE.md
+++ b/imagine-template-library/product-templates/photo-style-edit/world_maya_attic/RECIPE.md
@@ -1,0 +1,5 @@
+name: World · Maya Attic
+type: style-edit
+world: maya_attic
+desc: Restyle into Maya in the golden attic with letters
+prompt: Restyle as Maya Chen in dusty attic golden afternoon, warm smile, ribbon-tied letter bundle steamer trunk, soft pastel film grain, keep composition, Image 2.0 Quality

--- a/imagine-template-library/product-templates/photo-style-edit/world_mira_signal/RECIPE.md
+++ b/imagine-template-library/product-templates/photo-style-edit/world_mira_signal/RECIPE.md
@@ -1,0 +1,5 @@
+name: World · Mira Signal
+type: style-edit
+world: mira_signal
+desc: Restyle into Mira Kane in the signal facility
+prompt: Restyle as Dr Mira Kane in sterile underground facility with research tablet, clinical white sickly green, detached calm, keep composition, Image 2.0 Quality

--- a/imagine-template-library/product-templates/photo-style-edit/world_neonexus/RECIPE.md
+++ b/imagine-template-library/product-templates/photo-style-edit/world_neonexus/RECIPE.md
@@ -1,0 +1,5 @@
+name: World · Neonexus
+type: style-edit
+world: neonexus
+desc: Restyle into Chrome Nomad / Cyberpunk Desert Megacity Street Market / Chrome Hoverbike
+prompt: Restyle as Chrome Nomad in Cyberpunk Desert Megacity Street Market with Chrome Hoverbike, Chrome cybernetic arm; neon pink-cyan implants; dust goggles on forehead; scrap-metal jacket; desert cloak; weathered rugged face., Neon pink-cyan lights and implants, neon nights/scorching days, desert dust, holographic billboards, electrical buzz and distant sandstorm., keep composition, Image 2.0 Quality

--- a/imagine-template-library/product-templates/photo-style-edit/world_snow_archer/RECIPE.md
+++ b/imagine-template-library/product-templates/photo-style-edit/world_snow_archer/RECIPE.md
@@ -1,0 +1,5 @@
+name: World · Snow Archer
+type: style-edit
+world: snow_archer
+desc: Restyle into official One World snow archer saga
+prompt: Restyle as Snow Archer braid scarred cheek northern saga, snowbound grade muted steel rune wood, keep composition, Image 2.0 Quality

--- a/imagine-template-library/product-templates/photo-style-edit/world_steamforge/RECIPE.md
+++ b/imagine-template-library/product-templates/photo-style-edit/world_steamforge/RECIPE.md
@@ -1,0 +1,5 @@
+name: World · Steamforge
+type: style-edit
+world: steamforge
+desc: Restyle into Cogborn Engineer / Brass Forge-City Plaza / Steam-Aether Pistol
+prompt: Restyle as Cogborn Engineer in Brass Forge-City Plaza with Steam-Aether Pistol, Brass goggles; leather apron over shirt/waistcoat; mechanical prosthetic hand; copper tools; focused expression., Brass/copper metal, steam haze, industrial reflections, boiler warmth and airship skies., keep composition, Image 2.0 Quality

--- a/imagine-template-library/product-templates/photo-style-edit/world_thalassara/RECIPE.md
+++ b/imagine-template-library/product-templates/photo-style-edit/world_thalassara/RECIPE.md
@@ -1,0 +1,5 @@
+name: World · Thalassara
+type: style-edit
+world: thalassara
+desc: Restyle into Merfolk Luminae / Bioluminescent Underwater Plaza / Bioluminescent Coral Staff
+prompt: Restyle as Merfolk Luminae in Bioluminescent Underwater Plaza with Bioluminescent Coral Staff, Iridescent teal-cyan skin; bioluminescent fins and hair; coral jewelry; translucent scale armor; luminous cyan eyes., Eternal midnight, teal/cyan bioluminescence, coral/crystal glow, luminous fish and giant jellyfish; underwater-filtered darkness., keep composition, Image 2.0 Quality

--- a/imagine-template-library/product-templates/photo-style-edit/world_thorne_eldrath/RECIPE.md
+++ b/imagine-template-library/product-templates/photo-style-edit/world_thorne_eldrath/RECIPE.md
@@ -1,0 +1,5 @@
+name: World · Thorne Eldrath
+type: style-edit
+world: thorne_eldrath
+desc: Restyle into Thorne in Eldrath forest with crown
+prompt: Restyle as Sir Thorne Blackwood in Eldrath Forest with Crown of Eldrath, scarred haunted knight, god rays moss, painterly earth-gold, keep composition, Image 2.0 Quality

--- a/imagine-template-library/props/biolum_coral_staff/PACK.md
+++ b/imagine-template-library/props/biolum_coral_staff/PACK.md
@@ -1,0 +1,14 @@
+# Prop pack: Bioluminescent Coral Staff
+
+**Slug:** `biolum_coral_staff`  
+**World:** `thalassara`  
+**Status:** hero-ready  
+**Type:** Photo Style Edit
+
+## One-liner
+bioluminescent coral staff, teal-cyan glow
+
+## Prompts
+prop_biolum_coral_staff_hero: bioluminescent coral staff, teal-cyan glow, hero three-quarter, Imagine Quality Mode
+prop_biolum_coral_staff_reverse: reverse angle same prop, Imagine Quality Mode
+prop_biolum_coral_staff_detail: detail close-up material and marks, Imagine Quality Mode

--- a/imagine-template-library/props/chrome_hoverbike/PACK.md
+++ b/imagine-template-library/props/chrome_hoverbike/PACK.md
@@ -1,0 +1,14 @@
+# Prop pack: Chrome Hoverbike
+
+**Slug:** `chrome_hoverbike`  
+**World:** `neonexus`  
+**Status:** hero-ready  
+**Type:** Photo Style Edit
+
+## One-liner
+rugged chrome hoverbike, neon pink-cyan lights, scrap cyber
+
+## Prompts
+prop_chrome_hoverbike_hero: rugged chrome hoverbike, neon pink-cyan lights, scrap cyber, hero three-quarter, Imagine Quality Mode
+prop_chrome_hoverbike_reverse: reverse angle same prop, Imagine Quality Mode
+prop_chrome_hoverbike_detail: detail close-up material and marks, Imagine Quality Mode

--- a/imagine-template-library/props/harmonic_prism/PACK.md
+++ b/imagine-template-library/props/harmonic_prism/PACK.md
@@ -1,0 +1,14 @@
+# Prop pack: Harmonic Prism Crystal
+
+**Slug:** `harmonic_prism`  
+**World:** `crystallis`  
+**Status:** hero-ready  
+**Type:** Photo Style Edit
+
+## One-liner
+harmonic prism crystal, rainbow refraction
+
+## Prompts
+prop_harmonic_prism_hero: harmonic prism crystal, rainbow refraction, hero three-quarter, Imagine Quality Mode
+prop_harmonic_prism_reverse: reverse angle same prop, Imagine Quality Mode
+prop_harmonic_prism_detail: detail close-up material and marks, Imagine Quality Mode

--- a/imagine-template-library/props/living_root_wand/PACK.md
+++ b/imagine-template-library/props/living_root_wand/PACK.md
@@ -1,0 +1,14 @@
+# Prop pack: Living Root Wand
+
+**Slug:** `living_root_wand`  
+**World:** `eldergrove`  
+**Status:** hero-ready  
+**Type:** Photo Style Edit
+
+## One-liner
+living root wand with glowing emerald tips
+
+## Prompts
+prop_living_root_wand_hero: living root wand with glowing emerald tips, hero three-quarter, Imagine Quality Mode
+prop_living_root_wand_reverse: reverse angle same prop, Imagine Quality Mode
+prop_living_root_wand_detail: detail close-up material and marks, Imagine Quality Mode

--- a/imagine-template-library/props/steam_aether_pistol/PACK.md
+++ b/imagine-template-library/props/steam_aether_pistol/PACK.md
@@ -1,0 +1,14 @@
+# Prop pack: Steam-Aether Pistol
+
+**Slug:** `steam_aether_pistol`  
+**World:** `steamforge`  
+**Status:** hero-ready  
+**Type:** Photo Style Edit
+
+## One-liner
+brass steam-aether pistol, copper fittings
+
+## Prompts
+prop_steam_aether_pistol_hero: brass steam-aether pistol, copper fittings, hero three-quarter, Imagine Quality Mode
+prop_steam_aether_pistol_reverse: reverse angle same prop, Imagine Quality Mode
+prop_steam_aether_pistol_detail: detail close-up material and marks, Imagine Quality Mode

--- a/imagine-template-library/props/windweaving_staff/PACK.md
+++ b/imagine-template-library/props/windweaving_staff/PACK.md
@@ -1,0 +1,14 @@
+# Prop pack: Windweaving Staff
+
+**Slug:** `windweaving_staff`  
+**World:** `aetheris`  
+**Status:** hero-ready  
+**Type:** Photo Style Edit
+
+## One-liner
+windweaving staff with aether crystal accents
+
+## Prompts
+prop_windweaving_staff_hero: windweaving staff with aether crystal accents, hero three-quarter, Imagine Quality Mode
+prop_windweaving_staff_reverse: reverse angle same prop, Imagine Quality Mode
+prop_windweaving_staff_detail: detail close-up material and marks, Imagine Quality Mode

--- a/imagine-template-library/worlds/INDEX.md
+++ b/imagine-template-library/worlds/INDEX.md
@@ -1,0 +1,19 @@
+# World kits
+
+Official pattern: character + locations + props, one style across plates.
+
+| Slug | Title | Style |
+|------|-------|-------|
+| snow_archer | Snow Archer | northern saga (official demo) |
+| mara_neon | Mara Neon | rainy tech-noir |
+| clara_house | Clara House | aster folk dread |
+| maya_attic | Maya Attic | gerwig warm pastel |
+| jax_midnight | Jax Midnight | nolan wet-night |
+| mira_signal | Mira Signal | clinical horror |
+| thorne_eldrath | Thorne Eldrath | earth mystic gold |
+| aetheris | Aetheris | Floating Realms / golden hour |
+| thalassara | Thalassara | Abyssal Lumina / biolum deep |
+| neonexus | Neonexus | Wasteland Grid / neon desert |
+| eldergrove | Eldergrove | Living Weave / sentient forest |
+| steamforge | Steamforge | Clockwork Dominion / brass |
+| crystallis | Crystallis | Prismatic Veil / aurora crystal |

--- a/imagine-template-library/worlds/aetheris/WORLD.md
+++ b/imagine-template-library/worlds/aetheris/WORLD.md
@@ -1,0 +1,35 @@
+# World kit: Aetheris
+
+**Slug:** `aetheris`  
+**Premise:** The Floating Realms: an endless sky-ocean of floating continents linked by aether light-bridges; Winged Skyfolk and cloud spirits ride magitech airships through perpetual golden hour.  
+**Style lock / palette:** Perpetual golden hour, golden-white aether glow, volumetric light, blue-gold wings, cloud/sky atmosphere and waterfall spray.  
+**Trailer tag:** Wonder / Freedom  
+**DNA status:** LOCKED (source Studio Odyssey)  
+**Source:** Imagine Studio “6 Original Fantasy World Concepts” extract
+
+## Board
+| Kind | Slug | Notes |
+|------|------|-------|
+| Character | `winged_skyfolk` | Winged Skyfolk — LOCKED |
+| Location | `sky_city_plaza` | Floating Island Sky City Plaza (hero establish) |
+| Prop | `windweaving_staff` | Windweaving Staff |
+| More locs | — | Floating Island Sky City Plaza; Cloud sea; Waterfall islands; Aether light-bridge / glowing light-bridge city |
+| More props | — | Aether Light-Bridge Fragment, Magitech Airship Helm, Windweaving Staff |
+
+## Multi-ref recipe (≤5)
+1. `winged_skyfolk` hero
+2. `sky_city_plaza` establish
+3. `windweaving_staff` hero
+4. optional second loc/prop from board
+5. Hold world palette — do not cross-grade into other fantasy worlds
+
+## Scene still prompt seed
+```
+cinematic still, Winged Skyfolk in Floating Island Sky City Plaza, Blue-gold gradient wings; golden/amber eyes; long golden-blonde hair; white-gold aether robes with crystal accents; tall elegant build., windweaving staff with aether crystal accents, Perpetual golden hour, golden-white aether glow, volumetric light, blue-gold wings, cloud/sky atmosphere and waterfall spray., Imagine Quality Mode
+```
+
+## Style notes
+Rising wide, tracking/bank, dive/pull-up, push/orbit and crane resolve; ethereal choir/high strings, open-sky Doppler, crystalline aether chimes.
+
+## Production status
+Long-form Flight of the Skyfolk completed, titled, stitched and polished; ~69s delivery/high masters shown. Six-world trailer clip also approved.

--- a/imagine-template-library/worlds/clara_house/WORLD.md
+++ b/imagine-template-library/worlds/clara_house/WORLD.md
@@ -1,0 +1,23 @@
+# World kit: Clara House
+
+**Slug:** `clara_house`  
+**Style lock:** aster folk dread · sickly golden hour · domestic wrongness  
+**Style pack:** `aster_folk_dread`
+
+## Board
+| Kind | Slug |
+|------|------|
+| Character | `clara_voss` |
+| Location | `childhood_house` |
+| Prop | `house_key` |
+
+## Multi-ref recipe
+1. clara_voss hero
+2. childhood_house establish
+3. house_key hero
+4. Hold folk-dread golden hour — no neon
+
+## Scene still prompt seed
+```
+cinematic still, Clara Voss at overgrown childhood house porch, dark circles, gentle fraying, old brass house key, golden hour dread, Imagine Quality Mode
+```

--- a/imagine-template-library/worlds/crystallis/WORLD.md
+++ b/imagine-template-library/worlds/crystallis/WORLD.md
@@ -1,0 +1,35 @@
+# World kit: Crystallis
+
+**Slug:** `crystallis`  
+**Premise:** The Prismatic Veil: towering crystal mountains and faceted cities glowing with living light; Crystalborn Lightweavers harness harmonic prism magic across aurora-lit nights.  
+**Style lock / palette:** Rainbow/prismatic refraction, living crystal light, aurora-lit night, faceted city glow, high shimmer and long crystal tails.  
+**Trailer tag:** Transcendence / Unity  
+**DNA status:** LOCKED (source Studio Odyssey)  
+**Source:** Imagine Studio “6 Original Fantasy World Concepts” extract
+
+## Board
+| Kind | Slug | Notes |
+|------|------|-------|
+| Character | `crystalborn_lightweaver` | Crystalborn Lightweaver — LOCKED |
+| Location | `prism_bridge` | Crystalline Mountain & Prism Bridge (hero establish) |
+| Prop | `harmonic_prism` | Harmonic Prism Crystal |
+| More locs | — | Crystalline Mountain & Prism Bridge; Prism bridge between glowing crystal peaks; Crystal mountains; Faceted cities |
+| More props | — | Harmonic Prism Crystal, Lightforge Diadem, Resonance Shard Blade |
+
+## Multi-ref recipe (≤5)
+1. `crystalborn_lightweaver` hero
+2. `prism_bridge` establish
+3. `harmonic_prism` hero
+4. optional second loc/prop from board
+5. Hold world palette — do not cross-grade into other fantasy worlds
+
+## Scene still prompt seed
+```
+cinematic still, Crystalborn Lightweaver in Crystalline Mountain & Prism Bridge, Translucent prismatic/refracting skin; pure light-fabric robes; crystal diadem; glowing geometric tattoos., harmonic prism crystal, rainbow refraction, Rainbow/prismatic refraction, living crystal light, aurora-lit night, faceted city glow, high shimmer and long crystal tails., Imagine Quality Mode
+```
+
+## Style notes
+Rainbow ritual, harmonic resonance, prism chimes, floating shard orbit, light-fabric flow, aurora/crystal air; Transcendence / Unity.
+
+## Production status
+Concept, hero scene, location/prop plates and locked DNA visible; trailer clip 06 exists. No long-form sequence status visible.

--- a/imagine-template-library/worlds/eldergrove/WORLD.md
+++ b/imagine-template-library/worlds/eldergrove/WORLD.md
@@ -1,0 +1,35 @@
+# World kit: Eldergrove
+
+**Slug:** `eldergrove`  
+**Premise:** The Living Weave: a sentient planet-forest where colossal trees form living cities and glowing root highways; Sylvan Kin and dryad collectives commune via Lifeweave magic in eternal spring mist.  
+**Style lock / palette:** Eternal spring mist, emerald/organic glow, luminous roots, canopy greens, floating seed pods and soft forest atmosphere.  
+**Trailer tag:** Peace / Ancient  
+**DNA status:** LOCKED (source Studio Odyssey)  
+**Source:** Imagine Studio “6 Original Fantasy World Concepts” extract
+
+## Board
+| Kind | Slug | Notes |
+|------|------|-------|
+| Character | `sylvan_kin` | Sylvan Kin — LOCKED |
+| Location | `living_canopy_city` | Living Canopy City (hero establish) |
+| Prop | `living_root_wand` | Living Root Wand |
+| More locs | — | Living Canopy City; Glowing root highways; Sentient planet-forest |
+| More props | — | Living Root Wand, Memory Tree Seed Pod, Spirit Grove Lantern |
+
+## Multi-ref recipe (≤5)
+1. `sylvan_kin` hero
+2. `living_canopy_city` establish
+3. `living_root_wand` hero
+4. optional second loc/prop from board
+5. Hold world palette — do not cross-grade into other fantasy worlds
+
+## Scene still prompt seed
+```
+cinematic still, Sylvan Kin in Living Canopy City, Bark-textured green-brown skin; leafy hair and moss; flowering living vine clothing; glowing emerald eyes., living root wand with glowing emerald tips, Eternal spring mist, emerald/organic glow, luminous roots, canopy greens, floating seed pods and soft forest atmosphere., Imagine Quality Mode
+```
+
+## Style notes
+Organic root motion, walking beneath canopy cities, wooden pulse/root drone/leaf motif, mid-organic reverb and eternal spring mist; Peace / Ancient.
+
+## Production status
+Concept, hero scene, location/prop plates and locked DNA visible; trailer clip 04 exists. No long-form sequence status visible.

--- a/imagine-template-library/worlds/jax_midnight/WORLD.md
+++ b/imagine-template-library/worlds/jax_midnight/WORLD.md
@@ -1,0 +1,24 @@
+# World kit: Jax Midnight
+
+**Slug:** `jax_midnight`  
+**Style lock:** nolan high contrast · wet night · cool blue / sodium orange  
+**Style pack:** `nolan_high_contrast`  
+**Official bridges:** Smart Resize 16:9 · Photo → Video (`rainy_downtown`)
+
+## Board
+| Kind | Slug |
+|------|------|
+| Character | `jax_rivera` |
+| Location | `rainy_downtown` |
+| Prop | `mustang_69` |
+
+## Multi-ref recipe
+1. jax_rivera hero
+2. rainy_downtown establish
+3. mustang_69 hero
+4. Hold wet-night chase grade
+
+## Scene still prompt seed
+```
+cinematic still, Jax Rivera beside 1969 Mustang on rainy downtown avenue night, tense focus, wet chrome, neon reflections, Imagine Quality Mode
+```

--- a/imagine-template-library/worlds/mara_neon/WORLD.md
+++ b/imagine-template-library/worlds/mara_neon/WORLD.md
@@ -1,0 +1,29 @@
+# World kit: Mara Neon
+
+**Slug:** `mara_neon`  
+**Style lock:** rainy tech-noir · magenta/cyan neon · wet asphalt · courier grit  
+**Official bridges:** Reimagine · BG Removal · Photo → Edit → Video (`product-templates/.../mara_neon`)
+
+## Board
+| Kind | Slug | Notes |
+|------|------|-------|
+| Character | `mara_chen` | neon courier DNA + plates |
+| Location | `neon_pier` | establish + coverage |
+| Location | `rain_noir_alley` | optional B-location |
+| Location | `rooftop_dawn` | optional cold contrast beat |
+| Prop | `courier_satchel` | hero / reverse / detail |
+
+## Multi-ref recipe (≤5)
+1. mara_chen hero
+2. neon_pier establish
+3. courier_satchel hero
+4. optional: rain_noir_alley establish OR satchel detail
+5. Hold neon rainy grade — no warm golden hour
+
+## Scene still prompt seed
+```
+cinematic still, Mara Chen at neon pier night, beauty mark, blunt bangs, charcoal courier jacket, courier satchel, magenta-cyan neon, rainy bokeh, identity lock, Imagine Quality Mode
+```
+
+## Video bridge
+Photo → Edit → Video: restyle into Mara@pier, then soft rain + neon flicker micro-motion.

--- a/imagine-template-library/worlds/maya_attic/WORLD.md
+++ b/imagine-template-library/worlds/maya_attic/WORLD.md
@@ -1,0 +1,25 @@
+# World kit: Maya Attic
+
+**Slug:** `maya_attic`  
+**Style lock:** gerwig warm pastel · golden dust · tender nostalgia  
+**Style pack:** `gerwig_warm_pastel`
+
+## Board
+| Kind | Slug |
+|------|------|
+| Character | `maya_chen` |
+| Location | `attic_golden` |
+| Prop | `unsent_letter_bundle` |
+| Prop | `steamer_trunk` |
+
+## Multi-ref recipe
+1. maya_chen hero
+2. attic_golden establish
+3. unsent_letter_bundle hero
+4. optional steamer_trunk
+5. Hold warm pastel — no cold teal
+
+## Scene still prompt seed
+```
+cinematic still, Maya Chen in dusty attic golden afternoon, warm smile, ribbon-tied letter bundle, steamer trunk, soft film grain, Imagine Quality Mode
+```

--- a/imagine-template-library/worlds/mira_signal/WORLD.md
+++ b/imagine-template-library/worlds/mira_signal/WORLD.md
@@ -1,0 +1,23 @@
+# World kit: Mira Signal
+
+**Slug:** `mira_signal`  
+**Style lock:** clinical horror white · sickly green · sterile dread  
+**Style pack:** `clinical_horror_white`
+
+## Board
+| Kind | Slug |
+|------|------|
+| Character | `mira_kane` |
+| Location | `signal_facility` |
+| Prop | `signal_tablet` |
+
+## Multi-ref recipe
+1. mira_kane hero
+2. signal_facility establish
+3. signal_tablet hero
+4. Hold sterile clinical grade — no warm nostalgia
+
+## Scene still prompt seed
+```
+cinematic still, Dr Mira Kane in sterile underground facility corridor, research tablet, clinical white sickly green, detached calm, Imagine Quality Mode
+```

--- a/imagine-template-library/worlds/neonexus/WORLD.md
+++ b/imagine-template-library/worlds/neonexus/WORLD.md
@@ -1,0 +1,35 @@
+# World kit: Neonexus
+
+**Slug:** `neonexus`  
+**Premise:** The Wasteland Grid: post-collapse cyberpunk megacities rising from endless desert dunes; Chrome Nomads and data ghosts scavenge quantum tech under neon nights and scorching days.  
+**Style lock / palette:** Neon pink-cyan lights and implants, neon nights/scorching days, desert dust, holographic billboards, electrical buzz and distant sandstorm.  
+**Trailer tag:** Energy / Grit  
+**DNA status:** LOCKED (source Studio Odyssey)  
+**Source:** Imagine Studio “6 Original Fantasy World Concepts” extract
+
+## Board
+| Kind | Slug | Notes |
+|------|------|-------|
+| Character | `chrome_nomad` | Chrome Nomad — LOCKED |
+| Location | `desert_megacity_market` | Cyberpunk Desert Megacity Street Market (hero establish) |
+| Prop | `chrome_hoverbike` | Chrome Hoverbike |
+| More locs | — | Cyberpunk Desert Megacity Street Market; Neon-lit desert streets; Scrap canyon; Neon skyline |
+| More props | — | Chrome Hoverbike, Quantum Scrap Gauntlet, Holo-Oasis Projector |
+
+## Multi-ref recipe (≤5)
+1. `chrome_nomad` hero
+2. `desert_megacity_market` establish
+3. `chrome_hoverbike` hero
+4. optional second loc/prop from board
+5. Hold world palette — do not cross-grade into other fantasy worlds
+
+## Scene still prompt seed
+```
+cinematic still, Chrome Nomad in Cyberpunk Desert Megacity Street Market, Chrome cybernetic arm; neon pink-cyan implants; dust goggles on forehead; scrap-metal jacket; desert cloak; weathered rugged face., rugged chrome hoverbike, neon pink-cyan lights, scrap cyber, Neon pink-cyan lights and implants, neon nights/scorching days, desert dust, holographic billboards, electrical buzz and distant sandstorm., Imagine Quality Mode
+```
+
+## Style notes
+Kinetic low-angle tracking, thruster bank, pink-cyan trails, holo streaks, dust, glitch/industrial energy and dry-street Doppler; Grit → Speed → Pressure → Flash → Calm → Neon resolve.
+
+## Production status
+Chrome Run mid-clips: Clip 01 generated with Conditional GO and near-threshold drift; Clip 02 generated with mandatory DNA re-inject and awaiting gate; clips 03–06 pending.

--- a/imagine-template-library/worlds/steamforge/WORLD.md
+++ b/imagine-template-library/worlds/steamforge/WORLD.md
@@ -1,0 +1,35 @@
+# World kit: Steamforge
+
+**Slug:** `steamforge`  
+**Premise:** The Clockwork Dominion: a Victorian steampunk empire of brass, steam and eternal engines where Cogborn engineers and automaton guilds power forge-cities with steam-aether and clockwork magic.  
+**Style lock / palette:** Brass/copper metal, steam haze, industrial reflections, boiler warmth and airship skies.  
+**Trailer tag:** Industry / Pride  
+**DNA status:** LOCKED (source Studio Odyssey)  
+**Source:** Imagine Studio “6 Original Fantasy World Concepts” extract
+
+## Board
+| Kind | Slug | Notes |
+|------|------|-------|
+| Character | `cogborn_engineer` | Cogborn Engineer — LOCKED |
+| Location | `brass_forge_plaza` | Brass Forge-City Plaza (hero establish) |
+| Prop | `steam_aether_pistol` | Steam-Aether Pistol |
+| More locs | — | Brass Forge-City Plaza; Forge-cities; Brass plaza |
+| More props | — | Clockwork Automaton Core, Steam-Aether Pistol, Eternal Boiler Valve |
+
+## Multi-ref recipe (≤5)
+1. `cogborn_engineer` hero
+2. `brass_forge_plaza` establish
+3. `steam_aether_pistol` hero
+4. optional second loc/prop from board
+5. Hold world palette — do not cross-grade into other fantasy worlds
+
+## Scene still prompt seed
+```
+cinematic still, Cogborn Engineer in Brass Forge-City Plaza, Brass goggles; leather apron over shirt/waistcoat; mechanical prosthetic hand; copper tools; focused expression., brass steam-aether pistol, copper fittings, Brass/copper metal, steam haze, industrial reflections, boiler warmth and airship skies., Imagine Quality Mode
+```
+
+## Style notes
+Victorian steampunk spectacle, brass plaza, steam bursts, heavy automaton steps, gears, copper clinks and metallic reflections; Industry / Pride.
+
+## Production status
+Concept, hero scene, location/prop plates and locked DNA visible; trailer clip 05 exists. No long-form sequence status visible.

--- a/imagine-template-library/worlds/thalassara/WORLD.md
+++ b/imagine-template-library/worlds/thalassara/WORLD.md
@@ -1,0 +1,35 @@
+# World kit: Thalassara
+
+**Slug:** `thalassara`  
+**Premise:** The Abyssal Lumina: a bioluminescent empire 12 km beneath the waves where Merfolk Luminae and abyssal leviathans inhabit living coral-crystal cities under eternal midnight.  
+**Style lock / palette:** Eternal midnight, teal/cyan bioluminescence, coral/crystal glow, luminous fish and giant jellyfish; underwater-filtered darkness.  
+**Trailer tag:** Serenity / Mystery  
+**DNA status:** LOCKED (source Studio Odyssey)  
+**Source:** Imagine Studio “6 Original Fantasy World Concepts” extract
+
+## Board
+| Kind | Slug | Notes |
+|------|------|-------|
+| Character | `merfolk_luminae` | Merfolk Luminae — LOCKED |
+| Location | `biolum_plaza` | Bioluminescent Underwater Plaza (hero establish) |
+| Prop | `biolum_coral_staff` | Bioluminescent Coral Staff |
+| More locs | — | Bioluminescent Underwater Plaza; Living coral-crystal cities; 12 km beneath the waves |
+| More props | — | Bioluminescent Coral Staff, Pressure Dome Crystal, Depthsong Shell |
+
+## Multi-ref recipe (≤5)
+1. `merfolk_luminae` hero
+2. `biolum_plaza` establish
+3. `biolum_coral_staff` hero
+4. optional second loc/prop from board
+5. Hold world palette — do not cross-grade into other fantasy worlds
+
+## Scene still prompt seed
+```
+cinematic still, Merfolk Luminae in Bioluminescent Underwater Plaza, Iridescent teal-cyan skin; bioluminescent fins and hair; coral jewelry; translucent scale armor; luminous cyan eyes., bioluminescent coral staff, teal-cyan glow, Eternal midnight, teal/cyan bioluminescence, coral/crystal glow, luminous fish and giant jellyfish; underwater-filtered darkness., Imagine Quality Mode
+```
+
+## Style notes
+Serenity/mystery underwater cinematic; liquid pads, glass chimes, fin strokes, jellyfish pulse, distant leviathan and underwater filter.
+
+## Production status
+Concept, hero scene, location/prop plates and locked DNA visible; trailer clip 02 exists. No long-form sequence status visible.

--- a/imagine-template-library/worlds/thorne_eldrath/WORLD.md
+++ b/imagine-template-library/worlds/thorne_eldrath/WORLD.md
@@ -1,0 +1,25 @@
+# World kit: Thorne Eldrath
+
+**Slug:** `thorne_eldrath`  
+**Style lock:** earth mystic gold · forest greens · painterly myth  
+**Style pack:** `earth_mystic_gold`
+
+## Board
+| Kind | Slug |
+|------|------|
+| Character | `thorne_blackwood` |
+| Character | `elowen` (optional co-lead) |
+| Location | `eldrath_forest` |
+| Location | `ruined_hall` |
+| Prop | `eldrath_crown` |
+
+## Multi-ref recipe
+1. thorne_blackwood hero (or elowen)
+2. eldrath_forest OR ruined_hall establish
+3. eldrath_crown hero
+4. Hold mythic earth-gold — no neon
+
+## Scene still prompt seed
+```
+cinematic still, Sir Thorne Blackwood in Eldrath Forest, scarred haunted knight, Crown of Eldrath, god rays moss, painterly earth-gold grade, Imagine Quality Mode
+```


### PR DESCRIPTION
## Summary
Follow-up to #58 / #59: full Template Library re-vendor so the **fantasy six** world kits land on main (plus chars/locs/props/recipes already on the shelf).

**Note:** #59 (`chore/re-vendor-template-library-worlds`) was still **open/unmerged** at branch time. Branched from `origin/main` anyway; this PR’s full `rsync -a --delete` supersedes #59’s partial worlds sync.

### Fantasy six worlds
- `aetheris` — Floating Realms / golden hour
- `thalassara` — Abyssal Lumina / biolum deep
- `neonexus` — Wasteland Grid / neon desert
- `eldergrove` — Living Weave / sentient forest
- `steamforge` — Clockwork Dominion / brass
- `crystallis` — Prismatic Veil / aurora crystal

### Also lands (shelf sync / supersedes #59)
- Prior seven world kits + `worlds/INDEX.md` (mara_neon, clara_house, maya_attic, jax_midnight, mira_signal, thorne_eldrath, snow_archer)
- New fantasy chars: `winged_skyfolk`, `merfolk_luminae`, `chrome_nomad`, `sylvan_kin`, `cogborn_engineer`, `crystalborn_lightweaver`
- New locs/props for those kits + matching `world_*` Create Template recipes

### Inventory (post-rsync)
| Asset | Count |
|-------|------:|
| Characters | 20 |
| Locations | 21 |
| Props | 19 |
| Worlds | 13 |
| `RECIPE.md` | 53 |

### Pin
- Content SHA: `66d755a70924acbf0a486e4b910a8dc67f461b32`
- Pin tip SHA: `179858bb74ca1d322127394b3aef2a1764dc20ae` (pin-only `.grok-plugin/` follow-up)

### Validate
- Local: **`pytest -q` → 708 passed**
- `plugin catalog check --release` green on pin tip

## Test plan
- [x] Full library rsync from source → `imagine-template-library/`
- [x] Local `pytest -q` green
- [x] `plugin catalog check --release` green on pin tip
- [ ] CI validate on this PR
- [ ] Close/supersede #59 after merge if still open