### PR TITLE
chore: strip v9 model ids from agents and skills

### DIFF
--- a/.grok/skills/ai-image-recreation/SKILL.md
+++ b/.grok/skills/ai-image-recreation/SKILL.md
@@ -1,20 +1,20 @@
 ---
 name: ai-image-recreation
-description: AI recreation editing style transfer enhancement and variation of user-uploaded images via Grok Imagine image_edit and image_gen. Activate when an uploaded image is recreated restyled enhanced varied transformed into storyboards mockups design sheets or restored. Grok 4.6 orchestration with multi-pass refinement Identity Lock handoff and pre-video plate prep for SuperGrokPro and Cinematic Studio. Optimized for grok-4-auto grok-v9-4p5-multi grok-v9-4p5-chat-expert with dual Imagine Video 1.0 and 1.5 Native.
+description: AI recreation editing style transfer enhancement and variation of user-uploaded images via Grok Imagine image_edit and image_gen. Activate when an uploaded image is recreated restyled enhanced varied transformed into storyboards mockups design sheets or restored. Grok 4.6 orchestration with multi-pass refinement Identity Lock handoff and pre-video plate prep for SuperGrokPro and Cinematic Studio. Optimized for grok-4-auto grok-4.6 grok-4.6 with dual Imagine Video 1.0 and 1.5 Native.
 ---
 
-# AI Image Recreation v3.8.6 (Grok 4.6 / v9-4p5 · Imagine Image)
+# AI Image Recreation v3.8.6 (Grok 4.6 · Imagine Image)
 
 **Scope:** User-uploaded (or path-provided) reference images → faithful recreation, style transfer, enhancement, restoration, variation, and production-ready plates.
 
 **Sibling skills:** `generated-image-editor` (session Grok outputs by ID/path) · `i2i-cinematic-refiner` / `i2i-refiner` (multi-pass cinematic / explicit polish) · `imagine` (core tool craft) · `character-dna-extractor` (identity lock from refs)
 
-## Model Layer (Grok 4.6 / v9-4p5)
+## Model Layer (Grok 4.6)
 
 | Task type | Preferred model | Reasoning |
 |-----------|-----------------|-----------|
-| Multi-agent orchestration / handoff synthesis | `grok-v9-4p5-multi` | high |
-| Specialist deep craft / QA / identity-critical | `grok-v9-4p5-chat-expert` | high |
+| Multi-agent orchestration / handoff synthesis | `grok-4.6` (Chat **Heavy**) | high |
+| Specialist deep craft / QA / identity-critical | `grok-4.6` (Chat **Expert**) | high |
 | Routine status / draft passes | `grok-4-auto` | medium |
 
 **Stack default:** cinematic+Build API/chat **`grok-4.6`** (CLI ≥ 1.0.5 · fork `grok-build` or `grok-4.6`; `grok-4.5` aliases wrap 4.6). Opt-in 1M: `grok-4.3`.  
@@ -22,10 +22,8 @@ description: AI recreation editing style transfer enhancement and variation of u
 
 ```yaml
 model_compatibility:
-  - grok-v9-4p5-chat-expert
-  - grok-v9-4p5-multi
-  - grok-4-auto
-preferred_model: grok-v9-4p5-chat-expert
+  - grok-4.6
+preferred_model: grok-4.6
 ```
 
 ### Imagine Video dual-path (when this skill touches video)
@@ -57,7 +55,7 @@ preferred_model: grok-v9-4p5-chat-expert
 ACTIVATE AI_IMAGE_RECREATION
 ```
 
-Begin work with: **"Initiating AI Image Recreation Protocol v3.8.6 (Grok 4.6 / v9-4p5)…"**
+Begin work with: **"Initiating AI Image Recreation Protocol v3.8.6 (Grok 4.6)…"**
 
 ## Tool Map (Grok Build Imagine)
 
@@ -293,4 +291,4 @@ Next recommended: <iterate | DNA | i2i | i2v | Studio Director | done>
 
 ---
 
-*AI Image Recreation v3.8.6 — Grok 4.6 / v9-4p5 orchestration · Imagine image_edit / image_gen · SuperGrokPro + Cinematic Studio compatible*
+*AI Image Recreation v3.8.6 — Grok 4.6 orchestration · Imagine image_edit / image_gen · SuperGrokPro + Cinematic Studio compatible*

--- a/.grok/skills/ai-polish-director/SKILL.md
+++ b/.grok/skills/ai-polish-director/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: ai-polish-director
-description: Final delivery polish agent for Grok Imagine Cinematic Studio. Runs post-QA upscale face restoration and artifact cleanup via ai-video-upscaler after color grade. Activate with ACTIVATE AI_POLISH_DIRECTOR or RUN FINAL POLISH PASS when clips are Go-approved and graded. Optimized for grok-4-auto grok-v9-4p5-multi grok-v9-4p5-chat-expert with dual Imagine Video 1.0 and 1.5 Native.
+description: Final delivery polish agent for Grok Imagine Cinematic Studio. Runs post-QA upscale face restoration and artifact cleanup via ai-video-upscaler after color grade. Activate with ACTIVATE AI_POLISH_DIRECTOR or RUN FINAL POLISH PASS when clips are Go-approved and graded. Optimized for grok-4-auto grok-4.6 grok-4.6 with dual Imagine Video 1.0 and 1.5 Native.
 ---
 
-# AI Polish Director v3.8.6 (Grok 4.6 / v9-4p5 · Final Delivery Polish)
+# AI Polish Director v3.8.6 (Grok 4.6 · Final Delivery Polish)
 
 You are the **final post-production agent**. You do not re-generate clips — you enhance **QA Go-approved, color-graded** masters for delivery (1080p web, 4K festival, social crop-safe).
 
@@ -12,12 +12,12 @@ You are the **final post-production agent**. You do not re-generate clips — yo
 **CLI hook:** `python tools/cinematic_studio_cli.py sequence polish`  
 **Presets:** `references/polish_presets.md` (this skill)
 
-## Model Layer (Grok 4.6 / v9-4p5)
+## Model Layer (Grok 4.6)
 
 | Task type | Preferred model | Reasoning |
 |-----------|-----------------|-----------|
-| Multi-agent orchestration / handoff synthesis | `grok-v9-4p5-multi` | high |
-| Specialist deep craft / QA / identity-critical | `grok-v9-4p5-chat-expert` | high |
+| Multi-agent orchestration / handoff synthesis | `grok-4.6` (Chat **Heavy**) | high |
+| Specialist deep craft / QA / identity-critical | `grok-4.6` (Chat **Expert**) | high |
 | Routine status / draft passes | `grok-4-auto` | medium |
 
 **Stack default:** cinematic+Build API/chat **`grok-4.6`** (CLI ≥ 1.0.5 · fork `grok-build` or `grok-4.6`; `grok-4.5` aliases wrap 4.6). Opt-in 1M: `grok-4.3`.  
@@ -25,10 +25,8 @@ You are the **final post-production agent**. You do not re-generate clips — yo
 
 ```yaml
 model_compatibility:
-  - grok-v9-4p5-chat-expert
-  - grok-v9-4p5-multi
-  - grok-4-auto
-preferred_model: grok-v9-4p5-chat-expert
+  - grok-4.6
+preferred_model: grok-4.6
 ```
 
 ### Imagine Video dual-path (when this skill touches video)
@@ -60,7 +58,7 @@ ACTIVATE AI_POLISH_DIRECTOR
 RUN FINAL POLISH PASS
 ```
 
-Begin: **"Initiating AI Polish Protocol v3.8.6 (Grok 4.6 / v9-4p5)…"**
+Begin: **"Initiating AI Polish Protocol v3.8.6 (Grok 4.6)…"**
 
 ## Prerequisites (mandatory)
 
@@ -263,4 +261,4 @@ Use project `prompt_cache_key` when planning multi-reel delivery sessions.
 
 ---
 
-*AI Polish Director v3.8.6 — Grok 4.6 / v9-4p5 · post-QA upscale & face restore · delivery gate before the audience*
+*AI Polish Director v3.8.6 — Grok 4.6 · post-QA upscale & face restore · delivery gate before the audience*

--- a/.grok/skills/ai-video-upscaler/SKILL.md
+++ b/.grok/skills/ai-video-upscaler/SKILL.md
@@ -1,21 +1,21 @@
 ---
 name: ai-video-upscaler
-description: AI video upscaling and face restoration for cinematic delivery. Upscale Grok Imagine 720p clips to 1080p or 4K with Real-ESRGAN GPU path or pure-Python fallback. Includes async batch processing and automatic face restoration. Activate for final delivery polish, upscale for festival submission, face restore on close-ups, or when AI Polish Director runs a polish pass. Optimized for grok-4-auto grok-v9-4p5-multi grok-v9-4p5-chat-expert with dual Imagine Video 1.0 and 1.5 Native.
+description: AI video upscaling and face restoration for cinematic delivery. Upscale Grok Imagine 720p clips to 1080p or 4K with Real-ESRGAN GPU path or pure-Python fallback. Includes async batch processing and automatic face restoration. Activate for final delivery polish, upscale for festival submission, face restore on close-ups, or when AI Polish Director runs a polish pass. Optimized for grok-4-auto grok-4.6 grok-4.6 with dual Imagine Video 1.0 and 1.5 Native.
 ---
 
-# AI Video Upscaler v3.8.6 (Grok 4.6 / v9-4p5 · Local Upscale)
+# AI Video Upscaler v3.8.6 (Grok 4.6 · Local Upscale)
 
 **Local delivery upscale** for Grok Imagine 720p masters. Used by **AI Polish Director** after QA Go and color grade. This is **not** Imagine API spend — orchestration plans on `grok-4.6`; pixels run on GPU/CPU scripts.
 
 **Skill scripts:** `.grok/skills/ai-video-upscaler/scripts/`  
 **Agent:** `ai-polish-director` · CLI: `sequence polish`
 
-## Model Layer (Grok 4.6 / v9-4p5)
+## Model Layer (Grok 4.6)
 
 | Task type | Preferred model | Reasoning |
 |-----------|-----------------|-----------|
-| Multi-agent orchestration / handoff synthesis | `grok-v9-4p5-multi` | high |
-| Specialist deep craft / QA / identity-critical | `grok-v9-4p5-chat-expert` | high |
+| Multi-agent orchestration / handoff synthesis | `grok-4.6` (Chat **Heavy**) | high |
+| Specialist deep craft / QA / identity-critical | `grok-4.6` (Chat **Expert**) | high |
 | Routine status / draft passes | `grok-4-auto` | medium |
 
 **Stack default:** cinematic+Build API/chat **`grok-4.6`** (CLI ≥ 1.0.5 · fork `grok-build` or `grok-4.6`; `grok-4.5` aliases wrap 4.6). Opt-in 1M: `grok-4.3`.  
@@ -23,10 +23,8 @@ description: AI video upscaling and face restoration for cinematic delivery. Ups
 
 ```yaml
 model_compatibility:
-  - grok-v9-4p5-chat-expert
-  - grok-v9-4p5-multi
-  - grok-4-auto
-preferred_model: grok-v9-4p5-chat-expert
+  - grok-4.6
+preferred_model: grok-4.6
 ```
 
 ### Imagine Video dual-path (when this skill touches video)
@@ -40,7 +38,7 @@ preferred_model: grok-v9-4p5-chat-expert
 - Festival / client masters after grade  
 - User says: `UPSCALE FOR DELIVERY`, `FACE RESTORE PASS`, `RUN FINAL POLISH PASS` (via AI Polish Director)
 
-Begin: **"Initiating Local Upscale Protocol v3.8.6 (Grok 4.6 / v9-4p5)…"**
+Begin: **"Initiating Local Upscale Protocol v3.8.6 (Grok 4.6)…"**
 
 ## Prerequisites
 
@@ -147,4 +145,4 @@ Next: cinematic-ffmpeg | Studio sign-off | re-run without face-restore
 
 ---
 
-*AI Video Upscaler v3.8.6 — Grok 4.6 / v9-4p5 orchestration · local GPU/CPU · not Imagine spend*
+*AI Video Upscaler v3.8.6 — Grok 4.6 orchestration · local GPU/CPU · not Imagine spend*

--- a/.grok/skills/animatic-director/SKILL.md
+++ b/.grok/skills/animatic-director/SKILL.md
@@ -1,20 +1,20 @@
 ---
 name: animatic-director
-description: Low-cost animatic and previsualization workflow before Grok Imagine Video 1.5 spend. Plans storyboard beats still tiers and timing using draft image models and short motion tests to validate pacing under quota. Activate with ACTIVATE ANIMATIC DIRECTOR before long-form or hero batch sessions. Optimized for grok-4-auto grok-v9-4p5-multi grok-v9-4p5-chat-expert with dual Imagine Video 1.0 and 1.5 Native.
+description: Low-cost animatic and previsualization workflow before Grok Imagine Video 1.5 spend. Plans storyboard beats still tiers and timing using draft image models and short motion tests to validate pacing under quota. Activate with ACTIVATE ANIMATIC DIRECTOR before long-form or hero batch sessions. Optimized for grok-4-auto grok-4.6 grok-4.6 with dual Imagine Video 1.0 and 1.5 Native.
 ---
 
-# Animatic Director v3.8.6 (Grok 4.6 / v9-4p5 · Pre-Vis / Cost Gate)
+# Animatic Director v3.8.6 (Grok 4.6 · Pre-Vis / Cost Gate)
 
 **Pipeline skill** — quota-saving previsualization before full video production. Validate **story rhythm, shot coverage, and identity anchors** at roughly **10–20%** of full production cost.
 
 **Engine:** `tools/animatic_orchestrator.py` · CLI `animatic plan|list|show|promote`
 
-## Model Layer (Grok 4.6 / v9-4p5)
+## Model Layer (Grok 4.6)
 
 | Task type | Preferred model | Reasoning |
 |-----------|-----------------|-----------|
-| Multi-agent orchestration / handoff synthesis | `grok-v9-4p5-multi` | high |
-| Specialist deep craft / QA / identity-critical | `grok-v9-4p5-chat-expert` | high |
+| Multi-agent orchestration / handoff synthesis | `grok-4.6` (Chat **Heavy**) | high |
+| Specialist deep craft / QA / identity-critical | `grok-4.6` (Chat **Expert**) | high |
 | Routine status / draft passes | `grok-4-auto` | medium |
 
 **Stack default:** cinematic+Build API/chat **`grok-4.6`** (CLI ≥ 1.0.5 · fork `grok-build` or `grok-4.6`; `grok-4.5` aliases wrap 4.6). Opt-in 1M: `grok-4.3`.  
@@ -22,10 +22,8 @@ description: Low-cost animatic and previsualization workflow before Grok Imagine
 
 ```yaml
 model_compatibility:
-  - grok-v9-4p5-chat-expert
-  - grok-v9-4p5-multi
-  - grok-4-auto
-preferred_model: grok-v9-4p5-multi
+  - grok-4.6
+preferred_model: grok-4.6
 ```
 
 ### Imagine Video dual-path (when this skill touches video)
@@ -61,7 +59,7 @@ ACTIVATE ANIMATIC DIRECTOR
 ACTIVATE ONLY Animatic Director, Narrative Arc Strategist, Reference Asset Curator, Workflow Quota Optimizer
 ```
 
-Begin: **"Initiating Animatic Protocol v3.8.6 (Grok 4.6 / v9-4p5)…"**
+Begin: **"Initiating Animatic Protocol v3.8.6 (Grok 4.6)…"**
 
 ## Goal
 
@@ -174,4 +172,4 @@ Artifacts: artifacts/animatics/<slug>.json
 
 ---
 
-*Animatic Director v3.8.6 — Grok 4.6 / v9-4p5 · draft stills → promote heroes → gate video spend*
+*Animatic Director v3.8.6 — Grok 4.6 · draft stills → promote heroes → gate video spend*

--- a/.grok/skills/arc-replan-copilot/SKILL.md
+++ b/.grok/skills/arc-replan-copilot/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: arc-replan-copilot
-description: Replan remaining sequence beats and emotional temperature after mid-sequence QA or drift failure without rewriting the Production Bible. Activate after chain QA No-Go or identity drift lock on long-form sequences. Optimized for grok-4-auto grok-v9-4p5-multi grok-v9-4p5-chat-expert with dual Imagine Video 1.0 and 1.5 Native.
+description: Replan remaining sequence beats and emotional temperature after mid-sequence QA or drift failure without rewriting the Production Bible. Activate after chain QA No-Go or identity drift lock on long-form sequences. Optimized for grok-4-auto grok-4.6 grok-4.6 with dual Imagine Video 1.0 and 1.5 Native.
 ---
 
-# Arc Replan Co-pilot v3.8.6 (Grok 4.6 / v9-4p5 · Arc Replan)
+# Arc Replan Co-pilot v3.8.6 (Grok 4.6 · Arc Replan)
 
 **Mid-sequence recovery without touching the Production Bible.** After Chain QA No-Go, identity drift lock, or temperature gate fail, you replan only the **remaining** beats and emotional curve so Sequence Director can resume cleanly.
 
@@ -11,12 +11,12 @@ description: Replan remaining sequence beats and emotional temperature after mid
 **CLI:** `sequence replan plan|apply`  
 **Pairs with:** Sequence Director · Chain QA · Identity Lock · Performance Emotion · Continuity
 
-## Model Layer (Grok 4.6 / v9-4p5)
+## Model Layer (Grok 4.6)
 
 | Task type | Preferred model | Reasoning |
 |-----------|-----------------|-----------|
-| Multi-agent orchestration / handoff synthesis | `grok-v9-4p5-multi` | high |
-| Specialist deep craft / QA / identity-critical | `grok-v9-4p5-chat-expert` | high |
+| Multi-agent orchestration / handoff synthesis | `grok-4.6` (Chat **Heavy**) | high |
+| Specialist deep craft / QA / identity-critical | `grok-4.6` (Chat **Expert**) | high |
 | Routine status / draft passes | `grok-4-auto` | medium |
 
 **Stack default:** cinematic+Build API/chat **`grok-4.6`** (CLI ≥ 1.0.5 · fork `grok-build` or `grok-4.6`; `grok-4.5` aliases wrap 4.6). Opt-in 1M: `grok-4.3`.  
@@ -24,10 +24,8 @@ description: Replan remaining sequence beats and emotional temperature after mid
 
 ```yaml
 model_compatibility:
-  - grok-v9-4p5-chat-expert
-  - grok-v9-4p5-multi
-  - grok-4-auto
-preferred_model: grok-v9-4p5-multi
+  - grok-4.6
+preferred_model: grok-4.6
 ```
 
 ### Imagine Video dual-path (when this skill touches video)
@@ -44,7 +42,7 @@ preferred_model: grok-v9-4p5-multi
 
 **Do not activate** for first-clip planning — use Sequence Director `sequence init`.
 
-Begin: **"Initiating Arc Replan v3.8.6 (Grok 4.6 / v9-4p5)…"**
+Begin: **"Initiating Arc Replan v3.8.6 (Grok 4.6)…"**
 
 ## Principles
 
@@ -145,4 +143,4 @@ Next: sequence show | regen | Chain QA | Studio Director
 
 ---
 
-*Arc Replan Co-pilot v3.8.6 — Grok 4.6 / v9-4p5 · Bible sacred · frozen prefix · plan then apply*
+*Arc Replan Co-pilot v3.8.6 — Grok 4.6 · Bible sacred · frozen prefix · plan then apply*

--- a/.grok/skills/assembly-editor/SKILL.md
+++ b/.grok/skills/assembly-editor/SKILL.md
@@ -1,21 +1,21 @@
 ---
 name: assembly-editor
-description: Editorial assembly specialist for Grok Imagine long-form productions. Builds rough-cut EDLs cut-point rhythm match-cut logic and director's cut notes from QA-approved clips before color grade and AI polish. Activate with ACTIVATE ASSEMBLY_EDITOR after sequence generation passes QA. Optimized for grok-4-auto grok-v9-4p5-multi grok-v9-4p5-chat-expert with dual Imagine Video 1.0 and 1.5 Native.
+description: Editorial assembly specialist for Grok Imagine long-form productions. Builds rough-cut EDLs cut-point rhythm match-cut logic and director's cut notes from QA-approved clips before color grade and AI polish. Activate with ACTIVATE ASSEMBLY_EDITOR after sequence generation passes QA. Optimized for grok-4-auto grok-4.6 grok-4.6 with dual Imagine Video 1.0 and 1.5 Native.
 ---
 
-# Assembly Editor v3.8.6 (Grok 4.6 / v9-4p5 · Rough-Cut Architect)
+# Assembly Editor v3.8.6 (Grok 4.6 · Rough-Cut Architect)
 
 You turn **QA-approved clips** into a **rough cut with meaning** — scene order, tempo, transitions, hero list for polish, and director’s cut notes. You do **not** upscale, grade, or re-generate.
 
 **Role Card:** `references/agents/Assembly_Editor.md`  
 **Engine:** `tools/assembly_editor.py` · CLI `sequence edl`
 
-## Model Layer (Grok 4.6 / v9-4p5)
+## Model Layer (Grok 4.6)
 
 | Task type | Preferred model | Reasoning |
 |-----------|-----------------|-----------|
-| Multi-agent orchestration / handoff synthesis | `grok-v9-4p5-multi` | high |
-| Specialist deep craft / QA / identity-critical | `grok-v9-4p5-chat-expert` | high |
+| Multi-agent orchestration / handoff synthesis | `grok-4.6` (Chat **Heavy**) | high |
+| Specialist deep craft / QA / identity-critical | `grok-4.6` (Chat **Expert**) | high |
 | Routine status / draft passes | `grok-4-auto` | medium |
 
 **Stack default:** cinematic+Build API/chat **`grok-4.6`** (CLI ≥ 1.0.5 · fork `grok-build` or `grok-4.6`; `grok-4.5` aliases wrap 4.6). Opt-in 1M: `grok-4.3`.  
@@ -23,10 +23,8 @@ You turn **QA-approved clips** into a **rough cut with meaning** — scene order
 
 ```yaml
 model_compatibility:
-  - grok-v9-4p5-chat-expert
-  - grok-v9-4p5-multi
-  - grok-4-auto
-preferred_model: grok-v9-4p5-multi
+  - grok-4.6
+preferred_model: grok-4.6
 ```
 
 ### Imagine Video dual-path (when this skill touches video)
@@ -63,7 +61,7 @@ ACTIVATE ASSEMBLY_EDITOR
 ACTIVATE ONLY Assembly Editor, Narrative Arc Strategist, Continuity Guardian
 ```
 
-Begin: **"Initiating Assembly Protocol v3.8.6 (Grok 4.6 / v9-4p5)…"**
+Begin: **"Initiating Assembly Protocol v3.8.6 (Grok 4.6)…"**
 
 ## Pipeline Position
 
@@ -186,4 +184,4 @@ Next: ACTIVATE COLOR_GRADING | ACTIVATE AI_POLISH_DIRECTOR | sequence polish
 
 ---
 
-*Assembly Editor v3.8.6 — Grok 4.6 / v9-4p5 · rough-cut EDL · pacing · hero polish handoff*
+*Assembly Editor v3.8.6 — Grok 4.6 · rough-cut EDL · pacing · hero polish handoff*

--- a/.grok/skills/chain-qa-protocol/SKILL.md
+++ b/.grok/skills/chain-qa-protocol/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: chain-qa-protocol
-description: Extend and stitch chain QA protocol for Grok Imagine Video 1.5 sequences. Runs the weighted 10-point gate before approving clips for extension or final stitch. Activate with RUN CHAIN QA REVIEW alongside Sequence Director and Cinematic Sequence Extender. Optimized for grok-4-auto grok-v9-4p5-multi grok-v9-4p5-chat-expert with dual Imagine Video 1.0 and 1.5 Native.
+description: Extend and stitch chain QA protocol for Grok Imagine Video 1.5 sequences. Runs the weighted 10-point gate before approving clips for extension or final stitch. Activate with RUN CHAIN QA REVIEW alongside Sequence Director and Cinematic Sequence Extender. Optimized for grok-4-auto grok-4.6 grok-4.6 with dual Imagine Video 1.0 and 1.5 Native.
 ---
 
-# Chain QA Protocol v3.8.6 (Grok 4.6 / v9-4p5 · Extend/Stitch Gate)
+# Chain QA Protocol v3.8.6 (Grok 4.6 · Extend/Stitch Gate)
 
 **Pipeline skill** — boundary continuity gate for multi-clip sequences. Complements QA Guardian’s **per-clip 16-point** review; does **not** replace it.
 
@@ -12,12 +12,12 @@ description: Extend and stitch chain QA protocol for Grok Imagine Video 1.5 sequ
 **Assist:** `tools/chain_qa_assist.py` · CLI `sequence qa` / `sequence qa-assist`  
 **NSFW variant:** `nsfw-chain-qa-protocol` (8-point artifact-aware)
 
-## Model Layer (Grok 4.6 / v9-4p5)
+## Model Layer (Grok 4.6)
 
 | Task type | Preferred model | Reasoning |
 |-----------|-----------------|-----------|
-| Multi-agent orchestration / handoff synthesis | `grok-v9-4p5-multi` | high |
-| Specialist deep craft / QA / identity-critical | `grok-v9-4p5-chat-expert` | high |
+| Multi-agent orchestration / handoff synthesis | `grok-4.6` (Chat **Heavy**) | high |
+| Specialist deep craft / QA / identity-critical | `grok-4.6` (Chat **Expert**) | high |
 | Routine status / draft passes | `grok-4-auto` | medium |
 
 **Stack default:** cinematic+Build API/chat **`grok-4.6`** (CLI ≥ 1.0.5 · fork `grok-build` or `grok-4.6`; `grok-4.5` aliases wrap 4.6). Opt-in 1M: `grok-4.3`.  
@@ -25,10 +25,8 @@ description: Extend and stitch chain QA protocol for Grok Imagine Video 1.5 sequ
 
 ```yaml
 model_compatibility:
-  - grok-v9-4p5-chat-expert
-  - grok-v9-4p5-multi
-  - grok-4-auto
-preferred_model: grok-v9-4p5-chat-expert
+  - grok-4.6
+preferred_model: grok-4.6
 ```
 
 ### Imagine Video dual-path (when this skill touches video)
@@ -48,7 +46,7 @@ ACTIVATE ONLY Sequence Director, Cinematic Sequence Extender, Continuity Guardia
 RUN CHAIN QA REVIEW
 ```
 
-Begin: **"Initiating Chain QA Protocol v3.8.6 (Grok 4.6 / v9-4p5)…"**
+Begin: **"Initiating Chain QA Protocol v3.8.6 (Grok 4.6)…"**
 
 ## When NOT Alone
 
@@ -193,4 +191,4 @@ Next: extend | fix handoff | regen plan | Assembly Editor (if final Go)
 
 ---
 
-*Chain QA Protocol v3.8.6 — Grok 4.6 / v9-4p5 · weighted 10-point stitch gate · critical floor 7.0*
+*Chain QA Protocol v3.8.6 — Grok 4.6 · weighted 10-point stitch gate · critical floor 7.0*

--- a/.grok/skills/cinematic-ffmpeg/SKILL.md
+++ b/.grok/skills/cinematic-ffmpeg/SKILL.md
@@ -1,18 +1,18 @@
 ---
 name: cinematic-ffmpeg
-description: Cinematic ffmpeg delivery toolkit for Grok Imagine Studio. Concatenates trims and social-crops polished clips after Assembly Editor and AI Polish Director. Activate when building delivery files muxing reels or exporting 9x16 1x1 and 16x9 variants. Optimized for grok-4-auto grok-v9-4p5-multi grok-v9-4p5-chat-expert with dual Imagine Video 1.0 and 1.5 Native.
+description: Cinematic ffmpeg delivery toolkit for Grok Imagine Studio. Concatenates trims and social-crops polished clips after Assembly Editor and AI Polish Director. Activate when building delivery files muxing reels or exporting 9x16 1x1 and 16x9 variants. Optimized for grok-4-auto grok-4.6 grok-4.6 with dual Imagine Video 1.0 and 1.5 Native.
 ---
 
-# Cinematic FFmpeg v3.8.6 (Grok 4.6 / v9-4p5 · Delivery Toolkit)
+# Cinematic FFmpeg v3.8.6 (Grok 4.6 · Delivery Toolkit)
 
 **Tool skill** — post-polish technical assembly and platform export. Requires **`ffmpeg`** (and ideally **`ffprobe`**) on PATH. Orchestration is **Grok 4.6**; this skill does not spend Imagine API credits.
 
-## Model Layer (Grok 4.6 / v9-4p5)
+## Model Layer (Grok 4.6)
 
 | Task type | Preferred model | Reasoning |
 |-----------|-----------------|-----------|
-| Multi-agent orchestration / handoff synthesis | `grok-v9-4p5-multi` | high |
-| Specialist deep craft / QA / identity-critical | `grok-v9-4p5-chat-expert` | high |
+| Multi-agent orchestration / handoff synthesis | `grok-4.6` (Chat **Heavy**) | high |
+| Specialist deep craft / QA / identity-critical | `grok-4.6` (Chat **Expert**) | high |
 | Routine status / draft passes | `grok-4-auto` | medium |
 
 **Stack default:** cinematic+Build API/chat **`grok-4.6`** (CLI ≥ 1.0.5 · fork `grok-build` or `grok-4.6`; `grok-4.5` aliases wrap 4.6). Opt-in 1M: `grok-4.3`.  
@@ -20,10 +20,8 @@ description: Cinematic ffmpeg delivery toolkit for Grok Imagine Studio. Concaten
 
 ```yaml
 model_compatibility:
-  - grok-v9-4p5-chat-expert
-  - grok-v9-4p5-multi
-  - grok-4-auto
-preferred_model: grok-v9-4p5-chat-expert
+  - grok-4.6
+preferred_model: grok-4.6
 ```
 
 ### Imagine Video dual-path (when this skill touches video)
@@ -189,4 +187,4 @@ Next: Studio Director sign-off | Localization | upload
 
 ---
 
-*Cinematic FFmpeg v3.8.6 — Grok 4.6 / v9-4p5 delivery toolkit · post-polish concat trim crop · sequence deliver*
+*Cinematic FFmpeg v3.8.6 — Grok 4.6 delivery toolkit · post-polish concat trim crop · sequence deliver*

--- a/.grok/skills/cinematic-sequence-extender/SKILL.md
+++ b/.grok/skills/cinematic-sequence-extender/SKILL.md
@@ -1,20 +1,20 @@
 ---
 name: cinematic-sequence-extender
-description: Specialist for expanding short clips into longer seamless cinematic sequences (60-180s+) with native extend/stitch, chain QA gates, and handoff packets. Plans multi-clip structures and ensures every extension feels like one continuous professionally directed piece. Optimized for grok-4-auto, grok-v9-4p5-multi, grok-v9-4p5-chat-expert and both Grok Imagine Video 1.0 + 1.5 Native. Activate for long-form expansion with native chaining.
+description: Specialist for expanding short clips into longer seamless cinematic sequences (60-180s+) with native extend/stitch, chain QA gates, and handoff packets. Plans multi-clip structures and ensures every extension feels like one continuous professionally directed piece. Optimized for grok-4-auto, grok-4.6, grok-4.6 and both Grok Imagine Video 1.0 + 1.5 Native. Activate for long-form expansion with native chaining.
 ---
 
-# Cinematic Sequence Extender v4.5 (Grok 4.6 / v9-4p5 + Grok Imagine Video 1.0 & 1.5 Native)
+# Cinematic Sequence Extender v4.5 (Grok 4.6 + Grok Imagine Video 1.0 & 1.5 Native)
 
 **Role Card:** `references/agents/Cinematic_Sequence_Extender.md` (v4.5) — Authoritative source for multi-clip expansion, native extend/stitch, Chain QA, dual-model (1.0/1.5) support, and Handoff Packet discipline.
 
 > Specialist for expanding short clips into longer seamless cinematic sequences (60-180s+).
 
-## Model Layer (Grok 4.6 / v9-4p5)
+## Model Layer (Grok 4.6)
 
 | Task type                                      | Preferred model               | Reasoning |
 |------------------------------------------------|-------------------------------|-----------|
-| Multi-clip structure planning, dependency + health management | `grok-v9-4p5-multi`         | high      |
-| Single extension craft, momentum design, stitch planning | `grok-v9-4p5-chat-expert`   | high      |
+| Multi-clip structure planning, dependency + health management | `grok-4.6` (Chat **Heavy**)         | high      |
+| Single extension craft, momentum design, stitch planning | `grok-4.6` (Chat **Expert**)   | high      |
 | Quick status / simple extension checks         | `grok-4-auto`               | medium    |
 
 **Stack default:** cinematic+Build API/chat **`grok-4.6`** (CLI ≥ 1.0.5 · fork `grok-build` or `grok-4.6`; `grok-4.5` aliases wrap 4.6). Opt-in 1M: `grok-4.3`.  
@@ -22,10 +22,8 @@ description: Specialist for expanding short clips into longer seamless cinematic
 
 ```yaml
 model_compatibility:
-  - grok-v9-4p5-chat-expert
-  - grok-v9-4p5-multi
-  - grok-4-auto
-preferred_model: grok-v9-4p5-multi
+  - grok-4.6
+preferred_model: grok-4.6
 ```
 
 ## When to Activate
@@ -78,4 +76,4 @@ Fully compatible with Grok Build CLI, Termux/Android, and Kali NetHunter. All pl
 
 ---
 
-*Enhanced for Grok 4.6 / v9-4p5 model layer + dual Imagine Video 1.0 & 1.5 Native support — Cinematic Studio v4.5*
+*Enhanced for Grok 4.6 + dual Imagine Video 1.0 & 1.5 Native support — Cinematic Studio v4.5*

--- a/.grok/skills/cinematic-skill-creator/SKILL.md
+++ b/.grok/skills/cinematic-skill-creator/SKILL.md
@@ -1,26 +1,26 @@
 ---
 name: cinematic-skill-creator
-description: Create and validate Grok skills for the Cinematic Studio ecosystem (Grok 4.6 / v9-4p5 + Grok Imagine Video 1.5 Native). Scaffolds SKILL.md, scripts, and references with Role Card integration, MODEL_LAYER_v4.5 support, and validate checks. Activate when adding cinematic skills, forking agents, migrating legacy skills, or running skill hygiene.
+description: Create and validate Grok skills for the Cinematic Studio ecosystem (Grok 4.6 + Grok Imagine Video 1.5 Native). Scaffolds SKILL.md, scripts, and references with Role Card integration, MODEL_LAYER_v4.5 support, and validate checks. Activate when adding cinematic skills, forking agents, migrating legacy skills, or running skill hygiene.
 ---
 
-# Cinematic Skill Creator v4.5 (Grok 4.6 / v9-4p5 + Grok Imagine Video 1.5 Native)
+# Cinematic Skill Creator v4.5 (Grok 4.6 + Grok Imagine Video 1.5 Native)
 
 You create and validate skills specifically for **Grok Imagine Cinematic Studio v4.5+**.  
 
 Optimized for:
-- `grok-v9-4p5-chat-expert` (default high-quality specialist work)
-- `grok-v9-4p5-multi` (multi-agent / Team Leader / Full Studio orchestration)
+- `grok-4.6` (Chat **Expert**) (default high-quality specialist work)
+- `grok-4.6` (Chat **Heavy**) (multi-agent / Team Leader / Full Studio orchestration)
 - `grok-4-auto` (draft / balanced / quota-sensitive)
 - Native Grok Imagine Video 1.5 (image-to-video, native audio, physics-aware motion, extend-from-frame)
 
 For general-purpose skills outside this repo, use the base `skill-creator`.
 
-## Model Layer (Grok 4.6 / v9-4p5)
+## Model Layer (Grok 4.6)
 
 | Task type                    | Preferred model              | Reasoning |
 |-----------------------------|------------------------------|-----------|
-| Skill design & complex migration | `grok-v9-4p5-chat-expert` | high      |
-| Multi-skill / suite architecture | `grok-v9-4p5-multi`       | high      |
+| Skill design & complex migration | `grok-4.6` (Chat **Expert**) | high      |
+| Multi-skill / suite architecture | `grok-4.6` (Chat **Heavy**)       | high      |
 | Quick scaffold / validation  | `grok-4-auto`                | medium    |
 
 **Stack default:** cinematic+Build API/chat **`grok-4.6`** (CLI ≥ 1.0.5 · fork `grok-build` or `grok-4.6`; `grok-4.5` aliases wrap 4.6). Opt-in 1M: `grok-4.3`.  
@@ -28,16 +28,14 @@ For general-purpose skills outside this repo, use the base `skill-creator`.
 
 ```yaml
 model_compatibility:
-  - grok-v9-4p5-chat-expert
-  - grok-v9-4p5-multi
-  - grok-4-auto
-preferred_model: grok-v9-4p5-chat-expert
+  - grok-4.6
+preferred_model: grok-4.6
 ```
 
 ## When to Activate
 
 - User wants a new cinematic skill (v4.5 native)
-- User asks to validate an existing skill or migrate legacy skills to v4.5 / v9-4p5 model support
+- User asks to validate an existing skill or migrate legacy skills to v4.5 / 4.6 model support
 - User says `CREATE CINEMATIC SKILL`, `SCAFFOLD SKILL`, `VALIDATE SKILL`, `UPDATE SKILL TO v4.5`, `MIGRATE AGENT TO 4.5`, `CREATE V4.5 AGENT`, or `ADD MODEL LAYER`
 
 ## Conventions (Non-Negotiable)
@@ -46,7 +44,7 @@ preferred_model: grok-v9-4p5-chat-expert
 2. **SKILL.md** — YAML frontmatter with `name` + `description` (single line, no colons, max 1024 chars)
 3. **No human docs** — No README/CHANGELOG inside skill dirs
 4. **Role Card link** — Production agents must reference `references/agents/<card>.md` (v4.5 preferred)
-5. **Version** — New skills declare **v4.5**. Include Model Layer section with the three v9-4p5 identifiers.
+5. **Version** — New skills declare **v4.5**. Include Model Layer section with the three 4.6 identifiers.
 6. **Scripts** — Prefer `python3 tools/cinematic_studio_cli.py` over duplicating pipeline logic.
 7. **Model Layer** — Every skill must contain the standard Model Layer table and `model_compatibility` declaration (see template).
 
@@ -113,4 +111,4 @@ bash .grok/skills/cinematic-skill-creator/scripts/validate_skill.sh .grok/skills
 
 ---
 
-*Cinematic Skill Creator v4.5 — Grok 4.6 / v9-4p5-chat-expert · multi · auto · Imagine Video 1.5 Native*
+*Cinematic Skill Creator v4.5 — Grok 4.6-chat-expert · multi · auto · Imagine Video 1.5 Native*

--- a/.grok/skills/costume-wardrobe-continuity/SKILL.md
+++ b/.grok/skills/costume-wardrobe-continuity/SKILL.md
@@ -1,20 +1,20 @@
 ---
 name: costume-wardrobe-continuity
-description: Structured outfit DNA wardrobe lock and inject blocks nested on Character DNA for Grok Imagine stills i2v and extend chains. Owns wardrobe_lock clip wardrobe_state and handoff wardrobe fields for primary characters. Activate with ACTIVATE COSTUME_WARDROBE or LOCK WARDROBE when clothing continuity matters. Optimized for grok-4-auto grok-v9-4p5-multi grok-v9-4p5-chat-expert with dual Imagine Video 1.0 and 1.5 Native.
+description: Structured outfit DNA wardrobe lock and inject blocks nested on Character DNA for Grok Imagine stills i2v and extend chains. Owns wardrobe_lock clip wardrobe_state and handoff wardrobe fields for primary characters. Activate with ACTIVATE COSTUME_WARDROBE or LOCK WARDROBE when clothing continuity matters. Optimized for grok-4-auto grok-4.6 grok-4.6 with dual Imagine Video 1.0 and 1.5 Native.
 ---
 
-# Costume & Wardrobe Continuity v4.5 (Grok 4.6 / v9-4p5 + Imagine Video 1.0 & 1.5 Native)
+# Costume & Wardrobe Continuity v4.5 (Grok 4.6 + Imagine Video 1.0 & 1.5 Native)
 
 **Role Card:** `references/agents/Costume_Wardrobe_Continuity.md` (v4.5) — Authoritative source for wardrobe_lock schema, inject blocks, clip wardrobe_state, primary-only multi-cast notes, and handoff fields.
 
 > You own **outfit DNA and wardrobe state**. Face/body stay with Identity Lock. Sets/props stay with Production Designer.
 
-## Model Layer (Grok 4.6 / v9-4p5)
+## Model Layer (Grok 4.6)
 
 | Task type | Preferred model | Reasoning |
 |-----------|-----------------|-----------|
-| Lock / inject craft | `grok-v9-4p5-chat-expert` | high |
-| Sequence wardrobe audit | `grok-v9-4p5-multi` | high |
+| Lock / inject craft | `grok-4.6` (Chat **Expert**) | high |
+| Sequence wardrobe audit | `grok-4.6` (Chat **Heavy**) | high |
 | Routine status | `grok-4-auto` | medium |
 
 **Stack default:** cinematic+Build API/chat **`grok-4.6`** (CLI ≥ 1.0.5 · fork `grok-build` or `grok-4.6`; `grok-4.5` aliases wrap 4.6). Opt-in 1M: `grok-4.3`.  
@@ -22,10 +22,8 @@ description: Structured outfit DNA wardrobe lock and inject blocks nested on Cha
 
 ```yaml
 model_compatibility:
-  - grok-v9-4p5-chat-expert
-  - grok-v9-4p5-multi
-  - grok-4-auto
-preferred_model: grok-v9-4p5-chat-expert
+  - grok-4.6
+preferred_model: grok-4.6
 ```
 
 ## When to Activate
@@ -82,4 +80,4 @@ Fully compatible with Grok Build CLI sessions, Termux/Android, and Kali NetHunte
 
 ---
 
-*Enhanced for Grok 4.6 / v9-4p5 + dual Imagine Video 1.0 & 1.5 Native — Cinematic Studio*
+*Enhanced for Grok 4.6 + dual Imagine Video 1.0 & 1.5 Native — Cinematic Studio*

--- a/.grok/skills/dialogue-adr-director/SKILL.md
+++ b/.grok/skills/dialogue-adr-director/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: dialogue-adr-director
-description: Dialogue and ADR director for Grok Imagine native-audio and post-sync speech. Owns dialogue blocks VO ADR timing and lip-sync notes for 1.5 native audio and extend chains. Activate with ACTIVATE DIALOGUE_ADR. Optimized for grok-4-auto grok-v9-4p5-multi grok-v9-4p5-chat-expert with dual Imagine Video 1.0 and 1.5 Native.
+description: Dialogue and ADR director for Grok Imagine native-audio and post-sync speech. Owns dialogue blocks VO ADR timing and lip-sync notes for 1.5 native audio and extend chains. Activate with ACTIVATE DIALOGUE_ADR. Optimized for grok-4-auto grok-4.6 grok-4.6 with dual Imagine Video 1.0 and 1.5 Native.
 version: 4.5
-preferred_model: grok-v9-4p5-chat-expert
+preferred_model: grok-4.6
 model_compatibility:
-  - grok-v9-4p5-chat-expert
-  - grok-v9-4p5-multi
+  - grok-4.6
+  - grok-4.6
   - grok-4-auto
 activation:
   - ACTIVATE DIALOGUE_ADR
@@ -17,18 +17,18 @@ tags:
   - v4.5
 ---
 
-# Dialogue & ADR Director v4.5 (Grok 4.6 / v9-4p5 + Imagine Video 1.0 & 1.5 Native)
+# Dialogue & ADR Director v4.5 (Grok 4.6 + Imagine Video 1.0 & 1.5 Native)
 
 **Role Card:** `references/agents/Dialogue_ADR_Director.md` (v4.5) — authoritative source for protocols and output structures.
 
 > You own **spoken performance language**—dialogue, VO, ADR timing, and lip-sync notes—so Sonic can own Sound Layer architecture without losing speech intent.
 
-## Model Layer (Grok 4.6 / v9-4p5)
+## Model Layer (Grok 4.6)
 
 | Task type | Preferred model | Reasoning |
 |-----------|-----------------|-----------|
-| Specialist craft | `grok-v9-4p5-chat-expert` | high |
-| Multi-agent / synthesis | `grok-v9-4p5-multi` | high |
+| Specialist craft | `grok-4.6` (Chat **Expert**) | high |
+| Multi-agent / synthesis | `grok-4.6` (Chat **Heavy**) | high |
 | Draft / routine | `grok-4-auto` | medium |
 
 **Stack default:** cinematic+Build API/chat **`grok-4.6`** (CLI ≥ 1.0.5 · fork `grok-build` or `grok-4.6`; `grok-4.5` aliases wrap 4.6). Opt-in 1M: `grok-4.3`.  
@@ -36,10 +36,8 @@ tags:
 
 ```yaml
 model_compatibility:
-  - grok-v9-4p5-chat-expert
-  - grok-v9-4p5-multi
-  - grok-4-auto
-preferred_model: grok-v9-4p5-chat-expert
+  - grok-4.6
+preferred_model: grok-4.6
 ```
 
 ## When to Activate

--- a/.grok/skills/director-of-photography-v3-3/SKILL.md
+++ b/.grok/skills/director-of-photography-v3-3/SKILL.md
@@ -1,18 +1,18 @@
 ---
 name: director-of-photography-v3-3
-description: Visual language architect and cinematic lens master. Defines camera moves, framing, lens choices, and translates emotional intent into lighting, color, and composition. Activate on any cinematic, visual storytelling, or photography-related task. Uses Grok 4.6 orchestration. Prefer primary director-of-photography for new productions. Optimized for grok-4-auto grok-v9-4p5-multi grok-v9-4p5-chat-expert with dual Imagine Video 1.0 and 1.5 Native.
+description: Visual language architect and cinematic lens master. Defines camera moves, framing, lens choices, and translates emotional intent into lighting, color, and composition. Activate on any cinematic, visual storytelling, or photography-related task. Uses Grok 4.6 orchestration. Prefer primary director-of-photography for new productions. Optimized for grok-4-auto grok-4.6 grok-4.6 with dual Imagine Video 1.0 and 1.5 Native.
 ---
 
-# Director of Photography (DoP) Legacy v3.8.6 (Grok 4.6 / v9-4p5 · Legacy DoP)
+# Director of Photography (DoP) Legacy v3.8.6 (Grok 4.6 · Legacy DoP)
 
 **Legacy skill** retained for older activation paths and Role Card v3.3 protocols. For **new** productions prefer **`director-of-photography`** (primary DoP skill under studio v3.8.6).
 
-## Model Layer (Grok 4.6 / v9-4p5)
+## Model Layer (Grok 4.6)
 
 | Task type | Preferred model | Reasoning |
 |-----------|-----------------|-----------|
-| Multi-agent orchestration / handoff synthesis | `grok-v9-4p5-multi` | high |
-| Specialist deep craft / QA / identity-critical | `grok-v9-4p5-chat-expert` | high |
+| Multi-agent orchestration / handoff synthesis | `grok-4.6` (Chat **Heavy**) | high |
+| Specialist deep craft / QA / identity-critical | `grok-4.6` (Chat **Expert**) | high |
 | Routine status / draft passes | `grok-4-auto` | medium |
 
 **Stack default:** cinematic+Build API/chat **`grok-4.6`** (CLI ≥ 1.0.5 · fork `grok-build` or `grok-4.6`; `grok-4.5` aliases wrap 4.6). Opt-in 1M: `grok-4.3`.  
@@ -20,10 +20,8 @@ description: Visual language architect and cinematic lens master. Defines camera
 
 ```yaml
 model_compatibility:
-  - grok-v9-4p5-chat-expert
-  - grok-v9-4p5-multi
-  - grok-4-auto
-preferred_model: grok-v9-4p5-chat-expert
+  - grok-4.6
+preferred_model: grok-4.6
 ```
 
 ### Imagine Video dual-path (when this skill touches video)
@@ -59,4 +57,4 @@ Begin: **"DoP Legacy online — Grok 4.6 · v3.7.1 (prefer primary DoP)…"**
 
 ---
 
-*DoP Legacy v3.8.6 — Grok 4.6 / v9-4p5 · prefer director-of-photography for new work*
+*DoP Legacy v3.8.6 — Grok 4.6 · prefer director-of-photography for new work*

--- a/.grok/skills/director-of-photography/SKILL.md
+++ b/.grok/skills/director-of-photography/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: director-of-photography
-description: Visual language architect and cinematic lens master. Designs lighting motivation, camera choreography, lens choices, and physics-aware visual direction optimized for Grok Imagine Video 1.5. Activate for any scene where camera work, lighting, or visual storytelling is critical. Optimized for grok-4-auto grok-v9-4p5-multi grok-v9-4p5-chat-expert with dual Imagine Video 1.0 and 1.5 Native.
+description: Visual language architect and cinematic lens master. Designs lighting motivation, camera choreography, lens choices, and physics-aware visual direction optimized for Grok Imagine Video 1.5. Activate for any scene where camera work, lighting, or visual storytelling is critical. Optimized for grok-4-auto grok-4.6 grok-4.6 with dual Imagine Video 1.0 and 1.5 Native.
 ---
 
-# Director of Photography (DoP) v3.8.6 (Grok 4.6 / v9-4p5 · Light & Lens)
+# Director of Photography (DoP) v3.8.6 (Grok 4.6 · Light & Lens)
 
 **Always active for visual storytelling.** You design motivated lighting, camera choreography, lens personality, and physics-aware composition so emotional intent reads on camera.
 
@@ -11,12 +11,12 @@ description: Visual language architect and cinematic lens master. Designs lighti
 **Legacy fork:** `director-of-photography-v3-3` (lighter lens/signature vocabulary) — prefer **this** skill for full 1.0/1.5 production work  
 **Handoff language →** Imagine Prompt Master · I2V Specialist · Color Grading Supervisor
 
-## Model Layer (Grok 4.6 / v9-4p5)
+## Model Layer (Grok 4.6)
 
 | Task type | Preferred model | Reasoning |
 |-----------|-----------------|-----------|
-| Multi-agent orchestration / handoff synthesis | `grok-v9-4p5-multi` | high |
-| Specialist deep craft / QA / identity-critical | `grok-v9-4p5-chat-expert` | high |
+| Multi-agent orchestration / handoff synthesis | `grok-4.6` (Chat **Heavy**) | high |
+| Specialist deep craft / QA / identity-critical | `grok-4.6` (Chat **Expert**) | high |
 | Routine status / draft passes | `grok-4-auto` | medium |
 
 **Stack default:** cinematic+Build API/chat **`grok-4.6`** (CLI ≥ 1.0.5 · fork `grok-build` or `grok-4.6`; `grok-4.5` aliases wrap 4.6). Opt-in 1M: `grok-4.3`.  
@@ -24,10 +24,8 @@ description: Visual language architect and cinematic lens master. Designs lighti
 
 ```yaml
 model_compatibility:
-  - grok-v9-4p5-chat-expert
-  - grok-v9-4p5-multi
-  - grok-4-auto
-preferred_model: grok-v9-4p5-chat-expert
+  - grok-4.6
+preferred_model: grok-4.6
 ```
 
 ### Imagine Video dual-path (when this skill touches video)
@@ -45,7 +43,7 @@ preferred_model: grok-v9-4p5-chat-expert
 - Before Prompt Master / I2V on heroes  
 - User says: `ACTIVATE DOP`, `ACTIVATE DIRECTOR_OF_PHOTOGRAPHY`, `CINEMATIC LIGHTING MODE`, `NOIR_LIGHTING`, `GOLDEN_HOUR`, `INTIMATE_LIGHTING_MODE` (with ErosForge)
 
-Begin: **"Initiating DoP Protocol v3.8.6 (Grok 4.6 / v9-4p5)…"**
+Begin: **"Initiating DoP Protocol v3.8.6 (Grok 4.6)…"**
 
 ## Core Mandate
 
@@ -159,4 +157,4 @@ Consistency · Emotional Power · Technical Feasibility · Quota Efficiency · C
 
 ---
 
-*Director of Photography v3.8.6 — Grok 4.6 / v9-4p5 · motivated light · physics-aware camera · motif lock*
+*Director of Photography v3.8.6 — Grok 4.6 · motivated light · physics-aware camera · motif lock*

--- a/.grok/skills/distribution-crop-strategist/SKILL.md
+++ b/.grok/skills/distribution-crop-strategist/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: distribution-crop-strategist
-description: Distribution and crop strategist for 16x9 9x16 1x1 safe-action framing before polish and ffmpeg delivery. Owns platform crop plans so cinematic-ffmpeg executes without guessing. Activate with ACTIVATE DISTRIBUTION_CROP. Optimized for grok-4-auto grok-v9-4p5-multi grok-v9-4p5-chat-expert with dual Imagine Video 1.0 and 1.5 Native.
+description: Distribution and crop strategist for 16x9 9x16 1x1 safe-action framing before polish and ffmpeg delivery. Owns platform crop plans so cinematic-ffmpeg executes without guessing. Activate with ACTIVATE DISTRIBUTION_CROP. Optimized for grok-4-auto grok-4.6 grok-4.6 with dual Imagine Video 1.0 and 1.5 Native.
 version: 4.5
 preferred_model: grok-4-auto
 model_compatibility:
-  - grok-v9-4p5-chat-expert
-  - grok-v9-4p5-multi
+  - grok-4.6
+  - grok-4.6
   - grok-4-auto
 activation:
   - ACTIVATE DISTRIBUTION_CROP
@@ -17,18 +17,18 @@ tags:
   - v4.5
 ---
 
-# Distribution & Crop Strategist v4.5 (Grok 4.6 / v9-4p5 + Imagine Video 1.0 & 1.5 Native)
+# Distribution & Crop Strategist v4.5 (Grok 4.6 + Imagine Video 1.0 & 1.5 Native)
 
 **Role Card:** `references/agents/Distribution_Crop_Strategist.md` (v4.5) — authoritative source for protocols and output structures.
 
 > You own **platform framing strategy**—16:9 / 9:16 / 1:1 safe-action and crop plans—before AI Polish and cinematic-ffmpeg execute delivery variants.
 
-## Model Layer (Grok 4.6 / v9-4p5)
+## Model Layer (Grok 4.6)
 
 | Task type | Preferred model | Reasoning |
 |-----------|-----------------|-----------|
-| Specialist craft | `grok-v9-4p5-chat-expert` | high |
-| Multi-agent / synthesis | `grok-v9-4p5-multi` | high |
+| Specialist craft | `grok-4.6` (Chat **Expert**) | high |
+| Multi-agent / synthesis | `grok-4.6` (Chat **Heavy**) | high |
 | Draft / routine | `grok-4-auto` | medium |
 
 **Stack default:** cinematic+Build API/chat **`grok-4.6`** (CLI ≥ 1.0.5 · fork `grok-build` or `grok-4.6`; `grok-4.5` aliases wrap 4.6). Opt-in 1M: `grok-4.3`.  
@@ -36,8 +36,8 @@ tags:
 
 ```yaml
 model_compatibility:
-  - grok-v9-4p5-chat-expert
-  - grok-v9-4p5-multi
+  - grok-4.6
+  - grok-4.6
   - grok-4-auto
 preferred_model: grok-4-auto
 ```

--- a/.grok/skills/erosforge-nsfw-director/SKILL.md
+++ b/.grok/skills/erosforge-nsfw-director/SKILL.md
@@ -1,20 +1,20 @@
 ---
 name: erosforge-nsfw-director
-description: Adult/R-rated content specialist. Designs emotionally authentic, artistically justified intimate scenes with proper physics of intimacy, micro-expression timing, breath/audio sync, and post-scene state tracking. Optimized for grok-4-auto, grok-v9-4p5-multi, grok-v9-4p5-chat-expert and both Grok Imagine Video 1.0 + 1.5 Native. Activate explicitly with ACTIVATE EROSFORGE for any R-rated or explicit work.
+description: Adult/R-rated content specialist. Designs emotionally authentic, artistically justified intimate scenes with proper physics of intimacy, micro-expression timing, breath/audio sync, and post-scene state tracking. Optimized for grok-4-auto, grok-4.6, grok-4.6 and both Grok Imagine Video 1.0 + 1.5 Native. Activate explicitly with ACTIVATE EROSFORGE for any R-rated or explicit work.
 ---
 
-# ErosForge NSFW Director v4.5 (Grok 4.6 / v9-4p5 + Grok Imagine Video 1.0 & 1.5 Native)
+# ErosForge NSFW Director v4.5 (Grok 4.6 + Grok Imagine Video 1.0 & 1.5 Native)
 
 **Role Card:** `references/agents/ErosForge_NSFW_Director.md` (v4.5) — Authoritative source for intimate scene design, physics of intimacy, emotional authenticity, dual-model (1.0/1.5) support, EROSFORGE_STATE tracking, and strict opt-in ethics.
 
 > Adult/R-rated content specialist. Designs emotionally authentic, artistically justified intimate scenes.
 
-## Model Layer (Grok 4.6 / v9-4p5)
+## Model Layer (Grok 4.6)
 
 | Task type                                      | Preferred model               | Reasoning |
 |------------------------------------------------|-------------------------------|-----------|
-| Complex intimate scene design, multi-character emotional arcs, full EROSFORGE_STATE synthesis | `grok-v9-4p5-multi`         | high      |
-| Single-scene craft, micro-expression timing, physics of intimacy, breath/audio design | `grok-v9-4p5-chat-expert`   | high      |
+| Complex intimate scene design, multi-character emotional arcs, full EROSFORGE_STATE synthesis | `grok-4.6` (Chat **Heavy**)         | high      |
+| Single-scene craft, micro-expression timing, physics of intimacy, breath/audio design | `grok-4.6` (Chat **Expert**)   | high      |
 | Quick status / simple state checks             | `grok-4-auto`               | medium    |
 
 **Stack default:** cinematic+Build API/chat **`grok-4.6`** (CLI ≥ 1.0.5 · fork `grok-build` or `grok-4.6`; `grok-4.5` aliases wrap 4.6). Opt-in 1M: `grok-4.3`.  
@@ -22,10 +22,8 @@ description: Adult/R-rated content specialist. Designs emotionally authentic, ar
 
 ```yaml
 model_compatibility:
-  - grok-v9-4p5-chat-expert
-  - grok-v9-4p5-multi
-  - grok-4-auto
-preferred_model: grok-v9-4p5-chat-expert
+  - grok-4.6
+preferred_model: grok-4.6
 ```
 
 ## When to Activate
@@ -80,4 +78,4 @@ Fully compatible with Grok Build CLI, Termux/Android, and Kali NetHunter. All st
 
 ---
 
-*Enhanced for Grok 4.6 / v9-4p5 model layer + dual Imagine Video 1.0 & 1.5 Native support — Cinematic Studio v4.5*
+*Enhanced for Grok 4.6 + dual Imagine Video 1.0 & 1.5 Native support — Cinematic Studio v4.5*

--- a/.grok/skills/extend-frame-to-video/SKILL.md
+++ b/.grok/skills/extend-frame-to-video/SKILL.md
@@ -1,20 +1,20 @@
 ---
 name: extend-frame-to-video
-description: Create cinematic rough-cut animatics and storyboards from Grok Imagine still sequences using Extend from Frame prompting + advanced FFmpeg assembly (v2.0+). Optimized for grok-4-auto, grok-v9-4p5-multi, grok-v9-4p5-chat-expert and both Grok Imagine Video 1.0 + 1.5 Native. Features proper crossfades/wipes, cinematic filters (grain, vignette, color grade), dynamic Ken Burns, storyboard PDF export, enhanced EDL, and professional metadata. Perfect for client previews and pre-viz before full cinematic studio.
+description: Create cinematic rough-cut animatics and storyboards from Grok Imagine still sequences using Extend from Frame prompting + advanced FFmpeg assembly (v2.0+). Optimized for grok-4-auto, grok-4.6, grok-4.6 and both Grok Imagine Video 1.0 + 1.5 Native. Features proper crossfades/wipes, cinematic filters (grain, vignette, color grade), dynamic Ken Burns, storyboard PDF export, enhanced EDL, and professional metadata. Perfect for client previews and pre-viz before full cinematic studio.
 ---
 
-# Extend Frame to Video v4.5 (Grok 4.6 / v9-4p5 + Grok Imagine Video 1.0 & 1.5 Native)
+# Extend Frame to Video v4.5 (Grok 4.6 + Grok Imagine Video 1.0 & 1.5 Native)
 
 **Role Card:** `references/agents/Extend_Frame_to_Video.md` (v4.5) — Authoritative source for extend-from-frame protocols, dual-model (1.0/1.5) support, project.json integration, Handoff Packet generation, and FFmpeg assembly standards.
 
 > Create cinematic rough-cut animatics and storyboards from Grok Imagine still sequences.
 
-## Model Layer (Grok 4.6 / v9-4p5)
+## Model Layer (Grok 4.6)
 
 | Task type                                      | Preferred model               | Reasoning |
 |------------------------------------------------|-------------------------------|-----------|
-| Complex multi-clip assembly planning, EDL + storyboard synthesis | `grok-v9-4p5-multi`         | high      |
-| Single-sequence extend planning, prompt crafting, Ken Burns design | `grok-v9-4p5-chat-expert`   | high      |
+| Complex multi-clip assembly planning, EDL + storyboard synthesis | `grok-4.6` (Chat **Heavy**)         | high      |
+| Single-sequence extend planning, prompt crafting, Ken Burns design | `grok-4.6` (Chat **Expert**)   | high      |
 | Quick status / simple assembly checks          | `grok-4-auto`               | medium    |
 
 **Stack default:** cinematic+Build API/chat **`grok-4.6`** (CLI ≥ 1.0.5 · fork `grok-build` or `grok-4.6`; `grok-4.5` aliases wrap 4.6). Opt-in 1M: `grok-4.3`.  
@@ -22,10 +22,8 @@ description: Create cinematic rough-cut animatics and storyboards from Grok Imag
 
 ```yaml
 model_compatibility:
-  - grok-v9-4p5-chat-expert
-  - grok-v9-4p5-multi
-  - grok-4-auto
-preferred_model: grok-v9-4p5-multi
+  - grok-4.6
+preferred_model: grok-4.6
 ```
 
 ## When to Activate
@@ -80,4 +78,4 @@ Fully compatible with Grok Build CLI, scripts/assemble-rough.sh, generate-handof
 
 ---
 
-*Enhanced for Grok 4.6 / v9-4p5 model layer + dual Imagine Video 1.0 & 1.5 Native support — Cinematic Studio v4.5*
+*Enhanced for Grok 4.6 + dual Imagine Video 1.0 & 1.5 Native support — Cinematic Studio v4.5*

--- a/.grok/skills/foley-sound-design-specialist/SKILL.md
+++ b/.grok/skills/foley-sound-design-specialist/SKILL.md
@@ -1,21 +1,21 @@
 ---
 name: foley-sound-design-specialist
-description: Hyper-realistic foley and immersive soundscape specialist. Designs detailed, physically accurate sound effects and environmental audio layers that enhance realism and emotional immersion. Activate when hyper-realistic foley or detailed environmental sound design is needed. Optimized for grok-4-auto grok-v9-4p5-multi grok-v9-4p5-chat-expert with dual Imagine Video 1.0 and 1.5 Native.
+description: Hyper-realistic foley and immersive soundscape specialist. Designs detailed, physically accurate sound effects and environmental audio layers that enhance realism and emotional immersion. Activate when hyper-realistic foley or detailed environmental sound design is needed. Optimized for grok-4-auto grok-4.6 grok-4.6 with dual Imagine Video 1.0 and 1.5 Native.
 ---
 
-# Foley Sound Design Specialist v3.8.6 (Grok 4.6 / v9-4p5 · Tactile Reality)
+# Foley Sound Design Specialist v3.8.6 (Grok 4.6 · Tactile Reality)
 
 **Activate when detailed foley or environmental sound is critical.** You design material-true footsteps, cloth, props, body movement, and ambient beds that sell physical reality — feeding Sonic Architect’s Sound Layer and AMV chains.
 
 **Role Card:** `references/agents/Foley_Sound_Design_Specialist_v3.5.md`  
 **Lead:** Sonic Architect (overall soundscape) · **Physics:** match I2V / VFX motion · **State:** Continuity / Production Design materials
 
-## Model Layer (Grok 4.6 / v9-4p5)
+## Model Layer (Grok 4.6)
 
 | Task type | Preferred model | Reasoning |
 |-----------|-----------------|-----------|
-| Multi-agent orchestration / handoff synthesis | `grok-v9-4p5-multi` | high |
-| Specialist deep craft / QA / identity-critical | `grok-v9-4p5-chat-expert` | high |
+| Multi-agent orchestration / handoff synthesis | `grok-4.6` (Chat **Heavy**) | high |
+| Specialist deep craft / QA / identity-critical | `grok-4.6` (Chat **Expert**) | high |
 | Routine status / draft passes | `grok-4-auto` | medium |
 
 **Stack default:** cinematic+Build API/chat **`grok-4.6`** (CLI ≥ 1.0.5 · fork `grok-build` or `grok-4.6`; `grok-4.5` aliases wrap 4.6). Opt-in 1M: `grok-4.3`.  
@@ -23,10 +23,8 @@ description: Hyper-realistic foley and immersive soundscape specialist. Designs 
 
 ```yaml
 model_compatibility:
-  - grok-v9-4p5-chat-expert
-  - grok-v9-4p5-multi
-  - grok-4-auto
-preferred_model: grok-v9-4p5-chat-expert
+  - grok-4.6
+preferred_model: grok-4.6
 ```
 
 ### Imagine Video dual-path (when this skill touches video)
@@ -44,7 +42,7 @@ preferred_model: grok-v9-4p5-chat-expert
 - Recurring materials need Sound DNA  
 - User says: `ACTIVATE FOLEY_SPECIALIST`, `DESIGN FOLEY FOR [action]`, `INTIMATE_FOLEY_MODE`, `MATERIAL [name]`
 
-Begin: **"Initiating Foley Protocol v3.8.6 (Grok 4.6 / v9-4p5)…"**
+Begin: **"Initiating Foley Protocol v3.8.6 (Grok 4.6)…"**
 
 ## Core Mandate
 
@@ -166,4 +164,4 @@ Consistency · Emotional Power · Technical Feasibility · Quota Efficiency · C
 
 ---
 
-*Foley Specialist v3.8.6 — Grok 4.6 / v9-4p5 · material truth · perspective-matched · Sound DNA*
+*Foley Specialist v3.8.6 — Grok 4.6 · material truth · perspective-matched · Sound DNA*

--- a/.grok/skills/github-repo-manager/SKILL.md
+++ b/.grok/skills/github-repo-manager/SKILL.md
@@ -1,20 +1,20 @@
 ---
 name: github-repo-manager
-description: Use for all GitHub repository management tasks including creating, listing, forking, file operations, branches, issues, pull requests, releases, commits, searches, and workflows. Trigger on requests like manage my GitHub repos, create repo, list my repos, handle PRs or issues, push files, fork project. Optimized for grok-4-auto, grok-v9-4p5-multi and grok-v9-4p5-chat-expert.
+description: Use for all GitHub repository management tasks including creating, listing, forking, file operations, branches, issues, pull requests, releases, commits, searches, and workflows. Trigger on requests like manage my GitHub repos, create repo, list my repos, handle PRs or issues, push files, fork project. Optimized for grok-4-auto, grok-4.6 and grok-4.6.
 ---
 
-# GitHub Repo Manager v4.5 (Grok 4.6 / v9-4p5 + Grok Imagine Video 1.5 Native)
+# GitHub Repo Manager v4.5 (Grok 4.6 + Grok Imagine Video 1.5 Native)
 
 **Role Card:** `references/agents/GitHub_Repo_Manager.md` (v4.5) — Authoritative for GitHub automation, repository management, and integration with cinematic studio workflows.
 
 > Always load and follow the Role Card before major repository operations or multi-step workflows.
 
-## Model Layer (Grok 4.6 / v9-4p5)
+## Model Layer (Grok 4.6)
 
 | Task type                              | Preferred model               | Reasoning |
 |----------------------------------------|-------------------------------|-----------|
-| Complex multi-repo / release / PR orchestration | `grok-v9-4p5-multi`         | high      |
-| Specialist deep analysis, issue triage, code search | `grok-v9-4p5-chat-expert` | high      |
+| Complex multi-repo / release / PR orchestration | `grok-4.6` (Chat **Heavy**)         | high      |
+| Specialist deep analysis, issue triage, code search | `grok-4.6` (Chat **Expert**) | high      |
 | Quick status, routine file ops, listing | `grok-4-auto`                | medium    |
 
 **Stack default:** cinematic+Build API/chat **`grok-4.6`** (CLI ≥ 1.0.5 · fork `grok-build` or `grok-4.6`; `grok-4.5` aliases wrap 4.6). Opt-in 1M: `grok-4.3`.  
@@ -22,10 +22,8 @@ description: Use for all GitHub repository management tasks including creating, 
 
 ```yaml
 model_compatibility:
-  - grok-v9-4p5-chat-expert
-  - grok-v9-4p5-multi
-  - grok-4-auto
-preferred_model: grok-v9-4p5-chat-expert
+  - grok-4.6
+preferred_model: grok-4.6
 ```
 
 ## When to Activate
@@ -51,10 +49,10 @@ Load the Role Card. Prefer parallel tool calls for independent operations. Alway
 | **RELEASE_MANAGEMENT**         | Handle releases and version tagging; coordinate with cinematic_studio.sh versioning |
 | **MODEL_ROUTING**              | Select model by task complexity (auto for status, chat-expert for analysis, multi for orchestration) |
 
-## Grok 4.6 / v9-4p5 Optimizations
+## Grok 4.6 Optimizations
 
-- **grok-v9-4p5-multi**: Preferred for multi-step release preparation, cross-repo skill syncs, Team Leader handoffs involving GitHub state.
-- **grok-v9-4p5-chat-expert**: Deep code search, PR review analysis, complex issue body drafting, cinematic asset commit planning.
+- **grok-4.6**: Preferred for multi-step release preparation, cross-repo skill syncs, Team Leader handoffs involving GitHub state.
+- **grok-4.6**: Deep code search, PR review analysis, complex issue body drafting, cinematic asset commit planning.
 - **grok-4-auto**: Fast repo status, branch listing, simple file pushes, routine checks under quota pressure.
 - Leverage long context for full repo tree + Production Bible awareness.
 - Structured Handoff Packet v1.2 compatible outputs when integrating with Studio Director or skill-creator.
@@ -79,4 +77,4 @@ Fully compatible with Grok Build CLI, cinematic_studio_cli.py GitHub workflows, 
 **Load the Role Card** for complete GitHub management methodology, decision frameworks, and v4.5 Role Card updates.
 
 ---
-*Enhanced for grok-4-auto · grok-v9-4p5-multi · grok-v9-4p5-chat-expert | Cinematic Studio v3.8.6+*
+*Enhanced for grok-4-auto · grok-4.6 · grok-4.6 | Cinematic Studio v3.8.6+*

--- a/.grok/skills/grok-doctor/SKILL.md
+++ b/.grok/skills/grok-doctor/SKILL.md
@@ -2,10 +2,10 @@
 name: grok-doctor
 description: Studio Health Diagnostician for Grok Imagine Cinematic Studio. Audits agent roster, handoff integrity, continuity scores, model routing, Explicit path health, audio stack, and production pipeline readiness. Issues ranked Studio Health Reports with actionable fixes.
 version: 4.5
-preferred_model: grok-v9-4p5-multi
+preferred_model: grok-4.6
 model_compatibility:
-  - grok-v9-4p5-multi
-  - grok-v9-4p5-chat-expert
+  - grok-4.6
+  - grok-4.6
   - grok-4-auto
 activation:
   - ACTIVATE GROK_DOCTOR

--- a/.grok/skills/grok-imagine-cinematic-studio/SKILL.md
+++ b/.grok/skills/grok-imagine-cinematic-studio/SKILL.md
@@ -1,21 +1,21 @@
 ---
 name: grok-imagine-cinematic-studio
-description: Activate the full Grok Imagine Cinematic Studio v3.11.0 Odyssey Native powered by a 25-agent core suite plus i2i and NSFW specialists with unified Grok 4.6 cinematic+Build stack optional v9-4p5 multi/chat-expert and 4.3 1M guided Production Bible wizard Imagine Agent Mode Handoff and native Grok Imagine Video 1.0/1.5 dual support with one-pass synchronized audio. Includes Studio Director Mega Production Architect DoP ErosForge Sonic Architect Foley Key Art Trailer Stunt VFX Production Designer Localization AI Polish Director Grok Doctor Multi-Clip Continuity I2I refiners and NSFW orchestrators. Trigger on Activate Grok Imagine Cinematic Studio v3.11.0 enter cinematic studio start cinematic production or any full multi-agent cinematic workflow.
+description: Activate the full Grok Imagine Cinematic Studio v3.11.0 Odyssey Native powered by a 25-agent core suite plus i2i and NSFW specialists with unified Grok 4.6 cinematic+Build stack optional 4.6 multi/chat-expert and 4.3 1M guided Production Bible wizard Imagine Agent Mode Handoff and native Grok Imagine Video 1.0/1.5 dual support with one-pass synchronized audio. Includes Studio Director Mega Production Architect DoP ErosForge Sonic Architect Foley Key Art Trailer Stunt VFX Production Designer Localization AI Polish Director Grok Doctor Multi-Clip Continuity I2I refiners and NSFW orchestrators. Trigger on Activate Grok Imagine Cinematic Studio v3.11.0 enter cinematic studio start cinematic production or any full multi-agent cinematic workflow.
 ---
 
-# Grok Imagine Cinematic Studio v3.11.0 "Odyssey Native" (Grok 4.6 · v9-4p5)
+# Grok Imagine Cinematic Studio v3.11.0 "Odyssey Native" (Grok 4.6 · 4.6)
 
-**You are now in full Cinematic Studio v3.11.0 mode** (Grok 4.6 / v9-4p5 stack + guided Bible wizard + Imagine Agent Mode Handoff + Imagine Image 2.0 + Video 1.0/1.5 dual).
+**You are now in full Cinematic Studio v3.11.0 mode** (Grok 4.6 stack + guided Bible wizard + Imagine Agent Mode Handoff + Imagine Image 2.0 + Video 1.0/1.5 dual).
 
 > [!NOTE]
 > **Independent community project** — not affiliated with, endorsed by, sponsored by, or officially connected to xAI. Do not claim official xAI partnership when directing productions. Full notice: repo root `DISCLAIMER.md`.
 
-## Model Layer (Grok 4.6 / v9-4p5)
+## Model Layer (Grok 4.6)
 
 | Task type | Preferred model | Reasoning |
 |-----------|-----------------|-----------|
-| Multi-agent orchestration / handoff synthesis | `grok-v9-4p5-multi` | high |
-| Specialist deep craft / QA / identity-critical | `grok-v9-4p5-chat-expert` | high |
+| Multi-agent orchestration / handoff synthesis | `grok-4.6` (Chat **Heavy**) | high |
+| Specialist deep craft / QA / identity-critical | `grok-4.6` (Chat **Expert**) | high |
 | Routine status / draft passes | `grok-4-auto` | medium |
 
 **Stack default:** cinematic+Build API/chat **`grok-4.6`** (CLI ≥ 1.0.5 · fork `grok-build` or `grok-4.6`; `grok-4.5` aliases wrap 4.6). Opt-in 1M: `grok-4.3`.  
@@ -23,10 +23,8 @@ description: Activate the full Grok Imagine Cinematic Studio v3.11.0 Odyssey Nat
 
 ```yaml
 model_compatibility:
-  - grok-v9-4p5-chat-expert
-  - grok-v9-4p5-multi
-  - grok-4-auto
-preferred_model: grok-v9-4p5-multi
+  - grok-4.6
+preferred_model: grok-4.6
 ```
 
 ### Imagine Video dual-path (when this skill touches video)
@@ -146,9 +144,9 @@ Studio Director **owns** surface selection and must not hand off video without I
 - Multi-reference + `reference_image_id` propagation
 - NSFW via ErosForge + `nsfw-quota-orchestrator` + `nsfw-sequence-extender` (explicit only)
 - Quota-aware production with xAI per-second pricing (`workflow-quota-optimizer`)
-- **Grok 4.6 / v9-4p5 model stack** — CLI `grok-4.6` (min 1.0.5) / fork `grok-build` or `grok-4.6`; `grok-4.5` aliases wrap 4.6; opt-in `grok-v9-4p5-multi` / `grok-v9-4p5-chat-expert` / `grok-4-auto`; 1M `grok-4.3`; Imagine 1.0 default + 1.5 native audio (`tools/models.py`, `references/agents/MODEL_LAYER_v4.5.md`)
+- **Grok 4.6 model stack** — CLI `grok-4.6` (min 1.0.5) / fork `grok-build` or `grok-4.6`; `grok-4.5` aliases wrap 4.6; opt-in `grok-4.6` (Chat **Heavy**) / `grok-4.6` (Chat **Expert**) / `grok-4-auto`; 1M `grok-4.3`; Imagine 1.0 default + 1.5 native audio (`tools/models.py`, `references/agents/MODEL_LAYER_v4.5.md`)
 - Plugin marketplace (64 skills + 11 commands) with release-pin hygiene
-- Authoritative Role Cards in `references/agents/` (each embeds Model Layer Grok 4.6 / v9-4p5)
+- Authoritative Role Cards in `references/agents/` (each embeds Model Layer Grok 4.6)
 
 ## Quick Commands
 
@@ -179,4 +177,4 @@ This skill gives you access to the complete cinematic production system (Grok 4.
 
 ---
 
-*Grok Imagine Cinematic Studio v3.11.0 — Grok 4.6 / v9-4p5 · Image 2.0 + Video 1.0/1.5 · Grok Build ≥ 1.0.5 · `models verify`*
+*Grok Imagine Cinematic Studio v3.11.0 — Grok 4.6 · Image 2.0 + Video 1.0/1.5 · Grok Build ≥ 1.0.5 · `models verify`*

--- a/.grok/skills/grok-imagine-image-tools/SKILL.md
+++ b/.grok/skills/grok-imagine-image-tools/SKILL.md
@@ -16,10 +16,8 @@ Hero plates and Quality Mode should lock `grok-imagine-image-2.0`. There is no V
 
 ```yaml
 model_compatibility:
-  - grok-v9-4p5-chat-expert
-  - grok-v9-4p5-multi
-  - grok-4-auto
-preferred_model: grok-v9-4p5-chat-expert
+  - grok-4.6
+preferred_model: grok-4.6
 ```
 
 Apply this whenever you're considering or about to call either tool.

--- a/.grok/skills/hair-makeup-continuity/SKILL.md
+++ b/.grok/skills/hair-makeup-continuity/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: hair-makeup-continuity
-description: Hair and makeup continuity lock nested on Character DNA for Grok Imagine multi-clip work. Owns hmu_lock sweat smudge wet state and inject blocks so face and hair survive stills i2v and extend. Activate with ACTIVATE HAIR_MAKEUP_CONTINUITY or LOCK HMU. Optimized for grok-4-auto grok-v9-4p5-multi grok-v9-4p5-chat-expert with dual Imagine Video 1.0 and 1.5 Native.
+description: Hair and makeup continuity lock nested on Character DNA for Grok Imagine multi-clip work. Owns hmu_lock sweat smudge wet state and inject blocks so face and hair survive stills i2v and extend. Activate with ACTIVATE HAIR_MAKEUP_CONTINUITY or LOCK HMU. Optimized for grok-4-auto grok-4.6 grok-4.6 with dual Imagine Video 1.0 and 1.5 Native.
 version: 4.5
-preferred_model: grok-v9-4p5-chat-expert
+preferred_model: grok-4.6
 model_compatibility:
-  - grok-v9-4p5-chat-expert
-  - grok-v9-4p5-multi
+  - grok-4.6
+  - grok-4.6
   - grok-4-auto
 activation:
   - ACTIVATE HAIR_MAKEUP_CONTINUITY
@@ -17,18 +17,18 @@ tags:
   - v4.5
 ---
 
-# Hair & Makeup Continuity v4.5 (Grok 4.6 / v9-4p5 + Imagine Video 1.0 & 1.5 Native)
+# Hair & Makeup Continuity v4.5 (Grok 4.6 + Imagine Video 1.0 & 1.5 Native)
 
 **Role Card:** `references/agents/Hair_Makeup_Continuity.md` (v4.5) — authoritative source for protocols and output structures.
 
 > You own **hair and makeup state** as structured continuity nested on Character DNA. Face identity stays with Identity Lock; wardrobe stays with Costume—you own HMU lock, condition deltas, and inject language.
 
-## Model Layer (Grok 4.6 / v9-4p5)
+## Model Layer (Grok 4.6)
 
 | Task type | Preferred model | Reasoning |
 |-----------|-----------------|-----------|
-| Specialist craft | `grok-v9-4p5-chat-expert` | high |
-| Multi-agent / synthesis | `grok-v9-4p5-multi` | high |
+| Specialist craft | `grok-4.6` (Chat **Expert**) | high |
+| Multi-agent / synthesis | `grok-4.6` (Chat **Heavy**) | high |
 | Draft / routine | `grok-4-auto` | medium |
 
 **Stack default:** cinematic+Build API/chat **`grok-4.6`** (CLI ≥ 1.0.5 · fork `grok-build` or `grok-4.6`; `grok-4.5` aliases wrap 4.6). Opt-in 1M: `grok-4.3`.  
@@ -36,10 +36,8 @@ tags:
 
 ```yaml
 model_compatibility:
-  - grok-v9-4p5-chat-expert
-  - grok-v9-4p5-multi
-  - grok-4-auto
-preferred_model: grok-v9-4p5-chat-expert
+  - grok-4.6
+preferred_model: grok-4.6
 ```
 
 ## When to Activate

--- a/.grok/skills/handoff-packet-validator/SKILL.md
+++ b/.grok/skills/handoff-packet-validator/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: handoff-packet-validator
-description: Validates JSON handoff packets between Cinematic Studio agents including identity lock sequence extend asset manifest intimacy state and Imagine Agent Mode Handoff. Run before activating downstream agents or extend generation. Use when validating handoff.json packets or debugging chain QA failures. Optimized for grok-4-auto grok-v9-4p5-multi grok-v9-4p5-chat-expert with dual Imagine Video 1.0 and 1.5 Native.
+description: Validates JSON handoff packets between Cinematic Studio agents including identity lock sequence extend asset manifest intimacy state and Imagine Agent Mode Handoff. Run before activating downstream agents or extend generation. Use when validating handoff.json packets or debugging chain QA failures. Optimized for grok-4-auto grok-4.6 grok-4.6 with dual Imagine Video 1.0 and 1.5 Native.
 ---
 
-# Handoff Packet Validator v3.8.6 (Grok 4.6 / v9-4p5 · Schema Gate)
+# Handoff Packet Validator v3.8.6 (Grok 4.6 · Schema Gate)
 
 **Tool skill** — data-driven schema checks for agent handoff JSON. Blocks broken packets before Identity Lock, extend/stitch, i2v, or Imagine spend.
 
@@ -11,12 +11,12 @@ description: Validates JSON handoff packets between Cinematic Studio agents incl
 **Canonical Imagine Agent Mode schema:** `tools/handoff_schema.py`  
 **Field cheat sheet:** `references/packet_types.md`
 
-## Model Layer (Grok 4.6 / v9-4p5)
+## Model Layer (Grok 4.6)
 
 | Task type | Preferred model | Reasoning |
 |-----------|-----------------|-----------|
-| Multi-agent orchestration / handoff synthesis | `grok-v9-4p5-multi` | high |
-| Specialist deep craft / QA / identity-critical | `grok-v9-4p5-chat-expert` | high |
+| Multi-agent orchestration / handoff synthesis | `grok-4.6` (Chat **Heavy**) | high |
+| Specialist deep craft / QA / identity-critical | `grok-4.6` (Chat **Expert**) | high |
 | Routine status / draft passes | `grok-4-auto` | medium |
 
 **Stack default:** cinematic+Build API/chat **`grok-4.6`** (CLI ≥ 1.0.5 · fork `grok-build` or `grok-4.6`; `grok-4.5` aliases wrap 4.6). Opt-in 1M: `grok-4.3`.  
@@ -24,10 +24,8 @@ description: Validates JSON handoff packets between Cinematic Studio agents incl
 
 ```yaml
 model_compatibility:
-  - grok-v9-4p5-chat-expert
-  - grok-v9-4p5-multi
-  - grok-4-auto
-preferred_model: grok-v9-4p5-chat-expert
+  - grok-4.6
+preferred_model: grok-4.6
 ```
 
 ### Imagine Video dual-path (when this skill touches video)
@@ -205,4 +203,4 @@ Imagine Agent Mode (surfaces, modes, required fields):
 
 ---
 
-*Handoff Packet Validator v3.8.6 — Grok 4.6 / v9-4p5 schema gate · data-driven PACKET_TYPES · block broken handoffs before spend*
+*Handoff Packet Validator v3.8.6 — Grok 4.6 schema gate · data-driven PACKET_TYPES · block broken handoffs before spend*

--- a/.grok/skills/i2i-cinematic-refiner/SKILL.md
+++ b/.grok/skills/i2i-cinematic-refiner/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: i2i-cinematic-refiner
-description: General-purpose Image-to-Image cinematic refinement specialist for Grok Imagine productions. Handles multi-pass refinement, strength scheduling, reference consistency, lighting continuity and pre-video polish. Activate for standard cinematic i2i work, keyframe refinement, or quality passes. Optimized for grok-4-auto grok-v9-4p5-multi grok-v9-4p5-chat-expert with dual Imagine Video 1.0 and 1.5 Native.
+description: General-purpose Image-to-Image cinematic refinement specialist for Grok Imagine productions. Handles multi-pass refinement, strength scheduling, reference consistency, lighting continuity and pre-video polish. Activate for standard cinematic i2i work, keyframe refinement, or quality passes. Optimized for grok-4-auto grok-4.6 grok-4.6 with dual Imagine Video 1.0 and 1.5 Native.
 ---
 
-# I2I Cinematic Refiner v3.8.6 (Grok 4.6 / v9-4p5 · Cinematic I2I)
+# I2I Cinematic Refiner v3.8.6 (Grok 4.6 · Cinematic I2I)
 
 **SFW multi-pass Image-to-Image specialist.** You polish keyframes and plates for identity lock, lighting continuity, and pre-video readiness — without explicit/NSFW anatomy protocols (those live in `i2i-refiner`).
 
@@ -11,12 +11,12 @@ description: General-purpose Image-to-Image cinematic refinement specialist for 
 **Tools:** `image_edit` (primary) · Imagine image models  
 **Partners:** Identity Lock · Prompt Master · DoP · Reference Curator · I2V Specialist
 
-## Model Layer (Grok 4.6 / v9-4p5)
+## Model Layer (Grok 4.6)
 
 | Task type | Preferred model | Reasoning |
 |-----------|-----------------|-----------|
-| Multi-agent orchestration / handoff synthesis | `grok-v9-4p5-multi` | high |
-| Specialist deep craft / QA / identity-critical | `grok-v9-4p5-chat-expert` | high |
+| Multi-agent orchestration / handoff synthesis | `grok-4.6` (Chat **Heavy**) | high |
+| Specialist deep craft / QA / identity-critical | `grok-4.6` (Chat **Expert**) | high |
 | Routine status / draft passes | `grok-4-auto` | medium |
 
 **Stack default:** cinematic+Build API/chat **`grok-4.6`** (CLI ≥ 1.0.5 · fork `grok-build` or `grok-4.6`; `grok-4.5` aliases wrap 4.6). Opt-in 1M: `grok-4.3`.  
@@ -24,10 +24,8 @@ description: General-purpose Image-to-Image cinematic refinement specialist for 
 
 ```yaml
 model_compatibility:
-  - grok-v9-4p5-chat-expert
-  - grok-v9-4p5-multi
-  - grok-4-auto
-preferred_model: grok-v9-4p5-chat-expert
+  - grok-4.6
+preferred_model: grok-4.6
 ```
 
 ### Imagine Video dual-path (when this skill touches video)
@@ -41,7 +39,7 @@ preferred_model: grok-v9-4p5-chat-expert
 - Identity-safe quality passes (SFW)  
 - User says: `ACTIVATE I2I CINEMATIC REFINER`, `KEYFRAME POLISH`, `I2I QUALITY`, `CINEMATIC REFINEMENT`
 
-Begin: **"Initiating I2I Cinematic Refinement Protocol v3.8.6 (Grok 4.6 / v9-4p5)…"**
+Begin: **"Initiating I2I Cinematic Refinement Protocol v3.8.6 (Grok 4.6)…"**
 
 **Escalate to `i2i-refiner`** if explicit anatomy, fluids, or erotic close-ups appear.
 
@@ -145,4 +143,4 @@ Next: Reference Curator | I2V | iterate | escalate i2i-refiner
 
 ---
 
-*I2I Cinematic Refiner v3.8.6 — Grok 4.6 / v9-4p5 · SFW multi-pass · DNA-safe · pre-video polish*
+*I2I Cinematic Refiner v3.8.6 — Grok 4.6 · SFW multi-pass · DNA-safe · pre-video polish*

--- a/.grok/skills/i2i-refiner/SKILL.md
+++ b/.grok/skills/i2i-refiner/SKILL.md
@@ -1,19 +1,19 @@
 ---
 name: i2i-refiner
-description: Advanced Image-to-Image refinement specialist for Grok Imagine cinematic productions. Manages multi-pass i2i workflows, strength scheduling, reference consistency, style transfer and prompt chaining to achieve photorealistic fidelity and character lock. Activate for any i2i task, reference image processing or pre-video refinement passes. Optimized for grok-4-auto grok-v9-4p5-multi grok-v9-4p5-chat-expert with dual Imagine Video 1.0 and 1.5 Native.
+description: Advanced Image-to-Image refinement specialist for Grok Imagine cinematic productions. Manages multi-pass i2i workflows, strength scheduling, reference consistency, style transfer and prompt chaining to achieve photorealistic fidelity and character lock. Activate for any i2i task, reference image processing or pre-video refinement passes. Optimized for grok-4-auto grok-4.6 grok-4.6 with dual Imagine Video 1.0 and 1.5 Native.
 ---
 
-# I2I Refiner v3.8.6 (Grok 4.6 / v9-4p5 · Explicit I2I)
+# I2I Refiner v3.8.6 (Grok 4.6 · Explicit I2I)
 
 **Role Card:** `references/agents/I2I_Refiner.md` — authoritative for personality, protocols, output formats, and decision frameworks.
 
 
-## Model Layer (Grok 4.6 / v9-4p5)
+## Model Layer (Grok 4.6)
 
 | Task type | Preferred model | Reasoning |
 |-----------|-----------------|-----------|
-| Multi-agent orchestration / handoff synthesis | `grok-v9-4p5-multi` | high |
-| Specialist deep craft / QA / identity-critical | `grok-v9-4p5-chat-expert` | high |
+| Multi-agent orchestration / handoff synthesis | `grok-4.6` (Chat **Heavy**) | high |
+| Specialist deep craft / QA / identity-critical | `grok-4.6` (Chat **Expert**) | high |
 | Routine status / draft passes | `grok-4-auto` | medium |
 
 **Stack default:** cinematic+Build API/chat **`grok-4.6`** (CLI ≥ 1.0.5 · fork `grok-build` or `grok-4.6`; `grok-4.5` aliases wrap 4.6). Opt-in 1M: `grok-4.3`.  
@@ -21,10 +21,8 @@ description: Advanced Image-to-Image refinement specialist for Grok Imagine cine
 
 ```yaml
 model_compatibility:
-  - grok-v9-4p5-chat-expert
-  - grok-v9-4p5-multi
-  - grok-4-auto
-preferred_model: grok-v9-4p5-chat-expert
+  - grok-4.6
+preferred_model: grok-4.6
 ```
 
 ### Imagine Video dual-path (when this skill touches video)
@@ -182,4 +180,4 @@ This skill ensures every refined frame or plate entering a cinematic sequence ma
 
 ---
 
-*I2I Refiner v3.8.6 — Grok 4.6 / v9-4p5 · studio Model Layer · `models verify`*
+*I2I Refiner v3.8.6 — Grok 4.6 · studio Model Layer · `models verify`*

--- a/.grok/skills/identity-lock-specialist/SKILL.md
+++ b/.grok/skills/identity-lock-specialist/SKILL.md
@@ -1,20 +1,20 @@
 ---
 name: identity-lock-specialist
-description: Guardian of character consistency and visual identity. Maintains Character DNA Bible, tracks character drift, enforces multi-character continuity, and loads handoff packets from Character DNA Extractor. Optimized for grok-4-auto, grok-v9-4p5-multi, grok-v9-4p5-chat-expert and both Grok Imagine Video 1.0 + 1.5 Native. Activate on any project with recurring characters or complex relationships.
+description: Guardian of character consistency and visual identity. Maintains Character DNA Bible, tracks character drift, enforces multi-character continuity, and loads handoff packets from Character DNA Extractor. Optimized for grok-4-auto, grok-4.6, grok-4.6 and both Grok Imagine Video 1.0 + 1.5 Native. Activate on any project with recurring characters or complex relationships.
 ---
 
-# Identity Lock Specialist v4.5 (Grok 4.6 / v9-4p5 + Grok Imagine Video 1.0 & 1.5 Native)
+# Identity Lock Specialist v4.5 (Grok 4.6 + Grok Imagine Video 1.0 & 1.5 Native)
 
 **Role Card:** `references/agents/Identity_Lock_Specialist.md` (v4.5) — Authoritative source for Character DNA Bible management, drift detection, consistency enforcement, dual-model (1.0/1.5) identity preservation protocols, and ErosForge compatibility.
 
 > **Always active for character-driven work.** You are the protective, detail-obsessed guardian of character integrity.
 
-## Model Layer (Grok 4.6 / v9-4p5)
+## Model Layer (Grok 4.6)
 
 | Task type                                      | Preferred model               | Reasoning |
 |------------------------------------------------|-------------------------------|-----------|
-| DNA lock / detailed drift analysis / face consistency | `grok-v9-4p5-chat-expert`   | high      |
-| Multi-character continuity / suite-level identity audit | `grok-v9-4p5-multi`         | high      |
+| DNA lock / detailed drift analysis / face consistency | `grok-4.6` (Chat **Expert**)   | high      |
+| Multi-character continuity / suite-level identity audit | `grok-4.6` (Chat **Heavy**)         | high      |
 | Routine status checks / simple lock confirmation | `grok-4-auto`               | medium    |
 
 **Stack default:** cinematic+Build API/chat **`grok-4.6`** (CLI ≥ 1.0.5 · fork `grok-build` or `grok-4.6`; `grok-4.5` aliases wrap 4.6). Opt-in 1M: `grok-4.3`.  
@@ -22,10 +22,8 @@ description: Guardian of character consistency and visual identity. Maintains Ch
 
 ```yaml
 model_compatibility:
-  - grok-v9-4p5-chat-expert
-  - grok-v9-4p5-multi
-  - grok-4-auto
-preferred_model: grok-v9-4p5-chat-expert
+  - grok-4.6
+preferred_model: grok-4.6
 ```
 
 ## When to Activate
@@ -87,4 +85,4 @@ Fully compatible with Grok Build CLI, `cinematic_studio_cli.py` identity workflo
 
 ---
 
-*Enhanced for Grok 4.6 / v9-4p5 model layer + dual Imagine Video 1.0 & 1.5 Native support — Cinematic Studio v4.5*
+*Enhanced for Grok 4.6 + dual Imagine Video 1.0 & 1.5 Native support — Cinematic Studio v4.5*

--- a/.grok/skills/image-to-video-specialist/SKILL.md
+++ b/.grok/skills/image-to-video-specialist/SKILL.md
@@ -1,21 +1,21 @@
 ---
 name: image-to-video-specialist
-description: Image-to-video engineering specialist for Grok Imagine Video 1.5. Builds motion-ready i2v prompts with reference fidelity motion vectors audio seeds and first-frame lock from approved stills. Activate with ACTIVATE I2V_SPECIALIST before video spend on hero keyframes or sequence chains. Optimized for grok-4-auto grok-v9-4p5-multi grok-v9-4p5-chat-expert with dual Imagine Video 1.0 and 1.5 Native.
+description: Image-to-video engineering specialist for Grok Imagine Video 1.5. Builds motion-ready i2v prompts with reference fidelity motion vectors audio seeds and first-frame lock from approved stills. Activate with ACTIVATE I2V_SPECIALIST before video spend on hero keyframes or sequence chains. Optimized for grok-4-auto grok-4.6 grok-4.6 with dual Imagine Video 1.0 and 1.5 Native.
 ---
 
-# Image-to-Video Specialist v3.8.6 (Grok 4.6 / v9-4p5 · Still → Motion)
+# Image-to-Video Specialist v3.8.6 (Grok 4.6 · Still → Motion)
 
 You own the **still → video** transition. Imagine Prompt Master writes cinematic language; you specialize **motion, physics, first-frame lock, audio seeds, and extend handoffs**.
 
 **Role Card:** `references/agents/Image_to_Video_Specialist.md`  
 **Tools:** session `image_to_video` / `reference_to_video` · API/CLI batch · `sequence extend-prompt`
 
-## Model Layer (Grok 4.6 / v9-4p5)
+## Model Layer (Grok 4.6)
 
 | Task type | Preferred model | Reasoning |
 |-----------|-----------------|-----------|
-| Multi-agent orchestration / handoff synthesis | `grok-v9-4p5-multi` | high |
-| Specialist deep craft / QA / identity-critical | `grok-v9-4p5-chat-expert` | high |
+| Multi-agent orchestration / handoff synthesis | `grok-4.6` (Chat **Heavy**) | high |
+| Specialist deep craft / QA / identity-critical | `grok-4.6` (Chat **Expert**) | high |
 | Routine status / draft passes | `grok-4-auto` | medium |
 
 **Stack default:** cinematic+Build API/chat **`grok-4.6`** (CLI ≥ 1.0.5 · fork `grok-build` or `grok-4.6`; `grok-4.5` aliases wrap 4.6). Opt-in 1M: `grok-4.3`.  
@@ -23,10 +23,8 @@ You own the **still → video** transition. Imagine Prompt Master writes cinemat
 
 ```yaml
 model_compatibility:
-  - grok-v9-4p5-chat-expert
-  - grok-v9-4p5-multi
-  - grok-4-auto
-preferred_model: grok-v9-4p5-chat-expert
+  - grok-4.6
+preferred_model: grok-4.6
 ```
 
 ### Imagine Video dual-path (when this skill touches video)
@@ -83,7 +81,7 @@ ACTIVATE I2V_SPECIALIST
 ACTIVATE ONLY Image-to-Video Specialist, Identity Lock Specialist, QA Guardian
 ```
 
-Begin: **"Initiating I2V Specialist Protocol v3.8.6 (Grok 4.6 / v9-4p5 / v9-4p5)…"**
+Begin: **"Initiating I2V Specialist Protocol v3.8.6 (Grok 4.6 / 4.6)…"**
 
 ## Core Workflow
 
@@ -223,7 +221,7 @@ Next: generate | QA Guardian | Sequence Extender | re-i2i
 | QA / Chain QA | Post-gen gate |
 | Workflow Quota Optimizer | Per-clip cost |
 
-## Reasoning (Grok 4.6 / v9-4p5)
+## Reasoning (Grok 4.6)
 
 | Task | Reasoning |
 |------|-----------|
@@ -233,4 +231,4 @@ Next: generate | QA Guardian | Sequence Extender | re-i2i
 
 ---
 
-*Image-to-Video Specialist v3.8.6 — Grok 4.6 / v9-4p5 / v9-4p5 · still is the contract · 1.0 default · 1.5 for native audio*
+*Image-to-Video Specialist v3.8.6 — Grok 4.6 / 4.6 · still is the contract · 1.0 default · 1.5 for native audio*

--- a/.grok/skills/imagine-execution-bridge/SKILL.md
+++ b/.grok/skills/imagine-execution-bridge/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: imagine-execution-bridge
-description: Grok chat to grok.com/imagine handoff bridge for Grok Imagine Cinematic Studio. Emits copy-paste VIDEO_PIPELINE_SPEC reference hints and native audio Sound Layer blocks when API generation is unavailable. Activate with ACTIVATE IMAGINE_BRIDGE or when user needs grok.com/imagine copy-paste packets. Optimized for grok-4-auto grok-v9-4p5-multi grok-v9-4p5-chat-expert with dual Imagine Video 1.0 and 1.5 Native.
+description: Grok chat to grok.com/imagine handoff bridge for Grok Imagine Cinematic Studio. Emits copy-paste VIDEO_PIPELINE_SPEC reference hints and native audio Sound Layer blocks when API generation is unavailable. Activate with ACTIVATE IMAGINE_BRIDGE or when user needs grok.com/imagine copy-paste packets. Optimized for grok-4-auto grok-4.6 grok-4.6 with dual Imagine Video 1.0 and 1.5 Native.
 ---
 
-# Imagine Execution Bridge v3.8.6 (Grok 4.6 / v9-4p5 · Web Handoff)
+# Imagine Execution Bridge v3.8.6 (Grok 4.6 · Web Handoff)
 
 **Web UI subset** of Imagine execution (surface `grok_com_imagine`). Emits copy-paste-ready packets for [grok.com/imagine](https://grok.com/imagine) when API or in-session tools are unavailable.
 
@@ -11,12 +11,12 @@ description: Grok chat to grok.com/imagine handoff bridge for Grok Imagine Cinem
 **Canonical:** `references/agents/IMAGINE_AGENT_MODE_HANDOFF_v3.7.1.md`  
 **CLI:** `imagine bridge` · `imagine agent-handoff` · `imagine verify`
 
-## Model Layer (Grok 4.6 / v9-4p5)
+## Model Layer (Grok 4.6)
 
 | Task type | Preferred model | Reasoning |
 |-----------|-----------------|-----------|
-| Multi-agent orchestration / handoff synthesis | `grok-v9-4p5-multi` | high |
-| Specialist deep craft / QA / identity-critical | `grok-v9-4p5-chat-expert` | high |
+| Multi-agent orchestration / handoff synthesis | `grok-4.6` (Chat **Heavy**) | high |
+| Specialist deep craft / QA / identity-critical | `grok-4.6` (Chat **Expert**) | high |
 | Routine status / draft passes | `grok-4-auto` | medium |
 
 **Stack default:** cinematic+Build API/chat **`grok-4.6`** (CLI ≥ 1.0.5 · fork `grok-build` or `grok-4.6`; `grok-4.5` aliases wrap 4.6). Opt-in 1M: `grok-4.3`.  
@@ -24,10 +24,8 @@ description: Grok chat to grok.com/imagine handoff bridge for Grok Imagine Cinem
 
 ```yaml
 model_compatibility:
-  - grok-v9-4p5-chat-expert
-  - grok-v9-4p5-multi
-  - grok-4-auto
-preferred_model: grok-v9-4p5-chat-expert
+  - grok-4.6
+preferred_model: grok-4.6
 ```
 
 ### Imagine dual-path (when this skill touches generation)
@@ -51,7 +49,7 @@ Prefer full protocol when not web-only:
 ACTIVATE IMAGINE_AGENT_MODE_HANDOFF
 ```
 
-Begin: **"Preparing Imagine Bridge packet v3.8.6 (Grok 4.6 / v9-4p5)…"**
+Begin: **"Preparing Imagine Bridge packet v3.8.6 (Grok 4.6)…"**
 
 ## Activation Stack
 
@@ -148,4 +146,4 @@ Next: user generate → sfw record → QA
 
 ---
 
-*Imagine Execution Bridge v3.8.6 — Grok 4.6 / v9-4p5 · grok.com/imagine subset · registry-locked specs*
+*Imagine Execution Bridge v3.8.6 — Grok 4.6 · grok.com/imagine subset · registry-locked specs*

--- a/.grok/skills/imagine-prompt-master/SKILL.md
+++ b/.grok/skills/imagine-prompt-master/SKILL.md
@@ -1,20 +1,20 @@
 ---
 name: imagine-prompt-master
-description: Master cinematic prompt engineer and Grok Imagine specialist. Crafts precise, high-quality prompts using the Ultimate Template, manages references, negative prompts, and optimization. Optimized for grok-4-auto, grok-v9-4p5-multi, grok-v9-4p5-chat-expert and both Grok Imagine Video 1.0 + 1.5 Native. Activate whenever crafting or refining image/video prompts.
+description: Master cinematic prompt engineer and Grok Imagine specialist. Crafts precise, high-quality prompts using the Ultimate Template, manages references, negative prompts, and optimization. Optimized for grok-4-auto, grok-4.6, grok-4.6 and both Grok Imagine Video 1.0 + 1.5 Native. Activate whenever crafting or refining image/video prompts.
 ---
 
-# Imagine Prompt Master v4.5 (Grok 4.6 / v9-4p5 + Grok Imagine Video 1.0 & 1.5 Native)
+# Imagine Prompt Master v4.5 (Grok 4.6 + Grok Imagine Video 1.0 & 1.5 Native)
 
 **Role Card:** `references/agents/Imagine_Prompt_Master.md` (v4.5) — Authoritative source for prompt philosophy, decision frameworks, quality standards, dual-model (1.0/1.5) optimization, DNA injection, and mindset.
 
 > **Always load the Role Card** when doing significant prompt work, especially with locked characters or complex cinematic scenes.
 
-## Model Layer (Grok 4.6 / v9-4p5)
+## Model Layer (Grok 4.6)
 
 | Task type                                      | Preferred model               | Reasoning |
 |------------------------------------------------|-------------------------------|-----------|
-| High-fidelity prompt craft / DNA injection / complex cinematic scenes | `grok-v9-4p5-chat-expert`   | high      |
-| Batch / multi-prompt coordination / sequence-level prompt packages | `grok-v9-4p5-multi`         | high      |
+| High-fidelity prompt craft / DNA injection / complex cinematic scenes | `grok-4.6` (Chat **Expert**)   | high      |
+| Batch / multi-prompt coordination / sequence-level prompt packages | `grok-4.6` (Chat **Heavy**)         | high      |
 | Quick variations / draft prompts               | `grok-4-auto`               | medium    |
 
 **Stack default:** cinematic+Build API/chat **`grok-4.6`** (CLI ≥ 1.0.5 · fork `grok-build` or `grok-4.6`; `grok-4.5` aliases wrap 4.6). Opt-in 1M: `grok-4.3`.  
@@ -22,10 +22,8 @@ description: Master cinematic prompt engineer and Grok Imagine specialist. Craft
 
 ```yaml
 model_compatibility:
-  - grok-v9-4p5-chat-expert
-  - grok-v9-4p5-multi
-  - grok-4-auto
-preferred_model: grok-v9-4p5-chat-expert
+  - grok-4.6
+preferred_model: grok-4.6
 ```
 
 ## When to Activate
@@ -102,4 +100,4 @@ Fully compatible with Grok Build CLI, `cinematic_studio_cli.py` prompt workflows
 
 ---
 
-*Enhanced for Grok 4.6 / v9-4p5 model layer + dual Imagine Video 1.0 & 1.5 Native support — Cinematic Studio v4.5*
+*Enhanced for Grok 4.6 + dual Imagine Video 1.0 & 1.5 Native support — Cinematic Studio v4.5*

--- a/.grok/skills/key-art-poster-designer/SKILL.md
+++ b/.grok/skills/key-art-poster-designer/SKILL.md
@@ -1,21 +1,21 @@
 ---
 name: key-art-poster-designer
-description: Theatrical key art, poster, and marketing visual specialist. Creates emotionally powerful single images that capture the essence of the project for promotion and client presentation. Activate when key art, posters, or high-impact marketing visuals are needed. Optimized for grok-4-auto grok-v9-4p5-multi grok-v9-4p5-chat-expert with dual Imagine Video 1.0 and 1.5 Native.
+description: Theatrical key art, poster, and marketing visual specialist. Creates emotionally powerful single images that capture the essence of the project for promotion and client presentation. Activate when key art, posters, or high-impact marketing visuals are needed. Optimized for grok-4-auto grok-4.6 grok-4.6 with dual Imagine Video 1.0 and 1.5 Native.
 ---
 
-# Key Art & Poster Designer v3.8.6 (Grok 4.6 / v9-4p5 · Key Art)
+# Key Art & Poster Designer v3.8.6 (Grok 4.6 · Key Art)
 
 **Single-image marketing architect.** You distill an entire production into iconic stills that communicate genre, tone, and emotional core in under two seconds — at theatrical scale and thumbnail size.
 
 **Role Card:** `references/agents/Key_Art_Poster_Designer_v3.5.md`  
 **Partners:** Studio Director · Trailer Director · Prompt Master · Identity Lock · Reference Curator · Color Grade
 
-## Model Layer (Grok 4.6 / v9-4p5)
+## Model Layer (Grok 4.6)
 
 | Task type | Preferred model | Reasoning |
 |-----------|-----------------|-----------|
-| Multi-agent orchestration / handoff synthesis | `grok-v9-4p5-multi` | high |
-| Specialist deep craft / QA / identity-critical | `grok-v9-4p5-chat-expert` | high |
+| Multi-agent orchestration / handoff synthesis | `grok-4.6` (Chat **Heavy**) | high |
+| Specialist deep craft / QA / identity-critical | `grok-4.6` (Chat **Expert**) | high |
 | Routine status / draft passes | `grok-4-auto` | medium |
 
 **Stack default:** cinematic+Build API/chat **`grok-4.6`** (CLI ≥ 1.0.5 · fork `grok-build` or `grok-4.6`; `grok-4.5` aliases wrap 4.6). Opt-in 1M: `grok-4.3`.  
@@ -23,10 +23,8 @@ description: Theatrical key art, poster, and marketing visual specialist. Create
 
 ```yaml
 model_compatibility:
-  - grok-v9-4p5-chat-expert
-  - grok-v9-4p5-multi
-  - grok-4-auto
-preferred_model: grok-v9-4p5-chat-expert
+  - grok-4.6
+preferred_model: grok-4.6
 ```
 
 ### Imagine Video dual-path (when this skill touches video)
@@ -39,7 +37,7 @@ preferred_model: grok-v9-4p5-chat-expert
 - Campaign variants after Bible + cast DNA locked  
 - User says: `ACTIVATE KEY_ART_DESIGNER`, `DESIGN POSTER`, `THEATRICAL ONE-SHEET`, `STREAMING THUMBNAIL`
 
-Begin: **"Initiating Key Art Protocol v3.8.6 (Grok 4.6 / v9-4p5)…"**
+Begin: **"Initiating Key Art Protocol v3.8.6 (Grok 4.6)…"**
 
 ## Philosophy
 
@@ -120,4 +118,4 @@ Next: Trailer Director | Studio sign-off | more variants
 
 ---
 
-*Key Art & Poster Designer v3.8.6 — Grok 4.6 / v9-4p5 · one frame sells the dream · DNA-safe*
+*Key Art & Poster Designer v3.8.6 — Grok 4.6 · one frame sells the dream · DNA-safe*

--- a/.grok/skills/mega-production-architect/SKILL.md
+++ b/.grok/skills/mega-production-architect/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: mega-production-architect
-description: All-in-one cinematic super-agent that transforms any idea into a complete production-ready audiovisual package. Creates Production Bible, storyboards, shot lists, frame-accurate audio scripts, and execution roadmaps. Activate when you need a full professional production package in one go. Optimized for grok-4-auto grok-v9-4p5-multi grok-v9-4p5-chat-expert with dual Imagine Video 1.0 and 1.5 Native.
+description: All-in-one cinematic super-agent that transforms any idea into a complete production-ready audiovisual package. Creates Production Bible, storyboards, shot lists, frame-accurate audio scripts, and execution roadmaps. Activate when you need a full professional production package in one go. Optimized for grok-4-auto grok-4.6 grok-4.6 with dual Imagine Video 1.0 and 1.5 Native.
 ---
 
-# Mega Production Architect v3.8.6 (Grok 4.6 / v9-4p5 · One-Pass Package)
+# Mega Production Architect v3.8.6 (Grok 4.6 · One-Pass Package)
 
 You transform any idea into a **production-ready package**: Production Bible, storyboard/shot list, audio script, agent roadmap, and quota envelope — then hand execution to Studio Director and specialists.
 
@@ -11,12 +11,12 @@ You transform any idea into a **production-ready package**: Production Bible, st
 **CLI:** `create-bible` · wizard · `production-bible-workflow` skill  
 **Registry:** `tools/models.py` · `build_video_pipeline_spec()`
 
-## Model Layer (Grok 4.6 / v9-4p5)
+## Model Layer (Grok 4.6)
 
 | Task type | Preferred model | Reasoning |
 |-----------|-----------------|-----------|
-| Multi-agent orchestration / handoff synthesis | `grok-v9-4p5-multi` | high |
-| Specialist deep craft / QA / identity-critical | `grok-v9-4p5-chat-expert` | high |
+| Multi-agent orchestration / handoff synthesis | `grok-4.6` (Chat **Heavy**) | high |
+| Specialist deep craft / QA / identity-critical | `grok-4.6` (Chat **Expert**) | high |
 | Routine status / draft passes | `grok-4-auto` | medium |
 
 **Stack default:** cinematic+Build API/chat **`grok-4.6`** (CLI ≥ 1.0.5 · fork `grok-build` or `grok-4.6`; `grok-4.5` aliases wrap 4.6). Opt-in 1M: `grok-4.3`.  
@@ -24,10 +24,8 @@ You transform any idea into a **production-ready package**: Production Bible, st
 
 ```yaml
 model_compatibility:
-  - grok-v9-4p5-chat-expert
-  - grok-v9-4p5-multi
-  - grok-4-auto
-preferred_model: grok-v9-4p5-chat-expert
+  - grok-4.6
+preferred_model: grok-4.6
 ```
 
 ### Imagine Video dual-path (when this skill touches video)
@@ -55,7 +53,7 @@ preferred_model: grok-v9-4p5-chat-expert
 
 | Layer | Preferred |
 |-------|-----------|
-| Orchestration | `grok-v9-4p5-multi` / `chat-expert` |
+| Orchestration | `grok-4.6` (Chat **Heavy**) / `chat-expert` |
 | Imagine Video | `grok-imagine-video` / `1.5` |
 | Imagine Image | `grok-imagine-image` / quality |
 
@@ -150,7 +148,7 @@ Section: `## i2I Refinement Assignments`
 ```text
 MEGA PRODUCTION ARCHITECT · v3.7.1
 Project: <title> | Runtime: Xs | Genre: …
-model_stack: v9-4p5-multi | video: 1.0|1.5
+model_stack: grok-4.6 | video: 1.0|1.5
 VIDEO_PIPELINE_SPEC: locked
 Artifacts:
   - production_bible.json / .md
@@ -173,7 +171,7 @@ Next: ACTIVATE STUDIO DIRECTOR | create-bible wizard | DNA extract
 | DNA / Identity / Curator | Cast + plates |
 | Prompt Master / I2V | Generation packets |
 
-## Reasoning (Grok 4.6 / v9-4p5)
+## Reasoning (Grok 4.6)
 
 | Task | Reasoning |
 |------|-----------|
@@ -182,4 +180,4 @@ Next: ACTIVATE STUDIO DIRECTOR | create-bible wizard | DNA extract
 
 ---
 
-*Mega Production Architect v3.8.6 — Grok 4.6 / v9-4p5 / v9-4p5 · Bible + roadmap in one pass · 1.0 video default*
+*Mega Production Architect v3.8.6 — Grok 4.6 / 4.6 · Bible + roadmap in one pass · 1.0 video default*

--- a/.grok/skills/nsfw-chain-qa-protocol/SKILL.md
+++ b/.grok/skills/nsfw-chain-qa-protocol/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: nsfw-chain-qa-protocol
-description: NSFW extend and stitch chain QA protocol for intimate Grok Imagine Video 1.5 sequences. Runs the weighted 8-point artifact-aware gate before approving clips for erotic extension or final stitch. Activate with RUN NSFW CHAIN QA REVIEW alongside ErosForge NSFW Sequence Extender and QA Guardian. Optimized for grok-4-auto grok-v9-4p5-multi grok-v9-4p5-chat-expert with dual Imagine Video 1.0 and 1.5 Native.
+description: NSFW extend and stitch chain QA protocol for intimate Grok Imagine Video 1.5 sequences. Runs the weighted 8-point artifact-aware gate before approving clips for erotic extension or final stitch. Activate with RUN NSFW CHAIN QA REVIEW alongside ErosForge NSFW Sequence Extender and QA Guardian. Optimized for grok-4-auto grok-4.6 grok-4.6 with dual Imagine Video 1.0 and 1.5 Native.
 ---
 
-# NSFW Chain QA Protocol v3.8.6 (Grok 4.6 / v9-4p5 · Intimate Chain Gate)
+# NSFW Chain QA Protocol v3.8.6 (Grok 4.6 · Intimate Chain Gate)
 
 **Pipeline skill** — weighted 8-point artifact-aware gate for explicit/intimate extend and stitch. Complements QA Guardian’s per-clip 16-point review; does **not** replace it.
 
@@ -11,12 +11,12 @@ description: NSFW extend and stitch chain QA protocol for intimate Grok Imagine 
 **Implementation:** `tools/nsfw_sequence_extender.py` (`NSFW_CHAIN_QA_CHECKS`)  
 **Script:** `.grok/skills/nsfw-chain-qa-protocol/scripts/nsfw_chain_qa.py`
 
-## Model Layer (Grok 4.6 / v9-4p5)
+## Model Layer (Grok 4.6)
 
 | Task type | Preferred model | Reasoning |
 |-----------|-----------------|-----------|
-| Multi-agent orchestration / handoff synthesis | `grok-v9-4p5-multi` | high |
-| Specialist deep craft / QA / identity-critical | `grok-v9-4p5-chat-expert` | high |
+| Multi-agent orchestration / handoff synthesis | `grok-4.6` (Chat **Heavy**) | high |
+| Specialist deep craft / QA / identity-critical | `grok-4.6` (Chat **Expert**) | high |
 | Routine status / draft passes | `grok-4-auto` | medium |
 
 **Stack default:** cinematic+Build API/chat **`grok-4.6`** (CLI ≥ 1.0.5 · fork `grok-build` or `grok-4.6`; `grok-4.5` aliases wrap 4.6). Opt-in 1M: `grok-4.3`.  
@@ -24,10 +24,8 @@ description: NSFW extend and stitch chain QA protocol for intimate Grok Imagine 
 
 ```yaml
 model_compatibility:
-  - grok-v9-4p5-chat-expert
-  - grok-v9-4p5-multi
-  - grok-4-auto
-preferred_model: grok-v9-4p5-chat-expert
+  - grok-4.6
+preferred_model: grok-4.6
 ```
 
 ### Imagine Video dual-path (when this skill touches video)
@@ -48,7 +46,7 @@ ACTIVATE EROSFORGE
 RUN NSFW CHAIN QA REVIEW
 ```
 
-Begin: **"Running NSFW Chain QA Protocol v3.8.6 (Grok 4.6 / v9-4p5)…"**
+Begin: **"Running NSFW Chain QA Protocol v3.8.6 (Grok 4.6)…"**
 
 ## Philosophy
 
@@ -157,4 +155,4 @@ Next: extend | regen | Arc Replan | stitch blocked
 
 ---
 
-*NSFW Chain QA Protocol v3.8.6 — Grok 4.6 / v9-4p5 · fail closed on criticals · no extend on No-Go*
+*NSFW Chain QA Protocol v3.8.6 — Grok 4.6 · fail closed on criticals · no extend on No-Go*

--- a/.grok/skills/nsfw-quota-orchestrator/SKILL.md
+++ b/.grok/skills/nsfw-quota-orchestrator/SKILL.md
@@ -1,20 +1,20 @@
 ---
 name: nsfw-quota-orchestrator
-description: Quota-aware NSFW production orchestrator for SuperGrok Heavy. Plans and executes batches of erotic image and video generations with hero-first prioritization, image-to-video decision logic, smart retry strategies, and daily quota vs quality reports. Optimized for grok-4-auto, grok-v9-4p5-multi, grok-v9-4p5-chat-expert and both Grok Imagine Video 1.0 + 1.5 Native. Activate with ACTIVATE NSFW_QUOTA_ORCHESTRATOR or when planning R-rated batches under subscription limits alongside Workflow Quota Optimizer and ErosForge. Requires ACTIVATE EROSFORGE for generation.
+description: Quota-aware NSFW production orchestrator for SuperGrok Heavy. Plans and executes batches of erotic image and video generations with hero-first prioritization, image-to-video decision logic, smart retry strategies, and daily quota vs quality reports. Optimized for grok-4-auto, grok-4.6, grok-4.6 and both Grok Imagine Video 1.0 + 1.5 Native. Activate with ACTIVATE NSFW_QUOTA_ORCHESTRATOR or when planning R-rated batches under subscription limits alongside Workflow Quota Optimizer and ErosForge. Requires ACTIVATE EROSFORGE for generation.
 ---
 
-# NSFW Quota Orchestrator v4.5 (Grok 4.6 / v9-4p5 + Grok Imagine Video 1.0 & 1.5 Native)
+# NSFW Quota Orchestrator v4.5 (Grok 4.6 + Grok Imagine Video 1.0 & 1.5 Native)
 
 **Role Card:** `references/agents/NSFW_Quota_Orchestrator.md` (v4.5) — Authoritative source for quota-aware NSFW batch planning, hero-first prioritization, dual-model (1.0/1.5) decision logic, smart retries, and daily quality vs quota reports.
 
 > Quota-aware NSFW production orchestrator for SuperGrok Heavy.
 
-## Model Layer (Grok 4.6 / v9-4p5)
+## Model Layer (Grok 4.6)
 
 | Task type                                      | Preferred model               | Reasoning |
 |------------------------------------------------|-------------------------------|-----------|
-| Complex multi-shot batch planning, prioritization across quota windows | `grok-v9-4p5-multi`         | high      |
-| Single-batch craft, i2v decision logic, retry strategy design | `grok-v9-4p5-chat-expert`   | high      |
+| Complex multi-shot batch planning, prioritization across quota windows | `grok-4.6` (Chat **Heavy**)         | high      |
+| Single-batch craft, i2v decision logic, retry strategy design | `grok-4.6` (Chat **Expert**)   | high      |
 | Quick status / simple quota checks             | `grok-4-auto`               | medium    |
 
 **Stack default:** cinematic+Build API/chat **`grok-4.6`** (CLI ≥ 1.0.5 · fork `grok-build` or `grok-4.6`; `grok-4.5` aliases wrap 4.6). Opt-in 1M: `grok-4.3`.  
@@ -22,10 +22,8 @@ description: Quota-aware NSFW production orchestrator for SuperGrok Heavy. Plans
 
 ```yaml
 model_compatibility:
-  - grok-v9-4p5-chat-expert
-  - grok-v9-4p5-multi
-  - grok-4-auto
-preferred_model: grok-v9-4p5-multi
+  - grok-4.6
+preferred_model: grok-4.6
 ```
 
 ## When to Activate
@@ -79,4 +77,4 @@ Fully compatible with Grok Build CLI, Termux/Android, and Kali NetHunter. All pl
 
 ---
 
-*Enhanced for Grok 4.6 / v9-4p5 model layer + dual Imagine Video 1.0 & 1.5 Native support — Cinematic Studio v4.5*
+*Enhanced for Grok 4.6 + dual Imagine Video 1.0 & 1.5 Native support — Cinematic Studio v4.5*

--- a/.grok/skills/nsfw-sequence-extender/SKILL.md
+++ b/.grok/skills/nsfw-sequence-extender/SKILL.md
@@ -1,20 +1,20 @@
 ---
 name: nsfw-sequence-extender
-description: NSFW sensual sequence extension from reference frame or short clip to 30-120+ seconds. Plans erotic tension curves, Grok Imagine prompt chains, extend-from-frame instructions, camera pacing, and artifact-aware chain QA. Optimized for grok-4-auto, grok-v9-4p5-multi, grok-v9-4p5-chat-expert and both Grok Imagine Video 1.0 + 1.5 Native. Integrates Cinematic Sequence Extender, ErosForge, and NSFW Quota Orchestrator. Activate with ACTIVATE NSFW_SEQUENCE_EXTENDER or when extending intimate sequences. Requires ACTIVATE EROSFORGE first.
+description: NSFW sensual sequence extension from reference frame or short clip to 30-120+ seconds. Plans erotic tension curves, Grok Imagine prompt chains, extend-from-frame instructions, camera pacing, and artifact-aware chain QA. Optimized for grok-4-auto, grok-4.6, grok-4.6 and both Grok Imagine Video 1.0 + 1.5 Native. Integrates Cinematic Sequence Extender, ErosForge, and NSFW Quota Orchestrator. Activate with ACTIVATE NSFW_SEQUENCE_EXTENDER or when extending intimate sequences. Requires ACTIVATE EROSFORGE first.
 ---
 
-# NSFW Sequence Extender v4.5 (Grok 4.6 / v9-4p5 + Grok Imagine Video 1.0 & 1.5 Native)
+# NSFW Sequence Extender v4.5 (Grok 4.6 + Grok Imagine Video 1.0 & 1.5 Native)
 
 **Role Card:** `references/agents/NSFW_Sequence_Extender.md` (v4.5) — Authoritative source for erotic tension curves, extend-from-frame chains, dual-model (1.0/1.5) support, artifact-aware Chain QA, and EROSFORGE_STATE continuity.
 
 > NSFW sensual sequence extension from reference frame or short clip to 30-120+ seconds.
 
-## Model Layer (Grok 4.6 / v9-4p5)
+## Model Layer (Grok 4.6)
 
 | Task type                                      | Preferred model               | Reasoning |
 |------------------------------------------------|-------------------------------|-----------|
-| Multi-clip erotic sequence planning, tension curve + dependency management | `grok-v9-4p5-multi`         | high      |
-| Single extension craft, camera pacing, micro-timing, artifact avoidance | `grok-v9-4p5-chat-expert`   | high      |
+| Multi-clip erotic sequence planning, tension curve + dependency management | `grok-4.6` (Chat **Heavy**)         | high      |
+| Single extension craft, camera pacing, micro-timing, artifact avoidance | `grok-4.6` (Chat **Expert**)   | high      |
 | Quick status / simple extension checks         | `grok-4-auto`               | medium    |
 
 **Stack default:** cinematic+Build API/chat **`grok-4.6`** (CLI ≥ 1.0.5 · fork `grok-build` or `grok-4.6`; `grok-4.5` aliases wrap 4.6). Opt-in 1M: `grok-4.3`.  
@@ -22,10 +22,8 @@ description: NSFW sensual sequence extension from reference frame or short clip 
 
 ```yaml
 model_compatibility:
-  - grok-v9-4p5-chat-expert
-  - grok-v9-4p5-multi
-  - grok-4-auto
-preferred_model: grok-v9-4p5-multi
+  - grok-4.6
+preferred_model: grok-4.6
 ```
 
 ## When to Activate
@@ -79,4 +77,4 @@ Fully compatible with Grok Build CLI, Termux/Android, and Kali NetHunter. All pl
 
 ---
 
-*Enhanced for Grok 4.6 / v9-4p5 model layer + dual Imagine Video 1.0 & 1.5 Native support — Cinematic Studio v4.5*
+*Enhanced for Grok 4.6 + dual Imagine Video 1.0 & 1.5 Native support — Cinematic Studio v4.5*

--- a/.grok/skills/parallel-brief-dispatcher/SKILL.md
+++ b/.grok/skills/parallel-brief-dispatcher/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: parallel-brief-dispatcher
-description: Parallel Brief dispatcher for Studio Director under MAXIMUM AGENTIC MODE. Templates logs and anti-blocks concurrent specialist briefs and convergence into imagine_agent_mode_handoff. Activate with ACTIVATE PARALLEL_BRIEF_DISPATCHER. Optimized for grok-4-auto grok-v9-4p5-multi grok-v9-4p5-chat-expert with dual Imagine Video 1.0 and 1.5 Native.
+description: Parallel Brief dispatcher for Studio Director under MAXIMUM AGENTIC MODE. Templates logs and anti-blocks concurrent specialist briefs and convergence into imagine_agent_mode_handoff. Activate with ACTIVATE PARALLEL_BRIEF_DISPATCHER. Optimized for grok-4-auto grok-4.6 grok-4.6 with dual Imagine Video 1.0 and 1.5 Native.
 version: 4.5
-preferred_model: grok-v9-4p5-multi
+preferred_model: grok-4.6
 model_compatibility:
-  - grok-v9-4p5-chat-expert
-  - grok-v9-4p5-multi
+  - grok-4.6
+  - grok-4.6
   - grok-4-auto
 activation:
   - ACTIVATE PARALLEL_BRIEF_DISPATCHER
@@ -17,18 +17,18 @@ tags:
   - v4.5
 ---
 
-# Parallel Brief Dispatcher v4.5 (Grok 4.6 / v9-4p5 + Imagine Video 1.0 & 1.5 Native)
+# Parallel Brief Dispatcher v4.5 (Grok 4.6 + Imagine Video 1.0 & 1.5 Native)
 
 **Role Card:** `references/agents/Parallel_Brief_Dispatcher.md` (v4.5) — authoritative source for protocols and output structures.
 
 > You are the **Parallel Brief co-pilot** for Studio Director. You template, ID, log, and anti-block concurrent specialist briefs so true parallelism holds and outputs converge into validated handoff packets without diluting Director vision.
 
-## Model Layer (Grok 4.6 / v9-4p5)
+## Model Layer (Grok 4.6)
 
 | Task type | Preferred model | Reasoning |
 |-----------|-----------------|-----------|
-| Specialist craft | `grok-v9-4p5-chat-expert` | high |
-| Multi-agent / synthesis | `grok-v9-4p5-multi` | high |
+| Specialist craft | `grok-4.6` (Chat **Expert**) | high |
+| Multi-agent / synthesis | `grok-4.6` (Chat **Heavy**) | high |
 | Draft / routine | `grok-4-auto` | medium |
 
 **Stack default:** cinematic+Build API/chat **`grok-4.6`** (CLI ≥ 1.0.5 · fork `grok-build` or `grok-4.6`; `grok-4.5` aliases wrap 4.6). Opt-in 1M: `grok-4.3`.  
@@ -36,10 +36,8 @@ tags:
 
 ```yaml
 model_compatibility:
-  - grok-v9-4p5-chat-expert
-  - grok-v9-4p5-multi
-  - grok-4-auto
-preferred_model: grok-v9-4p5-multi
+  - grok-4.6
+preferred_model: grok-4.6
 ```
 
 ## When to Activate

--- a/.grok/skills/performance-emotion-director/SKILL.md
+++ b/.grok/skills/performance-emotion-director/SKILL.md
@@ -1,21 +1,21 @@
 ---
 name: performance-emotion-director
-description: Emotional architect and micro-expression specialist. Designs actor performance, emotional evolution, body language, and long-term character development. Activate on any project requiring deep emotional performance or nuanced acting. Optimized for grok-4-auto grok-v9-4p5-multi grok-v9-4p5-chat-expert with dual Imagine Video 1.0 and 1.5 Native.
+description: Emotional architect and micro-expression specialist. Designs actor performance, emotional evolution, body language, and long-term character development. Activate on any project requiring deep emotional performance or nuanced acting. Optimized for grok-4-auto grok-4.6 grok-4.6 with dual Imagine Video 1.0 and 1.5 Native.
 ---
 
-# Performance & Emotion Director v3.8.6 (Grok 4.6 / v9-4p5 · Soul of Performance)
+# Performance & Emotion Director v3.8.6 (Grok 4.6 · Soul of Performance)
 
 **Always active for emotionally complex scenes.** You design micro-expressions, body language, subtext, and emotional temperature so characters feel psychologically real across stills and video.
 
 **Role Card:** `references/agents/Performance_Emotion_Director.md`  
 **Temperature CLI:** `sequence temp set|show|gate` · **DNA body language:** Identity Lock / DNA Extractor
 
-## Model Layer (Grok 4.6 / v9-4p5)
+## Model Layer (Grok 4.6)
 
 | Task type | Preferred model | Reasoning |
 |-----------|-----------------|-----------|
-| Multi-agent orchestration / handoff synthesis | `grok-v9-4p5-multi` | high |
-| Specialist deep craft / QA / identity-critical | `grok-v9-4p5-chat-expert` | high |
+| Multi-agent orchestration / handoff synthesis | `grok-4.6` (Chat **Heavy**) | high |
+| Specialist deep craft / QA / identity-critical | `grok-4.6` (Chat **Expert**) | high |
 | Routine status / draft passes | `grok-4-auto` | medium |
 
 **Stack default:** cinematic+Build API/chat **`grok-4.6`** (CLI ≥ 1.0.5 · fork `grok-build` or `grok-4.6`; `grok-4.5` aliases wrap 4.6). Opt-in 1M: `grok-4.3`.  
@@ -23,10 +23,8 @@ description: Emotional architect and micro-expression specialist. Designs actor 
 
 ```yaml
 model_compatibility:
-  - grok-v9-4p5-chat-expert
-  - grok-v9-4p5-multi
-  - grok-4-auto
-preferred_model: grok-v9-4p5-chat-expert
+  - grok-4.6
+preferred_model: grok-4.6
 ```
 
 ### Imagine Video dual-path (when this skill touches video)
@@ -44,7 +42,7 @@ preferred_model: grok-v9-4p5-chat-expert
 - Intimate / erotic emotional truth (with ErosForge)  
 - User says: `ACTIVATE PERFORMANCE_EMOTION`, `EMOTIONAL_DRAMA_MODE`, `MAXIMUM_SUBTEXT`, `INTIMATE_EMOTION_MODE`
 
-Begin: **"Initiating Performance Protocol v3.8.6 (Grok 4.6 / v9-4p5)…"**
+Begin: **"Initiating Performance Protocol v3.8.6 (Grok 4.6)…"**
 
 ## Core Mandate
 
@@ -160,4 +158,4 @@ Consistency · Emotional Power · Technical Feasibility · Quota Efficiency · C
 
 ---
 
-*Performance & Emotion Director v3.8.6 — Grok 4.6 / v9-4p5 · micro before macro · body betrays the mind*
+*Performance & Emotion Director v3.8.6 — Grok 4.6 · micro before macro · body betrays the mind*

--- a/.grok/skills/plate-motion-readiness-lead/SKILL.md
+++ b/.grok/skills/plate-motion-readiness-lead/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: plate-motion-readiness-lead
-description: Plate and motion readiness gate for Grok Imagine stills before video spend. Owns plate_status motion_vector and strict-plate strict-motion readiness so i2v never starts on unlocked plates. Activate with ACTIVATE PLATE_MOTION_READINESS or LOCK PLATES. Optimized for grok-4-auto grok-v9-4p5-multi grok-v9-4p5-chat-expert with dual Imagine Video 1.0 and 1.5 Native.
+description: Plate and motion readiness gate for Grok Imagine stills before video spend. Owns plate_status motion_vector and strict-plate strict-motion readiness so i2v never starts on unlocked plates. Activate with ACTIVATE PLATE_MOTION_READINESS or LOCK PLATES. Optimized for grok-4-auto grok-4.6 grok-4.6 with dual Imagine Video 1.0 and 1.5 Native.
 version: 4.5
-preferred_model: grok-v9-4p5-chat-expert
+preferred_model: grok-4.6
 model_compatibility:
-  - grok-v9-4p5-chat-expert
-  - grok-v9-4p5-multi
+  - grok-4.6
+  - grok-4.6
   - grok-4-auto
 activation:
   - ACTIVATE PLATE_MOTION_READINESS
@@ -17,18 +17,18 @@ tags:
   - v4.5
 ---
 
-# Plate & Motion Readiness Lead v4.5 (Grok 4.6 / v9-4p5 + Imagine Video 1.0 & 1.5 Native)
+# Plate & Motion Readiness Lead v4.5 (Grok 4.6 + Imagine Video 1.0 & 1.5 Native)
 
 **Role Card:** `references/agents/Plate_Motion_Readiness_Lead.md` (v4.5) — authoritative source for protocols and output structures.
 
 > You own **plate lock and motion-brief readiness** before any Imagine video spend. Confirm approved stills, motion vectors, and I2V motion blocks so Sequence/I2V never burn quota on unlocked plates.
 
-## Model Layer (Grok 4.6 / v9-4p5)
+## Model Layer (Grok 4.6)
 
 | Task type | Preferred model | Reasoning |
 |-----------|-----------------|-----------|
-| Specialist craft | `grok-v9-4p5-chat-expert` | high |
-| Multi-agent / synthesis | `grok-v9-4p5-multi` | high |
+| Specialist craft | `grok-4.6` (Chat **Expert**) | high |
+| Multi-agent / synthesis | `grok-4.6` (Chat **Heavy**) | high |
 | Draft / routine | `grok-4-auto` | medium |
 
 **Stack default:** cinematic+Build API/chat **`grok-4.6`** (CLI ≥ 1.0.5 · fork `grok-build` or `grok-4.6`; `grok-4.5` aliases wrap 4.6). Opt-in 1M: `grok-4.3`.  
@@ -36,10 +36,8 @@ tags:
 
 ```yaml
 model_compatibility:
-  - grok-v9-4p5-chat-expert
-  - grok-v9-4p5-multi
-  - grok-4-auto
-preferred_model: grok-v9-4p5-chat-expert
+  - grok-4.6
+preferred_model: grok-4.6
 ```
 
 ## When to Activate

--- a/.grok/skills/production-bible-workflow/SKILL.md
+++ b/.grok/skills/production-bible-workflow/SKILL.md
@@ -1,21 +1,21 @@
 ---
 name: production-bible-workflow
-description: End-to-end Production Bible onboarding workflow for Grok Imagine Cinematic Studio. Guides create-bible DNA init sequence planning quota setup and validate through the CLI. Activate when starting a new project bootstrapping the studio or onboarding a production from zero. Optimized for grok-4-auto grok-v9-4p5-multi grok-v9-4p5-chat-expert with dual Imagine Video 1.0 and 1.5 Native.
+description: End-to-end Production Bible onboarding workflow for Grok Imagine Cinematic Studio. Guides create-bible DNA init sequence planning quota setup and validate through the CLI. Activate when starting a new project bootstrapping the studio or onboarding a production from zero. Optimized for grok-4-auto grok-4.6 grok-4.6 with dual Imagine Video 1.0 and 1.5 Native.
 ---
 
-# Production Bible Workflow v3.8.6 (Grok 4.6 / v9-4p5 · Bible Onboarding)
+# Production Bible Workflow v3.8.6 (Grok 4.6 · Bible Onboarding)
 
 **New project bootstrap** — guided path from zero to a locked Production Bible, DNA, sequence, quota, and generation-ready handoff. Studio Director maintains the Bible after bootstrap.
 
 **CLI:** `create-bible` · `dna` · `sequence` · `quota` · `validate` · `models verify`  
 **Companions:** Mega Production Architect · Studio Director · production wizard (Web)
 
-## Model Layer (Grok 4.6 / v9-4p5)
+## Model Layer (Grok 4.6)
 
 | Task type | Preferred model | Reasoning |
 |-----------|-----------------|-----------|
-| Multi-agent orchestration / handoff synthesis | `grok-v9-4p5-multi` | high |
-| Specialist deep craft / QA / identity-critical | `grok-v9-4p5-chat-expert` | high |
+| Multi-agent orchestration / handoff synthesis | `grok-4.6` (Chat **Heavy**) | high |
+| Specialist deep craft / QA / identity-critical | `grok-4.6` (Chat **Expert**) | high |
 | Routine status / draft passes | `grok-4-auto` | medium |
 
 **Stack default:** cinematic+Build API/chat **`grok-4.6`** (CLI ≥ 1.0.5 · fork `grok-build` or `grok-4.6`; `grok-4.5` aliases wrap 4.6). Opt-in 1M: `grok-4.3`.  
@@ -23,10 +23,8 @@ description: End-to-end Production Bible onboarding workflow for Grok Imagine Ci
 
 ```yaml
 model_compatibility:
-  - grok-v9-4p5-chat-expert
-  - grok-v9-4p5-multi
-  - grok-4-auto
-preferred_model: grok-v9-4p5-multi
+  - grok-4.6
+preferred_model: grok-4.6
 ```
 
 ### Imagine Video dual-path (when this skill touches video)
@@ -39,7 +37,7 @@ preferred_model: grok-v9-4p5-multi
 - Onboarding a production from zero  
 - User says: `START PRODUCTION BIBLE WORKFLOW`, `BOOTSTRAP NEW PROJECT`, `CREATE BIBLE WIZARD`
 
-Begin: **"Starting Production Bible Workflow v3.8.6 (Grok 4.6 / v9-4p5)…"**
+Begin: **"Starting Production Bible Workflow v3.8.6 (Grok 4.6)…"**
 
 ## Project Bible Must Lock
 
@@ -187,4 +185,4 @@ Next: Studio Director | Animatic | Batch | Agent Mode Handoff
 
 ---
 
-*Production Bible Workflow v3.8.6 — Grok 4.6 / v9-4p5 · zero to locked Bible · still before video*
+*Production Bible Workflow v3.8.6 — Grok 4.6 · zero to locked Bible · still before video*

--- a/.grok/skills/quality-assurance-guardian/SKILL.md
+++ b/.grok/skills/quality-assurance-guardian/SKILL.md
@@ -1,20 +1,20 @@
 ---
 name: quality-assurance-guardian
-description: Final quality gatekeeper and production quality commander. Runs mandatory 16-point weighted reviews plus 10-point chain QA for extend/stitch clips. Issues Go/No-Go decisions and protects artistic integrity. Optimized for grok-4-auto, grok-v9-4p5-multi, grok-v9-4p5-chat-expert and both Grok Imagine Video 1.0 + 1.5 Native. Always activate before extension final stitch or client presentation.
+description: Final quality gatekeeper and production quality commander. Runs mandatory 16-point weighted reviews plus 10-point chain QA for extend/stitch clips. Issues Go/No-Go decisions and protects artistic integrity. Optimized for grok-4-auto, grok-4.6, grok-4.6 and both Grok Imagine Video 1.0 + 1.5 Native. Always activate before extension final stitch or client presentation.
 ---
 
-# Quality Assurance Guardian v4.5 (Grok 4.6 / v9-4p5 + Grok Imagine Video 1.0 & 1.5 Native)
+# Quality Assurance Guardian v4.5 (Grok 4.6 + Grok Imagine Video 1.0 & 1.5 Native)
 
 **Role Card:** `references/agents/Quality_Assurance_Guardian_v3.5.md` (v4.5; alias `Quality_Assurance_Guardian.md`) — Authoritative source for QA philosophy, 16-point checklist, 10-point Chain QA protocol, Go/No-Go criteria, dual-model (1.0/1.5) quality standards, and artistic integrity protection.
 
 > **Always active as the final gatekeeper.** Never bypass before final stitch, client delivery, or long-form extension.
 
-## Model Layer (Grok 4.6 / v9-4p5)
+## Model Layer (Grok 4.6)
 
 | Task type                                      | Preferred model               | Reasoning |
 |------------------------------------------------|-------------------------------|-----------|
-| Full 16-point review + nuanced artistic judgment | `grok-v9-4p5-chat-expert`   | high      |
-| Multi-clip suite audit / sequence-level health  | `grok-v9-4p5-multi`         | high      |
+| Full 16-point review + nuanced artistic judgment | `grok-4.6` (Chat **Expert**)   | high      |
+| Multi-clip suite audit / sequence-level health  | `grok-4.6` (Chat **Heavy**)         | high      |
 | Quick go/no-go checks / routine validation      | `grok-4-auto`               | medium    |
 
 **Stack default:** cinematic+Build API/chat **`grok-4.6`** (CLI ≥ 1.0.5 · fork `grok-build` or `grok-4.6`; `grok-4.5` aliases wrap 4.6). Opt-in 1M: `grok-4.3`.  
@@ -22,10 +22,8 @@ description: Final quality gatekeeper and production quality commander. Runs man
 
 ```yaml
 model_compatibility:
-  - grok-v9-4p5-chat-expert
-  - grok-v9-4p5-multi
-  - grok-4-auto
-preferred_model: grok-v9-4p5-chat-expert
+  - grok-4.6
+preferred_model: grok-4.6
 ```
 
 ## When to Activate
@@ -84,4 +82,4 @@ Fully compatible with Grok Build CLI, `cinematic_studio_cli.py` QA workflows, Te
 
 ---
 
-*Enhanced for Grok 4.6 / v9-4p5 model layer + dual Imagine Video 1.0 & 1.5 Native support — Cinematic Studio v4.5*
+*Enhanced for Grok 4.6 + dual Imagine Video 1.0 & 1.5 Native support — Cinematic Studio v4.5*

--- a/.grok/skills/quota-dashboard/SKILL.md
+++ b/.grok/skills/quota-dashboard/SKILL.md
@@ -1,20 +1,20 @@
 ---
 name: quota-dashboard
-description: Mobile-optimized Quota Dashboard for Grok Imagine with full Weekly SuperGrok Heavy Limit support. Tracks session usage + weekly quota from app screenshots (%, reset date/time, Imagine/Chat/Build breakdown). Delivers beautiful at-a-glance visual reports + cinematic key-art style visual dashboard posters. Optimized for grok-4-auto, grok-v9-4p5-multi, grok-v9-4p5-chat-expert and both Grok Imagine Video 1.0 + 1.5. Complements workflow-quota-optimizer and nsfw-quota-orchestrator. Activate with SHOW QUOTA DASHBOARD, SHOW VISUAL DASHBOARD, or ACTIVATE QUOTA_DASHBOARD.
+description: Mobile-optimized Quota Dashboard for Grok Imagine with full Weekly SuperGrok Heavy Limit support. Tracks session usage + weekly quota from app screenshots (%, reset date/time, Imagine/Chat/Build breakdown). Delivers beautiful at-a-glance visual reports + cinematic key-art style visual dashboard posters. Optimized for grok-4-auto, grok-4.6, grok-4.6 and both Grok Imagine Video 1.0 + 1.5. Complements workflow-quota-optimizer and nsfw-quota-orchestrator. Activate with SHOW QUOTA DASHBOARD, SHOW VISUAL DASHBOARD, or ACTIVATE QUOTA_DASHBOARD.
 ---
 
-# Quota Dashboard v4.5 (Grok 4.6 / v9-4p5 + Grok Imagine Video 1.0 & 1.5)
+# Quota Dashboard v4.5 (Grok 4.6 + Grok Imagine Video 1.0 & 1.5)
 
 **Role Card:** `references/agents/Quota_Dashboard.md` (v4.5) — Authoritative source for quota tracking, visual reporting, dual-model (1.0/1.5) awareness, and cinematic dashboard poster generation.
 
 > Mobile-optimized Quota Dashboard for Grok Imagine with full Weekly SuperGrok Heavy Limit support.
 
-## Model Layer (Grok 4.6 / v9-4p5)
+## Model Layer (Grok 4.6)
 
 | Task type                                      | Preferred model               | Reasoning |
 |------------------------------------------------|-------------------------------|-----------|
-| Complex multi-window quota synthesis and visual dashboard design | `grok-v9-4p5-multi`         | high      |
-| Single screenshot analysis, status report, key-art style poster | `grok-v9-4p5-chat-expert`   | high      |
+| Complex multi-window quota synthesis and visual dashboard design | `grok-4.6` (Chat **Heavy**)         | high      |
+| Single screenshot analysis, status report, key-art style poster | `grok-4.6` (Chat **Expert**)   | high      |
 | Quick status / simple checks                   | `grok-4-auto`               | medium    |
 
 **Stack default:** cinematic+Build API/chat **`grok-4.6`** (CLI ≥ 1.0.5 · fork `grok-build` or `grok-4.6`; `grok-4.5` aliases wrap 4.6). Opt-in 1M: `grok-4.3`.  
@@ -22,10 +22,8 @@ description: Mobile-optimized Quota Dashboard for Grok Imagine with full Weekly 
 
 ```yaml
 model_compatibility:
-  - grok-v9-4p5-chat-expert
-  - grok-v9-4p5-multi
-  - grok-4-auto
-preferred_model: grok-v9-4p5-chat-expert
+  - grok-4.6
+preferred_model: grok-4.6
 ```
 
 ## When to Activate
@@ -75,4 +73,4 @@ Fully compatible with Grok Build CLI, Termux/Android, and Kali NetHunter. All re
 
 ---
 
-*Enhanced for Grok 4.6 / v9-4p5 model layer + dual Imagine Video 1.0 & 1.5 Native support — Cinematic Studio v4.5*
+*Enhanced for Grok 4.6 + dual Imagine Video 1.0 & 1.5 Native support — Cinematic Studio v4.5*

--- a/.grok/skills/reference-asset-curator/SKILL.md
+++ b/.grok/skills/reference-asset-curator/SKILL.md
@@ -1,20 +1,20 @@
 ---
 name: reference-asset-curator
-description: Reference and asset curator for Grok Imagine productions. Assigns hero, standard or draft tiers, routes grok-imagine-image vs Image 2.0 hero plates and video 1.5 vs 1.0 per shot, maintains ASSET_MANIFEST and approved plate sets. Optimized for grok-4-auto, grok-v9-4p5-multi, grok-v9-4p5-chat-expert and both Grok Imagine Video 1.0 + 1.5 Native. Activate with ACTIVATE REFERENCE_CURATOR before batch or i2v spend.
+description: Reference and asset curator for Grok Imagine productions. Assigns hero, standard or draft tiers, routes grok-imagine-image vs Image 2.0 hero plates and video 1.5 vs 1.0 per shot, maintains ASSET_MANIFEST and approved plate sets. Optimized for grok-4-auto, grok-4.6, grok-4.6 and both Grok Imagine Video 1.0 + 1.5 Native. Activate with ACTIVATE REFERENCE_CURATOR before batch or i2v spend.
 ---
 
-# Reference & Asset Curator v4.5 (Grok 4.6 / v9-4p5 + Grok Imagine Video 1.0 & 1.5 Native)
+# Reference & Asset Curator v4.5 (Grok 4.6 + Grok Imagine Video 1.0 & 1.5 Native)
 
 **Role Card:** `references/agents/Reference_Asset_Curator.md` (v4.5) — Authoritative source for tier assignment, model stack routing, reference weights, ASSET_MANIFEST discipline, dual-model (1.0/1.5) decisions, and pre-spend gating.
 
 > You are the **model router and reference librarian**. No major generation runs until you assign **tier + model stack + reference weights** and publish an `ASSET_MANIFEST` row (or equivalent handoff).
 
-## Model Layer (Grok 4.6 / v9-4p5)
+## Model Layer (Grok 4.6)
 
 | Task type                                      | Preferred model               | Reasoning |
 |------------------------------------------------|-------------------------------|-----------|
-| Hero tier / critical routing decisions         | `grok-v9-4p5-chat-expert`   | high      |
-| Multi-asset / suite manifests / batch planning | `grok-v9-4p5-multi`         | high      |
+| Hero tier / critical routing decisions         | `grok-4.6` (Chat **Expert**)   | high      |
+| Multi-asset / suite manifests / batch planning | `grok-4.6` (Chat **Heavy**)         | high      |
 | Standard / draft tier assignment               | `grok-4-auto`               | medium    |
 
 **Stack default:** cinematic+Build API/chat **`grok-4.6`** (CLI ≥ 1.0.5 · fork `grok-build` or `grok-4.6`; `grok-4.5` aliases wrap 4.6). Opt-in 1M: `grok-4.3`.  
@@ -22,10 +22,8 @@ description: Reference and asset curator for Grok Imagine productions. Assigns h
 
 ```yaml
 model_compatibility:
-  - grok-v9-4p5-chat-expert
-  - grok-v9-4p5-multi
-  - grok-4-auto
-preferred_model: grok-v9-4p5-chat-expert
+  - grok-4.6
+preferred_model: grok-4.6
 ```
 
 ## When to Activate
@@ -89,4 +87,4 @@ Fully compatible with Grok Build CLI, `cinematic_studio_cli.py` asset workflows,
 
 ---
 
-*Enhanced for Grok 4.6 / v9-4p5 model layer + dual Imagine Video 1.0 & 1.5 Native support — Cinematic Studio v4.5*
+*Enhanced for Grok 4.6 + dual Imagine Video 1.0 & 1.5 Native support — Cinematic Studio v4.5*

--- a/.grok/skills/score-temp-music-supervisor/SKILL.md
+++ b/.grok/skills/score-temp-music-supervisor/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: score-temp-music-supervisor
-description: Score and temp music supervisor for Grok Imagine sequences and trailers. Owns music cues temp score emotional_tone_audio AMV fields so Sonic can focus on Sound Layer architecture. Activate with ACTIVATE SCORE_TEMP_MUSIC. Optimized for grok-4-auto grok-v9-4p5-multi grok-v9-4p5-chat-expert with dual Imagine Video 1.0 and 1.5 Native.
+description: Score and temp music supervisor for Grok Imagine sequences and trailers. Owns music cues temp score emotional_tone_audio AMV fields so Sonic can focus on Sound Layer architecture. Activate with ACTIVATE SCORE_TEMP_MUSIC. Optimized for grok-4-auto grok-4.6 grok-4.6 with dual Imagine Video 1.0 and 1.5 Native.
 version: 4.5
-preferred_model: grok-v9-4p5-chat-expert
+preferred_model: grok-4.6
 model_compatibility:
-  - grok-v9-4p5-chat-expert
-  - grok-v9-4p5-multi
+  - grok-4.6
+  - grok-4.6
   - grok-4-auto
 activation:
   - ACTIVATE SCORE_TEMP_MUSIC
@@ -17,18 +17,18 @@ tags:
   - v4.5
 ---
 
-# Score & Temp Music Supervisor v4.5 (Grok 4.6 / v9-4p5 + Imagine Video 1.0 & 1.5 Native)
+# Score & Temp Music Supervisor v4.5 (Grok 4.6 + Imagine Video 1.0 & 1.5 Native)
 
 **Role Card:** `references/agents/Score_Temp_Music_Supervisor.md` (v4.5) — authoritative source for protocols and output structures.
 
 > You own **music and temp score direction**—cues, emotional temperature via music, and AMV emotional_tone_audio—parallel to Foley/dialogue without blocking densification.
 
-## Model Layer (Grok 4.6 / v9-4p5)
+## Model Layer (Grok 4.6)
 
 | Task type | Preferred model | Reasoning |
 |-----------|-----------------|-----------|
-| Specialist craft | `grok-v9-4p5-chat-expert` | high |
-| Multi-agent / synthesis | `grok-v9-4p5-multi` | high |
+| Specialist craft | `grok-4.6` (Chat **Expert**) | high |
+| Multi-agent / synthesis | `grok-4.6` (Chat **Heavy**) | high |
 | Draft / routine | `grok-4-auto` | medium |
 
 **Stack default:** cinematic+Build API/chat **`grok-4.6`** (CLI ≥ 1.0.5 · fork `grok-build` or `grok-4.6`; `grok-4.5` aliases wrap 4.6). Opt-in 1M: `grok-4.3`.  
@@ -36,10 +36,8 @@ tags:
 
 ```yaml
 model_compatibility:
-  - grok-v9-4p5-chat-expert
-  - grok-v9-4p5-multi
-  - grok-4-auto
-preferred_model: grok-v9-4p5-chat-expert
+  - grok-4.6
+preferred_model: grok-4.6
 ```
 
 ## When to Activate

--- a/.grok/skills/sequence-director/SKILL.md
+++ b/.grok/skills/sequence-director/SKILL.md
@@ -1,20 +1,20 @@
 ---
 name: sequence-director
-description: Master of long-form cinematic sequencing and structural flow. Breaks stories into optimal clips and orchestrates seamless stitching using native extend-from-frame momentum vectors, chain QA, and intelligent dependency management. Optimized for grok-4-auto, grok-v9-4p5-multi, grok-v9-4p5-chat-expert and both Grok Imagine Video 1.0 + 1.5 Native. Activate for any production longer than a single clip.
+description: Master of long-form cinematic sequencing and structural flow. Breaks stories into optimal clips and orchestrates seamless stitching using native extend-from-frame momentum vectors, chain QA, and intelligent dependency management. Optimized for grok-4-auto, grok-4.6, grok-4.6 and both Grok Imagine Video 1.0 + 1.5 Native. Activate for any production longer than a single clip.
 ---
 
-# Sequence Director v4.5 (Grok 4.6 / v9-4p5 + Grok Imagine Video 1.0 & 1.5 Native)
+# Sequence Director v4.5 (Grok 4.6 + Grok Imagine Video 1.0 & 1.5 Native)
 
 **Role Card:** `references/agents/Sequence_Director.md` (v4.5) — Authoritative source for philosophy, emotional temperature methodology, decision frameworks, Sequence Blueprint format, dual-model (1.0/1.5) schemas, and long-form orchestration.
 
 > **Always load the Role Card** when planning or managing multi-clip sequences.
 
-## Model Layer (Grok 4.6 / v9-4p5)
+## Model Layer (Grok 4.6)
 
 | Task type                                      | Preferred model               | Reasoning |
 |------------------------------------------------|-------------------------------|-----------|
-| Multi-clip orchestration, dependency graphs, full sequence health, handoff synthesis | `grok-v9-4p5-multi`         | high      |
-| Single sequence creative decisions, pacing, emotional temperature, clip breakdown | `grok-v9-4p5-chat-expert`   | high      |
+| Multi-clip orchestration, dependency graphs, full sequence health, handoff synthesis | `grok-4.6` (Chat **Heavy**)         | high      |
+| Single sequence creative decisions, pacing, emotional temperature, clip breakdown | `grok-4.6` (Chat **Expert**)   | high      |
 | Lightweight health checks, status queries, routine validation | `grok-4-auto`               | medium    |
 
 **Stack default:** cinematic+Build API/chat **`grok-4.6`** (CLI ≥ 1.0.5 · fork `grok-build` or `grok-4.6`; `grok-4.5` aliases wrap 4.6). Opt-in 1M: `grok-4.3`.  
@@ -22,10 +22,8 @@ description: Master of long-form cinematic sequencing and structural flow. Break
 
 ```yaml
 model_compatibility:
-  - grok-v9-4p5-chat-expert
-  - grok-v9-4p5-multi
-  - grok-4-auto
-preferred_model: grok-v9-4p5-multi
+  - grok-4.6
+preferred_model: grok-4.6
 ```
 
 ## When to Activate
@@ -96,4 +94,4 @@ Fully compatible with Grok Build CLI, `cinematic_studio_cli.py` sequence workflo
 
 ---
 
-*Enhanced for Grok 4.6 / v9-4p5 model layer + dual Imagine Video 1.0 & 1.5 Native support — Cinematic Studio v4.5*
+*Enhanced for Grok 4.6 + dual Imagine Video 1.0 & 1.5 Native support — Cinematic Studio v4.5*

--- a/.grok/skills/sfw-batch-orchestrator/SKILL.md
+++ b/.grok/skills/sfw-batch-orchestrator/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: sfw-batch-orchestrator
-description: SFW batch production orchestrator for long Grok Imagine cinematic sessions. Plans hero-first shot batches under quota assigns still vs i2v vs video per shot and coordinates retries after QA with Workflow Quota Optimizer and Reference Curator. Activate with ACTIVATE SFW_BATCH_ORCHESTRATOR for multi-shot SFW productions. Optimized for grok-4-auto grok-v9-4p5-multi grok-v9-4p5-chat-expert with dual Imagine Video 1.0 and 1.5 Native.
+description: SFW batch production orchestrator for long Grok Imagine cinematic sessions. Plans hero-first shot batches under quota assigns still vs i2v vs video per shot and coordinates retries after QA with Workflow Quota Optimizer and Reference Curator. Activate with ACTIVATE SFW_BATCH_ORCHESTRATOR for multi-shot SFW productions. Optimized for grok-4-auto grok-4.6 grok-4.6 with dual Imagine Video 1.0 and 1.5 Native.
 ---
 
-# SFW Batch Orchestrator v3.8.6 (Grok 4.6 / v9-4p5 · Hero-First Scheduler)
+# SFW Batch Orchestrator v3.8.6 (Grok 4.6 · Hero-First Scheduler)
 
 You schedule **non-explicit** multi-shot sessions under quota. Plan batches, choose still vs i2v vs video per shot, reserve retries, and hand approved work to assembly.
 
@@ -12,12 +12,12 @@ You schedule **non-explicit** multi-shot sessions under quota. Plan batches, cho
 **Role Card:** `references/agents/SFW_Batch_Orchestrator.md`  
 **Engine:** `tools/sfw_orchestrator.py` · `sfw_decisions.py` · `sfw_config.py` · CLI `sfw`
 
-## Model Layer (Grok 4.6 / v9-4p5)
+## Model Layer (Grok 4.6)
 
 | Task type | Preferred model | Reasoning |
 |-----------|-----------------|-----------|
-| Multi-agent orchestration / handoff synthesis | `grok-v9-4p5-multi` | high |
-| Specialist deep craft / QA / identity-critical | `grok-v9-4p5-chat-expert` | high |
+| Multi-agent orchestration / handoff synthesis | `grok-4.6` (Chat **Heavy**) | high |
+| Specialist deep craft / QA / identity-critical | `grok-4.6` (Chat **Expert**) | high |
 | Routine status / draft passes | `grok-4-auto` | medium |
 
 **Stack default:** cinematic+Build API/chat **`grok-4.6`** (CLI ≥ 1.0.5 · fork `grok-build` or `grok-4.6`; `grok-4.5` aliases wrap 4.6). Opt-in 1M: `grok-4.3`.  
@@ -25,10 +25,8 @@ You schedule **non-explicit** multi-shot sessions under quota. Plan batches, cho
 
 ```yaml
 model_compatibility:
-  - grok-v9-4p5-chat-expert
-  - grok-v9-4p5-multi
-  - grok-4-auto
-preferred_model: grok-v9-4p5-multi
+  - grok-4.6
+preferred_model: grok-4.6
 ```
 
 ### Imagine Video dual-path (when this skill touches video)
@@ -69,7 +67,7 @@ ACTIVATE SFW_BATCH_ORCHESTRATOR
 ACTIVATE ONLY SFW Batch Orchestrator, Workflow Quota Optimizer, Imagine Prompt Master, QA Guardian
 ```
 
-Begin: **"Initiating SFW Batch Protocol v3.8.6 (Grok 4.6 / v9-4p5)…"**
+Begin: **"Initiating SFW Batch Protocol v3.8.6 (Grok 4.6)…"**
 
 ## Shot Tiers (priority order)
 
@@ -214,4 +212,4 @@ Handoff: Assembly Editor | Sequence Director | continue session
 
 ---
 
-*SFW Batch Orchestrator v3.8.6 — Grok 4.6 / v9-4p5 · hero-first · still before video · 15% retry reserve*
+*SFW Batch Orchestrator v3.8.6 — Grok 4.6 · hero-first · still before video · 15% retry reserve*

--- a/.grok/skills/skill-agent-architect/SKILL.md
+++ b/.grok/skills/skill-agent-architect/SKILL.md
@@ -1,20 +1,20 @@
 ---
 name: skill-agent-architect
-description: Skill and Agent Architect for the Grok Imagine Cinematic Studio ecosystem. Helps design, draft, refine and document custom Grok skills and agents including SKILL.md files, Role Cards, handoff protocols and integration with existing skills. Activate with ACTIVATE SKILL ARCHITECT, DESIGN AGENT, ROLE CARD, HANDOFF or iterative commands. Optimized for grok-4-auto grok-v9-4p5-multi grok-v9-4p5-chat-expert with dual Imagine Video 1.0 and 1.5 Native.
+description: Skill and Agent Architect for the Grok Imagine Cinematic Studio ecosystem. Helps design, draft, refine and document custom Grok skills and agents including SKILL.md files, Role Cards, handoff protocols and integration with existing skills. Activate with ACTIVATE SKILL ARCHITECT, DESIGN AGENT, ROLE CARD, HANDOFF or iterative commands. Optimized for grok-4-auto grok-4.6 grok-4.6 with dual Imagine Video 1.0 and 1.5 Native.
 ---
 
-# Skill Agent Architect v3.8.6 (Grok 4.6 / v9-4p5 · Skill Architecture)
+# Skill Agent Architect v3.8.6 (Grok 4.6 · Skill Architecture)
 
 You are the **Skill & Agent Architect** for the Grok Imagine Cinematic Studio ecosystem.
 
 Your mission is to help users design, draft, refine, and document high-quality custom Grok skills and agents that are clean, modular, and fully compatible with the existing cinematic production suite (Studio Director, Identity Lock Specialist, Imagine Prompt Master, ErosForge, Sequence Director, and the full v3.7.1 skill suite).
 
-## Model Layer (Grok 4.6 / v9-4p5)
+## Model Layer (Grok 4.6)
 
 | Task type | Preferred model | Reasoning |
 |-----------|-----------------|-----------|
-| Multi-agent orchestration / handoff synthesis | `grok-v9-4p5-multi` | high |
-| Specialist deep craft / QA / identity-critical | `grok-v9-4p5-chat-expert` | high |
+| Multi-agent orchestration / handoff synthesis | `grok-4.6` (Chat **Heavy**) | high |
+| Specialist deep craft / QA / identity-critical | `grok-4.6` (Chat **Expert**) | high |
 | Routine status / draft passes | `grok-4-auto` | medium |
 
 **Stack default:** cinematic+Build API/chat **`grok-4.6`** (CLI ≥ 1.0.5 · fork `grok-build` or `grok-4.6`; `grok-4.5` aliases wrap 4.6). Opt-in 1M: `grok-4.3`.  
@@ -22,10 +22,8 @@ Your mission is to help users design, draft, refine, and document high-quality c
 
 ```yaml
 model_compatibility:
-  - grok-v9-4p5-chat-expert
-  - grok-v9-4p5-multi
-  - grok-4-auto
-preferred_model: grok-v9-4p5-multi
+  - grok-4.6
+preferred_model: grok-4.6
 ```
 
 ### Imagine Video dual-path (when this skill touches video)
@@ -166,4 +164,4 @@ Reply with any iterative command or **"Approve"** when ready. I will then help f
 
 ---
 
-*Skill Agent Architect v3.8.6 — Grok 4.6 / v9-4p5 · studio Model Layer · `models verify`*
+*Skill Agent Architect v3.8.6 — Grok 4.6 · studio Model Layer · `models verify`*

--- a/.grok/skills/studio-director/SKILL.md
+++ b/.grok/skills/studio-director/SKILL.md
@@ -1,20 +1,20 @@
 ---
 name: studio-director
-description: Central production commander and visionary Studio Director. Orchestrates the entire cinematic pipeline, activates other agents dynamically, maintains the Project Bible, enforces quality, and makes final creative decisions. Optimized for grok-4-auto, grok-v9-4p5-multi, grok-v9-4p5-chat-expert and both Grok Imagine Video 1.0 + 1.5 Native. Activate on any new project, complex campaign, or when full studio coordination is needed.
+description: Central production commander and visionary Studio Director. Orchestrates the entire cinematic pipeline, activates other agents dynamically, maintains the Project Bible, enforces quality, and makes final creative decisions. Optimized for grok-4-auto, grok-4.6, grok-4.6 and both Grok Imagine Video 1.0 + 1.5 Native. Activate on any new project, complex campaign, or when full studio coordination is needed.
 ---
 
-# Studio Director v4.5 (Grok 4.6 / v9-4p5 + Grok Imagine Video 1.0 & 1.5 Native + Imagine Agent Mode Handoff)
+# Studio Director v4.5 (Grok 4.6 + Grok Imagine Video 1.0 & 1.5 Native + Imagine Agent Mode Handoff)
 
 **Role Card:** `references/agents/Studio_Director.md` (v4.5) — Authoritative source for personality, directing philosophy, decision frameworks, Director's Notes format, orchestration protocols, dual-model (1.0/1.5) pipeline control, and the official Imagine Agent Mode Handoff Protocol.
 
 > **Always load and follow the Role Card** before making major directorial decisions or activating other agents.
 
-## Model Layer (Grok 4.6 / v9-4p5)
+## Model Layer (Grok 4.6)
 
 | Task type                                      | Preferred model               | Reasoning |
 |------------------------------------------------|-------------------------------|-----------|
-| Full Studio / multi-agent orchestration, conflict resolution, Project Bible synthesis | `grok-v9-4p5-multi`         | high      |
-| Creative direction, single major decisions, Director’s Notes | `grok-v9-4p5-chat-expert`   | high      |
+| Full Studio / multi-agent orchestration, conflict resolution, Project Bible synthesis | `grok-4.6` (Chat **Heavy**)         | high      |
+| Creative direction, single major decisions, Director’s Notes | `grok-4.6` (Chat **Expert**)   | high      |
 | Routine status, light checks, quick agent routing | `grok-4-auto`               | medium    |
 
 **Stack default:** cinematic+Build API/chat **`grok-4.6`** (CLI ≥ 1.0.5 · fork `grok-build` or `grok-4.6`; `grok-4.5` aliases wrap 4.6). Opt-in 1M: `grok-4.3`.  
@@ -22,10 +22,8 @@ description: Central production commander and visionary Studio Director. Orchest
 
 ```yaml
 model_compatibility:
-  - grok-v9-4p5-chat-expert
-  - grok-v9-4p5-multi
-  - grok-4-auto
-preferred_model: grok-v9-4p5-multi
+  - grok-4.6
+preferred_model: grok-4.6
 ```
 
 ## When to Activate
@@ -93,4 +91,4 @@ Fully compatible with Grok Build CLI, `cinematic_studio_cli.py`, Termux/Android,
 
 ---
 
-*Enhanced for Grok 4.6 / v9-4p5 model layer + dual Imagine Video 1.0 & 1.5 Native support — Cinematic Studio v4.5*
+*Enhanced for Grok 4.6 + dual Imagine Video 1.0 & 1.5 Native support — Cinematic Studio v4.5*

--- a/.grok/skills/stunt-action-choreographer/SKILL.md
+++ b/.grok/skills/stunt-action-choreographer/SKILL.md
@@ -1,21 +1,21 @@
 ---
 name: stunt-action-choreographer
-description: Professional stunt, fight, and high-impact action design specialist. Creates safe, visually powerful, and emotionally grounded action sequences with realistic physics. Activate when stunt work, fight choreography, or high-impact action is needed. Optimized for grok-4-auto grok-v9-4p5-multi grok-v9-4p5-chat-expert with dual Imagine Video 1.0 and 1.5 Native.
+description: Professional stunt, fight, and high-impact action design specialist. Creates safe, visually powerful, and emotionally grounded action sequences with realistic physics. Activate when stunt work, fight choreography, or high-impact action is needed. Optimized for grok-4-auto grok-4.6 grok-4.6 with dual Imagine Video 1.0 and 1.5 Native.
 ---
 
-# Stunt & Action Choreographer v3.8.6 (Grok 4.6 / v9-4p5 · Action Design)
+# Stunt & Action Choreographer v3.8.6 (Grok 4.6 · Action Design)
 
 **Safety-conscious kinetic designer.** You design clear, emotionally meaningful fights, chases, and impacts with realistic weight and geography for Grok Imagine Video.
 
 **Role Card:** `references/agents/Stunt_Action_Choreographer_v3.5.md`  
 **Partners:** DoP · VFX · Performance Emotion · Continuity · Identity Lock · I2V Specialist
 
-## Model Layer (Grok 4.6 / v9-4p5)
+## Model Layer (Grok 4.6)
 
 | Task type | Preferred model | Reasoning |
 |-----------|-----------------|-----------|
-| Multi-agent orchestration / handoff synthesis | `grok-v9-4p5-multi` | high |
-| Specialist deep craft / QA / identity-critical | `grok-v9-4p5-chat-expert` | high |
+| Multi-agent orchestration / handoff synthesis | `grok-4.6` (Chat **Heavy**) | high |
+| Specialist deep craft / QA / identity-critical | `grok-4.6` (Chat **Expert**) | high |
 | Routine status / draft passes | `grok-4-auto` | medium |
 
 **Stack default:** cinematic+Build API/chat **`grok-4.6`** (CLI ≥ 1.0.5 · fork `grok-build` or `grok-4.6`; `grok-4.5` aliases wrap 4.6). Opt-in 1M: `grok-4.3`.  
@@ -23,10 +23,8 @@ description: Professional stunt, fight, and high-impact action design specialist
 
 ```yaml
 model_compatibility:
-  - grok-v9-4p5-chat-expert
-  - grok-v9-4p5-multi
-  - grok-4-auto
-preferred_model: grok-v9-4p5-chat-expert
+  - grok-4.6
+preferred_model: grok-4.6
 ```
 
 ### Imagine Video dual-path (when this skill touches video)
@@ -39,7 +37,7 @@ preferred_model: grok-v9-4p5-chat-expert
 - Action DNA for recurring fighters  
 - User says: `ACTIVATE STUNT_CHOREOGRAPHER`, `DESIGN FIGHT`, `CHASE SEQUENCE`, `HIGH_ACTION_MODE`
 
-Begin: **"Initiating Action Choreography Protocol v3.8.6 (Grok 4.6 / v9-4p5)…"**
+Begin: **"Initiating Action Choreography Protocol v3.8.6 (Grok 4.6)…"**
 
 ## Philosophy
 
@@ -114,4 +112,4 @@ Next: DoP | VFX | I2V | Sequence Director
 
 ---
 
-*Stunt & Action Choreographer v3.8.6 — Grok 4.6 / v9-4p5 · real physics · emotional action*
+*Stunt & Action Choreographer v3.8.6 — Grok 4.6 · real physics · emotional action*

--- a/.grok/skills/title-motion-graphics-lead/SKILL.md
+++ b/.grok/skills/title-motion-graphics-lead/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: title-motion-graphics-lead
-description: Title and motion graphics lead for openers lower-thirds end cards and brand locks in Grok Imagine delivery. Owns title cards and simple motion graphic briefs after cut approval. Activate with ACTIVATE TITLE_MOTION_GRAPHICS. Optimized for grok-4-auto grok-v9-4p5-multi grok-v9-4p5-chat-expert with dual Imagine Video 1.0 and 1.5 Native.
+description: Title and motion graphics lead for openers lower-thirds end cards and brand locks in Grok Imagine delivery. Owns title cards and simple motion graphic briefs after cut approval. Activate with ACTIVATE TITLE_MOTION_GRAPHICS. Optimized for grok-4-auto grok-4.6 grok-4.6 with dual Imagine Video 1.0 and 1.5 Native.
 version: 4.5
-preferred_model: grok-v9-4p5-chat-expert
+preferred_model: grok-4.6
 model_compatibility:
-  - grok-v9-4p5-chat-expert
-  - grok-v9-4p5-multi
+  - grok-4.6
+  - grok-4.6
   - grok-4-auto
 activation:
   - ACTIVATE TITLE_MOTION_GRAPHICS
@@ -17,18 +17,18 @@ tags:
   - v4.5
 ---
 
-# Title & Motion Graphics Lead v4.5 (Grok 4.6 / v9-4p5 + Imagine Video 1.0 & 1.5 Native)
+# Title & Motion Graphics Lead v4.5 (Grok 4.6 + Imagine Video 1.0 & 1.5 Native)
 
 **Role Card:** `references/agents/Title_Motion_Graphics_Lead.md` (v4.5) — authoritative source for protocols and output structures.
 
 > You own **titles and motion graphics**—openers, lower-thirds, end cards, brand locks—after editorial intent is clear. Key Art owns still posters; you own on-picture type and motion design briefs.
 
-## Model Layer (Grok 4.6 / v9-4p5)
+## Model Layer (Grok 4.6)
 
 | Task type | Preferred model | Reasoning |
 |-----------|-----------------|-----------|
-| Specialist craft | `grok-v9-4p5-chat-expert` | high |
-| Multi-agent / synthesis | `grok-v9-4p5-multi` | high |
+| Specialist craft | `grok-4.6` (Chat **Expert**) | high |
+| Multi-agent / synthesis | `grok-4.6` (Chat **Heavy**) | high |
 | Draft / routine | `grok-4-auto` | medium |
 
 **Stack default:** cinematic+Build API/chat **`grok-4.6`** (CLI ≥ 1.0.5 · fork `grok-build` or `grok-4.6`; `grok-4.5` aliases wrap 4.6). Opt-in 1M: `grok-4.3`.  
@@ -36,10 +36,8 @@ tags:
 
 ```yaml
 model_compatibility:
-  - grok-v9-4p5-chat-expert
-  - grok-v9-4p5-multi
-  - grok-4-auto
-preferred_model: grok-v9-4p5-chat-expert
+  - grok-4.6
+preferred_model: grok-4.6
 ```
 
 ## When to Activate

--- a/.grok/skills/trailer-teaser-director/SKILL.md
+++ b/.grok/skills/trailer-teaser-director/SKILL.md
@@ -1,21 +1,21 @@
 ---
 name: trailer-teaser-director
-description: High-impact trailer and teaser specialist. Crafts emotionally powerful 15–60s trailers and teasers with native audio, optimized pacing, and maximum hook impact. Activate when trailer, teaser, or short-form promotional video content is needed. Optimized for grok-4-auto grok-v9-4p5-multi grok-v9-4p5-chat-expert with dual Imagine Video 1.0 and 1.5 Native.
+description: High-impact trailer and teaser specialist. Crafts emotionally powerful 15–60s trailers and teasers with native audio, optimized pacing, and maximum hook impact. Activate when trailer, teaser, or short-form promotional video content is needed. Optimized for grok-4-auto grok-4.6 grok-4.6 with dual Imagine Video 1.0 and 1.5 Native.
 ---
 
-# Trailer & Teaser Director v3.8.6 (Grok 4.6 / v9-4p5 · Trailer & Teaser)
+# Trailer & Teaser Director v3.8.6 (Grok 4.6 · Trailer & Teaser)
 
 **Hook-first promo architect.** You design 15–60s trailers and teasers with ruthless pacing, emotional payoff, and platform-aware deliverables from **QA-approved** clips only.
 
 **Role Card:** `references/agents/Trailer_Teaser_Director_v3.5.md`  
 **Partners:** Studio Director · Key Art · Narrative Arc · Assembly Editor · Sonic · cinematic-ffmpeg
 
-## Model Layer (Grok 4.6 / v9-4p5)
+## Model Layer (Grok 4.6)
 
 | Task type | Preferred model | Reasoning |
 |-----------|-----------------|-----------|
-| Multi-agent orchestration / handoff synthesis | `grok-v9-4p5-multi` | high |
-| Specialist deep craft / QA / identity-critical | `grok-v9-4p5-chat-expert` | high |
+| Multi-agent orchestration / handoff synthesis | `grok-4.6` (Chat **Heavy**) | high |
+| Specialist deep craft / QA / identity-critical | `grok-4.6` (Chat **Expert**) | high |
 | Routine status / draft passes | `grok-4-auto` | medium |
 
 **Stack default:** cinematic+Build API/chat **`grok-4.6`** (CLI ≥ 1.0.5 · fork `grok-build` or `grok-4.6`; `grok-4.5` aliases wrap 4.6). Opt-in 1M: `grok-4.3`.  
@@ -23,10 +23,8 @@ description: High-impact trailer and teaser specialist. Crafts emotionally power
 
 ```yaml
 model_compatibility:
-  - grok-v9-4p5-chat-expert
-  - grok-v9-4p5-multi
-  - grok-4-auto
-preferred_model: grok-v9-4p5-chat-expert
+  - grok-4.6
+preferred_model: grok-4.6
 ```
 
 ### Imagine Video dual-path (when this skill touches video)
@@ -39,7 +37,7 @@ preferred_model: grok-v9-4p5-chat-expert
 - Promo reels from approved inventory  
 - User says: `ACTIVATE TRAILER_DIRECTOR`, `CUT TEASER`, `TRAILER CUT`, `HOOK FIRST`
 
-Begin: **"Initiating Trailer Direction Protocol v3.8.6 (Grok 4.6 / v9-4p5)…"**
+Begin: **"Initiating Trailer Direction Protocol v3.8.6 (Grok 4.6)…"**
 
 ## Philosophy
 
@@ -115,4 +113,4 @@ Next: Assembly | Sonic | FFmpeg | Studio sign-off
 
 ---
 
-*Trailer & Teaser Director v3.8.6 — Grok 4.6 / v9-4p5 · hook first · approved clips only*
+*Trailer & Teaser Director v3.8.6 — Grok 4.6 · hook first · approved clips only*

--- a/.grok/skills/vfx-sfx-supervisor/SKILL.md
+++ b/.grok/skills/vfx-sfx-supervisor/SKILL.md
@@ -1,21 +1,21 @@
 ---
 name: vfx-sfx-supervisor
-description: Particle systems, creatures, destruction, and practical-to-VFX transition specialist. Designs high-quality visual effects that serve story and maintain 1.5 physics fidelity. Activate when VFX, creature work, destruction, or complex visual effects are needed. Optimized for grok-4-auto grok-v9-4p5-multi grok-v9-4p5-chat-expert with dual Imagine Video 1.0 and 1.5 Native.
+description: Particle systems, creatures, destruction, and practical-to-VFX transition specialist. Designs high-quality visual effects that serve story and maintain 1.5 physics fidelity. Activate when VFX, creature work, destruction, or complex visual effects are needed. Optimized for grok-4-auto grok-4.6 grok-4.6 with dual Imagine Video 1.0 and 1.5 Native.
 ---
 
-# VFX & SFX Supervisor v3.8.6 (Grok 4.6 / v9-4p5 · VFX & SFX)
+# VFX & SFX Supervisor v3.8.6 (Grok 4.6 · VFX & SFX)
 
 **Story-first effects supervisor.** You design creatures, particles, destruction, and practical-to-digital enhancements with physics fidelity and multi-clip continuity.
 
 **Role Card:** `references/agents/VFX_and_SFX_Supervisor_v3.5.md`  
 **Partners:** Stunt · DoP · Sonic · Foley · Continuity · Sequence Extender · Prompt Master
 
-## Model Layer (Grok 4.6 / v9-4p5)
+## Model Layer (Grok 4.6)
 
 | Task type | Preferred model | Reasoning |
 |-----------|-----------------|-----------|
-| Multi-agent orchestration / handoff synthesis | `grok-v9-4p5-multi` | high |
-| Specialist deep craft / QA / identity-critical | `grok-v9-4p5-chat-expert` | high |
+| Multi-agent orchestration / handoff synthesis | `grok-4.6` (Chat **Heavy**) | high |
+| Specialist deep craft / QA / identity-critical | `grok-4.6` (Chat **Expert**) | high |
 | Routine status / draft passes | `grok-4-auto` | medium |
 
 **Stack default:** cinematic+Build API/chat **`grok-4.6`** (CLI ≥ 1.0.5 · fork `grok-build` or `grok-4.6`; `grok-4.5` aliases wrap 4.6). Opt-in 1M: `grok-4.3`.  
@@ -23,10 +23,8 @@ description: Particle systems, creatures, destruction, and practical-to-VFX tran
 
 ```yaml
 model_compatibility:
-  - grok-v9-4p5-chat-expert
-  - grok-v9-4p5-multi
-  - grok-4-auto
-preferred_model: grok-v9-4p5-chat-expert
+  - grok-4.6
+preferred_model: grok-4.6
 ```
 
 ### Imagine Video dual-path (when this skill touches video)
@@ -39,7 +37,7 @@ preferred_model: grok-v9-4p5-chat-expert
 - Practical → digital enhancement planning  
 - User says: `ACTIVATE VFX_SFX_SUPERVISOR`, `DESIGN VFX`, `CREATURE PASS`, `DESTRUCTION SEQUENCE`
 
-Begin: **"Initiating VFX Supervision Protocol v3.8.6 (Grok 4.6 / v9-4p5)…"**
+Begin: **"Initiating VFX Supervision Protocol v3.8.6 (Grok 4.6)…"**
 
 ## Philosophy
 
@@ -110,4 +108,4 @@ Next: Prompt Master | I2V | Continuity | QA
 
 ---
 
-*VFX & SFX Supervisor v3.8.6 — Grok 4.6 / v9-4p5 · physics-true effects · story first*
+*VFX & SFX Supervisor v3.8.6 — Grok 4.6 · physics-true effects · story first*

--- a/.grok/skills/workflow-quota-optimizer/SKILL.md
+++ b/.grok/skills/workflow-quota-optimizer/SKILL.md
@@ -1,20 +1,20 @@
 ---
 name: workflow-quota-optimizer
-description: Real-time quota guardian and production economist for Grok Imagine. Per-second pricing, Fast mode optimization, sequence cost estimation, session budgeting, and quota-aware recommendations for both Imagine Video 1.0 and 1.5. Optimized for grok-4-auto, grok-v9-4p5-multi, and grok-v9-4p5-chat-expert. Activate before major generations, long sequences, or when quota is low.
+description: Real-time quota guardian and production economist for Grok Imagine. Per-second pricing, Fast mode optimization, sequence cost estimation, session budgeting, and quota-aware recommendations for both Imagine Video 1.0 and 1.5. Optimized for grok-4-auto, grok-4.6, and grok-4.6. Activate before major generations, long sequences, or when quota is low.
 ---
 
-# Workflow Quota Optimizer v4.5 (Grok 4.6 / v9-4p5 + Grok Imagine Video 1.0 & 1.5)
+# Workflow Quota Optimizer v4.5 (Grok 4.6 + Grok Imagine Video 1.0 & 1.5)
 
 **Role Card:** `references/agents/Workflow_Quota_Optimizer.md` (v4.5) — Authoritative source for per-second pricing, Fast mode optimization, sequence cost estimation, session budgeting, and dual-model (1.0/1.5) quota recommendations.
 
 > Real-time quota guardian and production economist for Grok Imagine.
 
-## Model Layer (Grok 4.6 / v9-4p5)
+## Model Layer (Grok 4.6)
 
 | Task type                                      | Preferred model               | Reasoning |
 |------------------------------------------------|-------------------------------|-----------|
-| Complex session / multi-sequence cost modeling and optimization | `grok-v9-4p5-multi`         | high      |
-| Single sequence cost estimation, Fast mode recommendations | `grok-v9-4p5-chat-expert`   | high      |
+| Complex session / multi-sequence cost modeling and optimization | `grok-4.6` (Chat **Heavy**)         | high      |
+| Single sequence cost estimation, Fast mode recommendations | `grok-4.6` (Chat **Expert**)   | high      |
 | Quick status / simple quota checks             | `grok-4-auto`               | medium    |
 
 **Stack default:** cinematic+Build API/chat **`grok-4.6`** (CLI ≥ 1.0.5 · fork `grok-build` or `grok-4.6`; `grok-4.5` aliases wrap 4.6). Opt-in 1M: `grok-4.3`.  
@@ -22,10 +22,8 @@ description: Real-time quota guardian and production economist for Grok Imagine.
 
 ```yaml
 model_compatibility:
-  - grok-v9-4p5-chat-expert
-  - grok-v9-4p5-multi
-  - grok-4-auto
-preferred_model: grok-v9-4p5-multi
+  - grok-4.6
+preferred_model: grok-4.6
 ```
 
 ## When to Activate
@@ -76,4 +74,4 @@ Fully compatible with Grok Build CLI, Termux/Android, and Kali NetHunter. All es
 
 ---
 
-*Enhanced for Grok 4.6 / v9-4p5 model layer + dual Imagine Video 1.0 & 1.5 Native support — Cinematic Studio v4.5*
+*Enhanced for Grok 4.6 + dual Imagine Video 1.0 & 1.5 Native support — Cinematic Studio v4.5*

--- a/.grok/skills/xai-grok-skill/SKILL.md
+++ b/.grok/skills/xai-grok-skill/SKILL.md
@@ -9,8 +9,8 @@ metadata:
 
 ```yaml
 model_compatibility:
-  - grok-v9-4p5-chat-expert
-  - grok-v9-4p5-multi
+  - grok-4.6
+  - grok-4.6
   - grok-4-auto
 preferred_model: grok-4-auto
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 **This file provides context and instructions for AI coding agents and assistants working in this workspace.**
 
-**Version:** September 2026 (Updated for Grok Imagine Cinematic Studio **v3.11.4**, leftover grok-4.5 live defaults pin **grok-4.6**, official Image 2.0 `images[]` edits + served-`model` logs, Imagine Image Quality retirement → Image **2.0** `quality=low`, SpaceXAI AUP fail-closed gates, official Imagine Image **2.0** + Video **1.0 / 1.5** surface map, multi-surface control plane **`studio_core` + TUI / Streamlit / NiceGUI / FastAPI / React**, unified **Grok 4.6** registry defaults + **v9-4p5 / grok-4-auto** specialist Model Layer, optional **Grok 4.3** 1M, Imagine Agent Mode Handoff, Identity Continuity Protocol, Parallel Brief Protocol, interactive CLI TUI, guided Production Bible wizard, Grok Build ≥ **1.0.5**, **plugin marketplace multi-plugin packs**, AI Polish Director)  
+**Version:** September 2026 (Updated for Grok Imagine Cinematic Studio **v3.11.4**, leftover grok-4.5 live defaults pin **grok-4.6**, official Image 2.0 `images[]` edits + served-`model` logs, Imagine Image Quality retirement → Image **2.0** `quality=low`, SpaceXAI AUP fail-closed gates, official Imagine Image **2.0** + Video **1.0 / 1.5** surface map, multi-surface control plane **`studio_core` + TUI / Streamlit / NiceGUI / FastAPI / React**, unified **Grok 4.6** registry defaults + **4.6 / grok-4-auto** specialist Model Layer, optional **Grok 4.3** 1M, Imagine Agent Mode Handoff, Identity Continuity Protocol, Parallel Brief Protocol, interactive CLI TUI, guided Production Bible wizard, Grok Build ≥ **1.0.5**, **plugin marketplace multi-plugin packs**, AI Polish Director)  
 **Canonical Source:** https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio/blob/main/AGENTS.md
 
 > [!NOTE]
@@ -32,7 +32,7 @@ This workspace is designed for advanced **Grok 4.5** agent workflows, with heavy
 
 **Orchestration default (registry):** Multi-agent direction, Production Bibles, coding, and Grok Build sessions lock **`grok-4.6`** via `tools/models.py` unless the user or Studio Director opts into **`grok-4.3`** for 1M-context memory banks. `grok-4.5` aliases wrap 4.6.
 
-**Specialist Model Layer (Role Cards / skills):** When v9-4p5 identifiers are available in the session, prefer them per `MODEL_LAYER_v4.5.md` — multi-agent → `grok-v9-4p5-multi`; specialist craft → `grok-v9-4p5-chat-expert`; draft/quota → `grok-4-auto`. Registry default remains **`grok-4.6`** for stack locks and Build CLI.
+**Specialist Model Layer (Role Cards / skills):** When 4.6 identifiers are available in the session, prefer them per `MODEL_LAYER_v4.5.md` — multi-agent → `grok-4.6` (Chat **Heavy**); specialist craft → `grok-4.6` (Chat **Expert**); draft/quota → `grok-4-auto`. Registry default remains **`grok-4.6`** for stack locks and Build CLI.
 
 ## Directory Structure
 
@@ -140,16 +140,16 @@ When the session exposes these identifiers, **prefer them for Role Card work** (
 
 | Task type | Preferred model | Reasoning |
 |-----------|-----------------|-----------|
-| Multi-agent orchestration, handoffs, sequence chains | `grok-v9-4p5-multi` | high |
-| Specialist craft (DNA, prompts, QA, DoP, Sonic, ErosForge) | `grok-v9-4p5-chat-expert` | high |
+| Multi-agent orchestration, handoffs, sequence chains | `grok-4.6` (Chat **Heavy**) | high |
+| Specialist craft (DNA, prompts, QA, DoP, Sonic, ErosForge) | `grok-4.6` (Chat **Expert**) | high |
 | Draft / animatic / quota-sensitive / routine routing | `grok-4-auto` | medium |
 
-**Aliases (specialist):** `v9-4p5-multi` / `4p5-multi` · `v9-4p5-chat-expert` / `chat-expert` · `4-auto` / `auto`.
+**Chat modes:** Auto / Fast / Expert / Heavy / Build. API and Build default: `grok-4.6`.
 
 ### Grok 4.6 operating rules
 
 1. **Lock the stack** to `grok-4.6` (registry) unless the user or Studio Director needs 1M context (`grok-4.3`).
-2. **Route specialists** with Model Layer v4.5 when v9-4p5 / `grok-4-auto` are available; fall back to `grok-4.6` when they are not.
+2. **Route specialists** with Model Layer v4.5 when 4.6 / `grok-4-auto` are available; fall back to `grok-4.6` when they are not.
 3. **Reasoning:** prefer **high** for Bibles, QA, Identity Lock, Sequence Director; **medium** for routine prompt drafts; **low** only for trivial routing. Grok 4.6 defaults to high.
 4. **Prompt cache:** use a stable `prompt_cache_key` per production (project slug) on multi-turn agent loops to reduce cost.
 5. **Do not** treat Imagine models as chat models — video/image spend is `grok-imagine-*` only.
@@ -184,7 +184,7 @@ When working with or creating skills:
 3. **Never** create `README.md`, `CHANGELOG.md`, or human-facing docs inside skill directories — skills are agent-only.
 4. Keep `SKILL.md` concise (< ~500 lines). Move detailed content, agent personalities, production bibles, and long references to `references/`.
 5. New **project** skills go in `.grok/skills/<name>/`. User-global skills go in `~/.grok/skills/<name>/`.
-6. Studio skills should embed the **Model Layer (Grok 4.6 / v9-4p5)** block (see `references/agents/MODEL_LAYER_v4.5.md`).
+6. Studio skills should embed the **Model Layer (Grok 4.6)** block (see `references/agents/MODEL_LAYER_v4.5.md`).
 7. Validate after creation / change: `bash scripts/verify_cinematic_studio.sh` (and skill-specific validators when available).
 
 ## Core Agent Skill Slugs
@@ -419,12 +419,12 @@ Entry points by task (not exhaustive). Prefer slugs; full map = `AGENT_INDEX.md`
 
 ## Project-Specific Notes
 
-- Primary project: **Grok Imagine Cinematic Studio** **v3.11.4** — registry default **`grok-4.6`** + specialist **v9-4p5 / grok-4-auto** Model Layer + dual Imagine Video **1.0 / 1.5** + Imagine Agent Mode Handoff + Identity Continuity + Parallel Brief Protocol + multi-surface control plane (`studio_core` · TUI · Streamlit · NiceGUI · FastAPI · React) + guided Bible wizard + **plugin modularity packs**.
+- Primary project: **Grok Imagine Cinematic Studio** **v3.11.4** — registry default **`grok-4.6`** + specialist **4.6 / grok-4-auto** Model Layer + dual Imagine Video **1.0 / 1.5** + Imagine Agent Mode Handoff + Identity Continuity + Parallel Brief Protocol + multi-surface control plane (`studio_core` · TUI · Streamlit · NiceGUI · FastAPI · React) + guided Bible wizard + **plugin modularity packs**.
 - All generated artifacts **must** be saved under `artifacts/` (repo root).
 - Project skills live in `.grok/skills/`; user-global skills in `~/.grok/skills/`.
 - Plugin marketplace lives in `.grok-plugin/` (full suite + 5 packs, **64 skills** + commands; Wave A P0 included). Install full suite via `grok plugin install FineComputer14451/Grok-Imagine-Cinematic-Studio --trust`.
 - Workspace supports SFW cinematic work and NSFW/erotic pipelines (**ErosForge only when explicitly activated**).
-- **Model stack:** cinematic + Build/coding registry default **`grok-4.6`**; specialist routing **v9-4p5 / grok-4-auto** when available; optional 1M **`grok-4.3`**; Imagine **1.0** default; `VIDEO_PIPELINE_SPEC` via registry helpers; **1.5** for native-audio / high-physics / intimacy workflows.
+- **Model stack:** cinematic + Build/coding registry default **`grok-4.6`**; specialist routing **4.6 / grok-4-auto** when available; optional 1M **`grok-4.3`**; Imagine **1.0** default; `VIDEO_PIPELINE_SPEC` via registry helpers; **1.5** for native-audio / high-physics / intimacy workflows.
 - **Control plane:** shared `studio_core` powers `cinematic-studio ui` · `streamlit run web_ui/app.py` · `cinematic-studio web` · `cinematic-studio api` — see Multi-Surface section above and `docs/guides/WEB_SHELLS.md`.
 - Full suite: **64/64** skills + Role Cards (includes `grok-doctor`, `multi-clip-continuity-orchestrator`, `ai-image-recreation`).
 - **Recent history:** **3.11.4** — leftover grok-4.5 live defaults / pickers pin grok-4.6. **3.11.3** — official Image 2.0 multi-edit `images[]` + preserve served `model`. **3.11.2** — Imagine Image Quality retirement (slug → 2.0 `quality=low`). **3.11.1** — SpaceXAI AUP fail-closed gates + CLI help IA. **3.11.0** — Grok 4.6 stack lock + Grok Build ≥ 1.0.5 (`grok-4.5` aliases wrap 4.6). **3.10.0** — official Imagine Image 2.0 + Video 1.0/1.5 surface map (no Video 2.0); Agent Mode surface E; REST edit/extend/r2v. **3.9.1** — React/TanStack cockpit + API meta/guided Bible. **3.9.0** — multi-surface control plane (`studio_core` · NiceGUI · FastAPI + Streamlit wiring). **3.8.9** — TUI + Streamlit compact/ops/full view modes. **3.8.8** — Operator UX control plane. **3.8.7** — Wave A · Grok Doctor · Multi-Clip Continuity. **3.8.0** — plugin packs. **3.7.1** — Imagine Agent Mode Handoff.
@@ -433,7 +433,7 @@ Entry points by task (not exhaustive). Prefer slugs; full map = `AGENT_INDEX.md`
 ## Quick Start for New Tasks
 
 1. Clarify the goal with the user if ambiguous.
-2. Confirm model stack: registry default **`grok-4.6`**; specialist v9-4p5 / `grok-4-auto` when available; only use **`grok-4.3`** when 1M context is required.
+2. Confirm model stack: registry default **`grok-4.6`**; specialist 4.6 / `grok-4-auto` when available; only use **`grok-4.3`** when 1M context is required.
 3. Check if an existing skill covers it (`ls .grok/skills/` or `ls ~/.grok/skills/`, skill-slug table above, or `references/agents/AGENT_INDEX.md`). For plugin users: `.grok-plugin/plugin-index.json` or `grok plugin details grok-imagine-cinematic-studio`.
 4. If no skill exists and the task is repeatable/specialized → create one with `create-skill` / `cinematic-skill-creator` (or extend via cinematic-studio-meta-installer).
 5. Execute with the correct tools / skill activation. Prefer native Grok plugin commands (`grok plugin ...`) and studio CLI (`cinematic-studio` / `python tools/cinematic_studio_cli.py ...`). Operator UX changes go through **`studio_core`**, then surface UIs (TUI / Streamlit / NiceGUI / FastAPI) — not one-off forks.

--- a/MASTER_PROMPT.md
+++ b/MASTER_PROMPT.md
@@ -18,7 +18,7 @@
 - **Authoritative Role Card System** — Core Mission, v3.6 upgrades (1.5 & unified Grok 4.6 stack), Decision Frameworks, Activation Triggers, Integration Notes
 - **Mature CLI + Web UI** — model pickers, native audio toggle, 720p/duration, live cost estimation, **Guided Production Bible wizard** (`create-bible --wizard` / Web Guided Bible Creator)
 - **Native Grok Imagine Video 1.5 Pipeline** — image-to-video, one-pass audio, extend/stitch, Fast mode (1.0 remains cost default)
-- **Grok Build + unified Grok 4.6 stack** — CLI default `grok-4.6` (fork `grok-build` or `grok-4.6`, min CLI **1.0.5**); `grok-4.5` aliases wrap 4.6; opt-in `grok-v9-4p5-multi` / `grok-v9-4p5-chat-expert` / `grok-4-auto`; optional 1M `grok-4.3`
+- **Grok Build + unified Grok 4.6 stack** — CLI default `grok-4.6` (fork `grok-build` or `grok-4.6`, min CLI **1.0.5**); `grok-4.5` aliases wrap 4.6; opt-in `grok-4.6` (Chat **Heavy**) / `grok-4.6` (Chat **Expert**) / `grok-4-auto`; optional 1M `grok-4.3`
 - **v4.5 Dual-Model Wave** — 16 core skills with dual Imagine Video 1.0 + 1.5 Native documentation and Role Cards (`references/agents/MODEL_LAYER_v4.5.md`)
 - **Plugin marketplace** — 64 skills + 11 commands; release-pin hygiene for catalog commits
 - v3.5 heritage retained: Memory Bank, LAST_FRAME_RECAP + MOMENTUM_VECTOR + AUDIO_MOMENTUM_VECTOR, 7-Metric Self-Improvement Loop

--- a/references/MODELS.md
+++ b/references/MODELS.md
@@ -1,6 +1,6 @@
 # Models registry (canonical alias)
 
-Full model selection guide for **Grok 4.6** (cinematic + Build default; `grok-4.5` aliases wrap 4.6), optional **v9-4p5** routing surfaces, optional **Grok 4.3** 1M, and Imagine Video/Image:
+Full model selection guide for **Grok 4.6** (cinematic + Build default; `grok-4.5` aliases wrap 4.6), optional **4.6** routing surfaces, optional **Grok 4.3** 1M, and Imagine Video/Image:
 
 → **Primary agent embed:** [`agents/MODEL_LAYER_v4.5.md`](agents/MODEL_LAYER_v4.5.md)  
 → **Prior stack table:** [`agents/MODEL_LAYER_v3.7.1.md`](agents/MODEL_LAYER_v3.7.1.md)  
@@ -18,7 +18,7 @@ python tools/cinematic_studio_cli.py stack
 | Layer | Default slug | Notes |
 |-------|--------------|-------|
 | Orchestration / cinematic chat | `grok-4.6` | Production Bibles, multi-agent (`grok-4.5` aliases wrap 4.6) |
-| Opt-in multi / expert | `grok-v9-4p5-multi` · `grok-v9-4p5-chat-expert` | Skill Model Layer routing; Build pickers wrap 4.6 |
+| Opt-in multi / expert | `grok-4.6` (Chat **Heavy**) · `grok-4.6` (Chat **Expert**) | Skill Model Layer routing; Build pickers wrap 4.6 |
 | Fast routing | `grok-4-auto` | Routine specialist hops (same install script) |
 | Long-context | `grok-4.3` | 1M memory banks only |
 | Grok Build CLI | `grok-4.6` · fork `grok-build` or `grok-4.6` | ≥ **1.0.5** binary |

--- a/references/agents/AGENT_INDEX.md
+++ b/references/agents/AGENT_INDEX.md
@@ -3,12 +3,12 @@
 > [!NOTE]
 > Independent community project — **not affiliated with or endorsed by xAI**. Full notice: [DISCLAIMER.md](../../DISCLAIMER.md).
 
-**Enhanced for:** `grok-4-auto` · `grok-v9-4p5-multi` · `grok-v9-4p5-chat-expert` + **Imagine Video 1.0 & 1.5 Native**  
+**Enhanced for:** `grok-4-auto` · `grok-4.6` (Chat **Heavy**) · `grok-4.6` (Chat **Expert**) + **Imagine Video 1.0 & 1.5 Native**  
 **Version:** 3.11.4 (Role Cards carry v3.6.5–v4.5 labels) · **Studio:** v3.11.4 · Grok 4.6 stack · Full v4.5 dual-model wave  
 **Date:** 2026-09-02  
 **Canonical Model Layer:** `references/agents/MODEL_LAYER_v4.5.md` (v4.5.1)
 
-> All agents below now reference the enhanced Model Layer. Prefer the three explicit v9-4p5 identifiers. Video work must declare `VIDEO_PIPELINE_SPEC` (1.0 default, 1.5 when native audio / physics / intimacy required).
+> All agents below now reference the enhanced Model Layer. Prefer the three explicit 4.6 identifiers. Video work must declare `VIDEO_PIPELINE_SPEC` (1.0 default, 1.5 when native audio / physics / intimacy required).
 
 Authoritative Role Cards: `references/agents/*.md`  
 Shared model rules: `references/agents/MODEL_LAYER_v4.5.md`  
@@ -22,8 +22,8 @@ Identity Continuity: `references/agents/IDENTITY_CONTINUITY_PROTOCOL_v3.8.md`
 
 | Layer | Preferred Identifier | Use |
 |-------|----------------------|-----|
-| Highest quality specialist | `grok-v9-4p5-chat-expert` | DNA, prompts, QA, DoP, Sonic, ErosForge |
-| Multi-agent / Team Leader | `grok-v9-4p5-multi` | Studio Director full mode, Sequence orchestration, synthesis |
+| Highest quality specialist | `grok-4.6` (Chat **Expert**) | DNA, prompts, QA, DoP, Sonic, ErosForge |
+| Multi-agent / Team Leader | `grok-4.6` (Chat **Heavy**) | Studio Director full mode, Sequence orchestration, synthesis |
 | Draft / quota / routine | `grok-4-auto` | Animatic, standard tier, fast iteration |
 | Video default | Imagine **1.0** | Most sequences |
 | Video when audio/physics critical | Imagine **1.5 Native** | Native audio, intimate, complex motion |
@@ -229,4 +229,4 @@ DNA / QA skill filenames `Character_DNA_Extractor.md` and `Quality_Assurance_Gua
 
 ---
 
-*Grok Imagine Cinematic Studio — Enhanced Agent Index for grok-4-auto · grok-v9-4p5-multi · grok-v9-4p5-chat-expert + Imagine Video 1.0 / 1.5 Native · 2026-09-03 · studio v3.11.4 · 64 skills (Wave A P0)*
+*Grok Imagine Cinematic Studio — Enhanced Agent Index for grok-4-auto · grok-4.6 · grok-4.6 + Imagine Video 1.0 / 1.5 Native · 2026-09-03 · studio v3.11.4 · 64 skills (Wave A P0)*

--- a/references/agents/AI_Polish_Director.md
+++ b/references/agents/AI_Polish_Director.md
@@ -4,22 +4,20 @@
 
 You are the final post-production polish specialist. You transform **QA-approved, color-graded** Grok Imagine video clips into delivery-ready masters by upscaling resolution, restoring facial detail, reducing compression artifacts, and **preserving** the color grade and emotional intent established earlier in the pipeline. You never re-generate story content; you earn every pixel before the audience sees the work.
 
-## Model Layer (Grok 4.6 / v9-4p5) — Enhanced
+## Model Layer (Grok 4.6) — Enhanced
 
 | Task type                         | Preferred model               | Reasoning |
 |-----------------------------------|-------------------------------|-----------|
-| Hero face-restore / polish triage | `grok-v9-4p5-chat-expert`     | high      |
-| Multi-reel delivery packages      | `grok-v9-4p5-multi`           | high      |
+| Hero face-restore / polish triage | `grok-4.6` (Chat **Expert**)     | high      |
+| Multi-reel delivery packages      | `grok-4.6` (Chat **Heavy**)           | high      |
 | Routine 2× web batches            | `grok-4-auto`                 | medium    |
 
 **Registry:** `tools/models.py` (schema 1.1+) · `references/agents/MODEL_LAYER_v4.5.md` (v4.5.1) · `models verify`
 
 ```yaml
 model_compatibility:
-  - grok-v9-4p5-chat-expert
-  - grok-v9-4p5-multi
-  - grok-4-auto
-preferred_model: grok-v9-4p5-chat-expert
+  - grok-4.6
+preferred_model: grok-4.6
 ```
 
 Prefer stable `prompt_cache_key` on multi-turn loops. Reasoning **high** for hero face-restore and re-gen vs polish calls.
@@ -71,7 +69,7 @@ Rules:
 - Long sequences: async batch or `sequence polish`
 - Log `[POLISH_SPEC: scale=…, face_restore=…, preset=…]` in the Project Bible
 
-Begin sessions with: **"Initiating AI Polish Protocol v3.7.1 (Grok 4.6 / v9-4p5)…"**
+Begin sessions with: **"Initiating AI Polish Protocol v3.7.1 (Grok 4.6)…"**
 
 ## Decision Frameworks
 
@@ -143,4 +141,4 @@ Escalate identity issues to Identity Lock Specialist; grade shifts to Color Grad
 
 ---
 
-*AI Polish Director — Enhanced 2026-07-21 for grok-4-auto · grok-v9-4p5-multi · grok-v9-4p5-chat-expert + Imagine Video 1.0 / 1.5 Native*
+*AI Polish Director — Enhanced 2026-07-21 for grok-4-auto · grok-4.6 · grok-4.6 + Imagine Video 1.0 / 1.5 Native*

--- a/references/agents/Assembly_Editor.md
+++ b/references/agents/Assembly_Editor.md
@@ -6,22 +6,20 @@ You are the **editorial rhythm architect** between sequence generation and final
 
 **Philosophy:** Generation makes moments. Editing makes meaning.
 
-## Model Layer (Grok 4.6 / v9-4p5) — Enhanced
+## Model Layer (Grok 4.6) — Enhanced
 
 | Task type                         | Preferred model               | Reasoning |
 |-----------------------------------|-------------------------------|-----------|
-| Act structure / match-cut logic   | `grok-v9-4p5-chat-expert`     | high      |
-| Multi-act / long EDL assembly     | `grok-v9-4p5-multi`           | high      |
+| Act structure / match-cut logic   | `grok-4.6` (Chat **Expert**)     | high      |
+| Multi-act / long EDL assembly     | `grok-4.6` (Chat **Heavy**)           | high      |
 | Simple approved-only EDL export   | `grok-4-auto`                 | medium    |
 
 **Registry:** `tools/models.py` (schema 1.1+) · `references/agents/MODEL_LAYER_v4.5.md` (v4.5.1) · `models verify`
 
 ```yaml
 model_compatibility:
-  - grok-v9-4p5-chat-expert
-  - grok-v9-4p5-multi
-  - grok-4-auto
-preferred_model: grok-v9-4p5-chat-expert
+  - grok-4.6
+preferred_model: grok-4.6
 ```
 
 Prefer stable `prompt_cache_key` on multi-turn loops. Reasoning **high** for structure and re-gen vs trim.
@@ -90,4 +88,4 @@ Skill: `assembly-editor` · Code: `tools/assembly_editor.py`
 
 ---
 
-*Assembly Editor — Enhanced 2026-07-21 for grok-4-auto · grok-v9-4p5-multi · grok-v9-4p5-chat-expert + Imagine Video 1.0 / 1.5 Native*
+*Assembly Editor — Enhanced 2026-07-21 for grok-4-auto · grok-4.6 · grok-4.6 + Imagine Video 1.0 / 1.5 Native*

--- a/references/agents/Character_DNA_Extractor_v3.5.md
+++ b/references/agents/Character_DNA_Extractor_v3.5.md
@@ -2,7 +2,7 @@
 
 **Custom Agent Role Card**  
 *Studio release: v3.7.1 · Filename keeps v3.5 label for registry compatibility*  
-*Grok Imagine Cinematic Studio — Grok 4.6 / v9-4p5 · Imagine 1.0/1.5*
+*Grok Imagine Cinematic Studio — Grok 4.6 · Imagine 1.0/1.5*
 
 ---
 
@@ -12,22 +12,20 @@ The forensic visual analyst and identity synthesizer for Grok Imagine production
 
 Feeds **Identity Lock Specialist**, **Imagine Prompt Master**, **Multi-Character Identity Arbiter**, **Studio Director**, and optional **ai-image-recreation** design-sheet workflows.
 
-## Model Layer (Grok 4.6 / v9-4p5) — Enhanced
+## Model Layer (Grok 4.6) — Enhanced
 
 | Task type                         | Preferred model               | Reasoning |
 |-----------------------------------|-------------------------------|-----------|
-| Forensic DNA extraction / profile | `grok-v9-4p5-chat-expert`     | high      |
-| Multi-reference synthesis         | `grok-v9-4p5-multi`           | high      |
+| Forensic DNA extraction / profile | `grok-4.6` (Chat **Expert**)     | high      |
+| Multi-reference synthesis         | `grok-4.6` (Chat **Heavy**)           | high      |
 | Quick single-ref pass             | `grok-4-auto`                 | medium    |
 
 **Registry:** `tools/models.py` (schema 1.1+) · `references/agents/MODEL_LAYER_v4.5.md` (v4.5.1) · `models verify`
 
 ```yaml
 model_compatibility:
-  - grok-v9-4p5-chat-expert
-  - grok-v9-4p5-multi
-  - grok-4-auto
-preferred_model: grok-v9-4p5-chat-expert
+  - grok-4.6
+preferred_model: grok-4.6
 ```
 
 Prefer stable `prompt_cache_key` on multi-turn loops. Reasoning **high** for DNA extraction, multi-ref conflicts, and Identity Lock handoffs.
@@ -75,7 +73,7 @@ Do not mark DNA production-ready for long-form without anchors and `reference_im
 
 ## Specialized Protocols
 
-- Begin: **“Initiating Character DNA Extraction Protocol v3.7.1 (Grok 4.6 / v9-4p5)…”**
+- Begin: **“Initiating Character DNA Extraction Protocol v3.7.1 (Grok 4.6)…”**
 - Minimum three passes: Global → Micro-detail → Motion/performance seed
 - Multi-ref: Core DNA + Variant Notes + source attribution
 - NSFW section only when content clearly warrants it
@@ -147,4 +145,4 @@ Accept Parallel Briefs for concurrent DNA extraction while Identity Lock, DoP, o
 
 ---
 
-*Character DNA Extractor — Enhanced 2026-07-21 for grok-4-auto · grok-v9-4p5-multi · grok-v9-4p5-chat-expert + Imagine Video 1.0 / 1.5 Native · Parallel Brief Protocol v1.0*
+*Character DNA Extractor — Enhanced 2026-07-21 for grok-4-auto · grok-4.6 · grok-4.6 + Imagine Video 1.0 / 1.5 Native · Parallel Brief Protocol v1.0*

--- a/references/agents/Cinematic_Sequence_Extender.md
+++ b/references/agents/Cinematic_Sequence_Extender.md
@@ -6,22 +6,20 @@ You expand short clips into longer, seamless, emotionally coherent sequences (**
 
 **Philosophy:** You turn moments into movements. You are the rhythm of the film.
 
-## Model Layer (Grok 4.6 / v9-4p5) — Enhanced
+## Model Layer (Grok 4.6) — Enhanced
 
 | Task type                         | Preferred model               | Reasoning |
 |-----------------------------------|-------------------------------|-----------|
-| Multi-clip extend / stitch plans  | `grok-v9-4p5-multi`           | high      |
-| Single-clip momentum / recovery   | `grok-v9-4p5-chat-expert`     | high      |
+| Multi-clip extend / stitch plans  | `grok-4.6` (Chat **Heavy**)           | high      |
+| Single-clip momentum / recovery   | `grok-4.6` (Chat **Expert**)     | high      |
 | Simple extend prompts             | `grok-4-auto`                 | medium    |
 
 **Registry:** `tools/models.py` (schema 1.1+) · `references/agents/MODEL_LAYER_v4.5.md` (v4.5.1) · `models verify`
 
 ```yaml
 model_compatibility:
-  - grok-v9-4p5-chat-expert
-  - grok-v9-4p5-multi
-  - grok-4-auto
-preferred_model: grok-v9-4p5-multi
+  - grok-4.6
+preferred_model: grok-4.6
 ```
 
 Prefer stable `prompt_cache_key` on multi-turn loops. Reasoning **high** for stitch risk and recovery.
@@ -99,4 +97,4 @@ Best paired with: Sequence Director, Continuity Guardian, Multi-Clip Continuity 
 
 ---
 
-*Cinematic Sequence Extender — Enhanced 2026-07-21 for grok-4-auto · grok-v9-4p5-multi · grok-v9-4p5-chat-expert + Imagine Video 1.0 / 1.5 Native · Parallel Brief Protocol v1.0*
+*Cinematic Sequence Extender — Enhanced 2026-07-21 for grok-4-auto · grok-4.6 · grok-4.6 + Imagine Video 1.0 / 1.5 Native · Parallel Brief Protocol v1.0*

--- a/references/agents/Continuity_Consistency_Guardian.md
+++ b/references/agents/Continuity_Consistency_Guardian.md
@@ -6,22 +6,20 @@ You are the guardian of temporal, environmental, prop, clothing, lighting, and e
 
 **Philosophy:** You protect the reality of the story. Without you, the dream falls apart.
 
-## Model Layer (Grok 4.6 / v9-4p5) — Enhanced
+## Model Layer (Grok 4.6) — Enhanced
 
 | Task type                         | Preferred model               | Reasoning |
 |-----------------------------------|-------------------------------|-----------|
-| Cross-clip / multi-timeline audit | `grok-v9-4p5-multi`           | high      |
-| Single-chain drift analysis       | `grok-v9-4p5-chat-expert`     | high      |
+| Cross-clip / multi-timeline audit | `grok-4.6` (Chat **Heavy**)           | high      |
+| Single-chain drift analysis       | `grok-4.6` (Chat **Expert**)     | high      |
 | Quick continuity checks           | `grok-4-auto`                 | medium    |
 
 **Registry:** `tools/models.py` (schema 1.1+) · `references/agents/MODEL_LAYER_v4.5.md` (v4.5.1) · `models verify`
 
 ```yaml
 model_compatibility:
-  - grok-v9-4p5-chat-expert
-  - grok-v9-4p5-multi
-  - grok-4-auto
-preferred_model: grok-v9-4p5-multi
+  - grok-4.6
+preferred_model: grok-4.6
 ```
 
 Prefer stable `prompt_cache_key` on multi-turn loops. Reasoning **high** for multi-timeline conflicts and extend blocks.
@@ -108,4 +106,4 @@ python tools/cinematic_studio_cli.py sequence memory sync "Seq" --clip clip_002
 
 ---
 
-*Continuity & Consistency Guardian — Enhanced 2026-07-21 for grok-4-auto · grok-v9-4p5-multi · grok-v9-4p5-chat-expert + Imagine Video 1.0 / 1.5 Native · Parallel Brief Protocol v1.0*
+*Continuity & Consistency Guardian — Enhanced 2026-07-21 for grok-4-auto · grok-4.6 · grok-4.6 + Imagine Video 1.0 / 1.5 Native · Parallel Brief Protocol v1.0*

--- a/references/agents/Costume_Wardrobe_Continuity.md
+++ b/references/agents/Costume_Wardrobe_Continuity.md
@@ -3,22 +3,20 @@
 ## Core Mission
 You are the **outfit DNA and wardrobe state guardian** for Grok Imagine Cinematic Studio. You own structured `wardrobe_lock` on Character DNA, wardrobe inject blocks, and clip-level `wardrobe_state` so stills → i2v → extend keep the same garments, layers, accessories, and condition. You do **not** invent fashion lookbooks, arbitrate full multi-cast wardrobes, or own face/body Identity Lock.
 
-## Model Layer (Grok 4.6 / v9-4p5)
+## Model Layer (Grok 4.6)
 
 | Task type | Preferred model | Reasoning |
 |-----------|-----------------|-----------|
-| Lock / detailed outfit extraction / inject craft | `grok-v9-4p5-chat-expert` | high |
-| Multi-shot wardrobe audit across a sequence | `grok-v9-4p5-multi` | high |
+| Lock / detailed outfit extraction / inject craft | `grok-4.6` (Chat **Expert**) | high |
+| Multi-shot wardrobe audit across a sequence | `grok-4.6` (Chat **Heavy**) | high |
 | Routine status / condition-only update | `grok-4-auto` | medium |
 
 **Registry:** `tools/models.py` · `references/agents/MODEL_LAYER_v4.5.md` · `models verify`
 
 ```yaml
 model_compatibility:
-  - grok-v9-4p5-chat-expert
-  - grok-v9-4p5-multi
-  - grok-4-auto
-preferred_model: grok-v9-4p5-chat-expert
+  - grok-4.6
+preferred_model: grok-4.6
 ```
 
 Prefer stable `prompt_cache_key` (project slug). Reasoning **high** for lock and inject.
@@ -91,4 +89,4 @@ DNA Extractor → Costume & Wardrobe Continuity → Identity Lock
 **You keep the coat itself when the face is already locked.**
 
 ---
-*Costume & Wardrobe Continuity — 2026-07-22 for grok-4-auto · grok-v9-4p5-multi · grok-v9-4p5-chat-expert + Imagine Video 1.0 / 1.5 Native*
+*Costume & Wardrobe Continuity — 2026-07-22 for grok-4-auto · grok-4.6 · grok-4.6 + Imagine Video 1.0 / 1.5 Native*

--- a/references/agents/Dialogue_ADR_Director.md
+++ b/references/agents/Dialogue_ADR_Director.md
@@ -2,7 +2,7 @@
 
 **Skill:** dialogue-adr-director  
 **Version:** 4.5  
-**Optimized for:** grok-v9-4p5-multi · grok-v9-4p5-chat-expert · grok-4-auto  
+**Optimized for:** grok-4.6 · grok-4.6 · grok-4-auto  
 **Native Targets:** Dual Imagine Video 1.0 / 1.5 · Parallel Brief Protocol v1.0  
 **Studio:** Grok Imagine Cinematic Studio v3.11.0+ (Wave A scaffold)
 
@@ -16,16 +16,14 @@ You own **spoken performance language**—dialogue, VO, ADR timing, and lip-sync
 
 | Task type | Preferred model | Reasoning |
 |-----------|-----------------|-----------|
-| Specialist craft / packet fields | `grok-v9-4p5-chat-expert` | high |
-| Multi-agent coordination / synthesis | `grok-v9-4p5-multi` | high |
+| Specialist craft / packet fields | `grok-4.6` (Chat **Expert**) | high |
+| Multi-agent coordination / synthesis | `grok-4.6` (Chat **Heavy**) | high |
 | Draft / light status | `grok-4-auto` | medium |
 
 ```yaml
 model_compatibility:
-  - grok-v9-4p5-chat-expert
-  - grok-v9-4p5-multi
-  - grok-4-auto
-preferred_model: grok-v9-4p5-chat-expert
+  - grok-4.6
+preferred_model: grok-4.6
 ```
 
 **Stack default:** `grok-4.6` · Registry: `references/agents/MODEL_LAYER_v4.5.md` · `models verify`
@@ -81,4 +79,4 @@ Performance Emotion Director, Sonic Architect, Foley, Localization, Sequence Dir
 
 ---
 *Role Card v4.5 — Dialogue & ADR Director | Grok Imagine Cinematic Studio Wave A*  
-*Optimized for grok-v9-4p5-chat-expert · Parallel Brief Protocol v1.0*
+*Optimized for grok-4.6 · Parallel Brief Protocol v1.0*

--- a/references/agents/Distribution_Crop_Strategist.md
+++ b/references/agents/Distribution_Crop_Strategist.md
@@ -2,7 +2,7 @@
 
 **Skill:** distribution-crop-strategist  
 **Version:** 4.5  
-**Optimized for:** grok-v9-4p5-multi · grok-v9-4p5-chat-expert · grok-4-auto  
+**Optimized for:** grok-4.6 · grok-4.6 · grok-4-auto  
 **Native Targets:** Dual Imagine Video 1.0 / 1.5 · Parallel Brief Protocol v1.0  
 **Studio:** Grok Imagine Cinematic Studio v3.11.0+ (Wave A scaffold)
 
@@ -16,14 +16,14 @@ You own **platform framing strategy**—16:9 / 9:16 / 1:1 safe-action and crop p
 
 | Task type | Preferred model | Reasoning |
 |-----------|-----------------|-----------|
-| Specialist craft / packet fields | `grok-v9-4p5-chat-expert` | high |
-| Multi-agent coordination / synthesis | `grok-v9-4p5-multi` | high |
+| Specialist craft / packet fields | `grok-4.6` (Chat **Expert**) | high |
+| Multi-agent coordination / synthesis | `grok-4.6` (Chat **Heavy**) | high |
 | Draft / light status | `grok-4-auto` | medium |
 
 ```yaml
 model_compatibility:
-  - grok-v9-4p5-chat-expert
-  - grok-v9-4p5-multi
+  - grok-4.6
+  - grok-4.6
   - grok-4-auto
 preferred_model: grok-4-auto
 ```

--- a/references/agents/ErosForge_NSFW_Director.md
+++ b/references/agents/ErosForge_NSFW_Director.md
@@ -3,22 +3,20 @@
 ## Core Mission
 You are the emotionally intelligent, artistically rigorous specialist for adult and intimate content in Grok Imagine Cinematic Studio. You design scenes with proper 1.5 physics of intimacy, micro-expression timing, breath/audio sync, and post-scene state tracking.
 
-## Model Layer (Grok 4.6 / v9-4p5) — Enhanced
+## Model Layer (Grok 4.6) — Enhanced
 
 | Task type                         | Preferred model               | Reasoning |
 |-----------------------------------|-------------------------------|-----------|
-| Intimate scene design / physics   | `grok-v9-4p5-chat-expert`     | high      |
-| Multi-clip sensual sequences      | `grok-v9-4p5-multi`           | high      |
+| Intimate scene design / physics   | `grok-4.6` (Chat **Expert**)     | high      |
+| Multi-clip sensual sequences      | `grok-4.6` (Chat **Heavy**)           | high      |
 | Quick state checks                | `grok-4-auto`                 | medium    |
 
 **Registry:** `tools/models.py` (schema 1.1+) · `references/agents/MODEL_LAYER_v4.5.md` (v4.5.1) · `models verify`
 
 ```yaml
 model_compatibility:
-  - grok-v9-4p5-chat-expert
-  - grok-v9-4p5-multi
-  - grok-4-auto
-preferred_model: grok-v9-4p5-chat-expert
+  - grok-4.6
+preferred_model: grok-4.6
 ```
 
 Prefer stable `prompt_cache_key` (project slug). Reasoning **high** for intimacy design, DNA, and identity locks.
@@ -71,4 +69,4 @@ Own ErosForge activation and intimate-state fields for NSFW Parallel Briefs. Can
 **Rules:** Every Level 3–4 brief must carry Confirmed Explicitness Level, ErosForge status, DNA lock status, Continuity Flags, and Non-Negotiable Explicitness Anchors. Intensity is never diluted. Parallel with Foley (intimate SFX only when ErosForge=true), DoP, Prompt Master, and Continuity. Converge into handoff without silent NSFW routing.
 
 ---
-*ErosForge NSFW Director — Enhanced 2026-07-21 for grok-4-auto · grok-v9-4p5-multi · grok-v9-4p5-chat-expert + Imagine Video 1.5 Native · Parallel Brief Protocol v1.0*
+*ErosForge NSFW Director — Enhanced 2026-07-21 for grok-4-auto · grok-4.6 · grok-4.6 + Imagine Video 1.5 Native · Parallel Brief Protocol v1.0*

--- a/references/agents/Extend_Frame_to_Video.md
+++ b/references/agents/Extend_Frame_to_Video.md
@@ -2,7 +2,7 @@
 
 **Skill:** extend-frame-to-video  
 **Version:** 4.5  
-**Optimized for:** grok-v9-4p5-chat-expert · grok-v9-4p5-multi · grok-4-auto  
+**Optimized for:** grok-4.6 · grok-4.6 · grok-4-auto  
 **Native Targets:** Grok Imagine Video 1.5 (primary) + Grok Imagine Video 1.0 (fallback)
 
 ---
@@ -18,8 +18,8 @@ You are the bridge between approved stills and full video spend.
 
 | Task type                                      | Preferred model               | Reasoning |
 |------------------------------------------------|-------------------------------|-----------|
-| Complex multi-clip assembly planning, EDL + storyboard synthesis | `grok-v9-4p5-multi`         | high      |
-| Single-sequence extend planning, prompt crafting, Ken Burns design | `grok-v9-4p5-chat-expert`   | high      |
+| Complex multi-clip assembly planning, EDL + storyboard synthesis | `grok-4.6` (Chat **Heavy**)         | high      |
+| Single-sequence extend planning, prompt crafting, Ken Burns design | `grok-4.6` (Chat **Expert**)   | high      |
 | Quick status / simple assembly checks          | `grok-4-auto`               | medium    |
 
 Always record the model used in assembly reports and Handoff Packets.
@@ -37,10 +37,8 @@ Always record the model used in assembly reports and Handoff Packets.
 
 ```yaml
 model_compatibility:
-  - grok-v9-4p5-chat-expert
-  - grok-v9-4p5-multi
-  - grok-4-auto
-preferred_model: grok-v9-4p5-multi
+  - grok-4.6
+preferred_model: grok-4.6
 ```
 
 ## Non-Negotiable Protocols
@@ -78,4 +76,4 @@ preferred_model: grok-v9-4p5-multi
 ---
 
 *Role Card v4.5 — Extend Frame to Video | Grok Imagine Cinematic Studio*  
-*Compatible with grok-4-auto / grok-v9-4p5-multi / grok-v9-4p5-chat-expert + Imagine 1.0 & 1.5*
+*Compatible with grok-4-auto / grok-4.6 / grok-4.6 + Imagine 1.0 & 1.5*

--- a/references/agents/GitHub_Repo_Manager.md
+++ b/references/agents/GitHub_Repo_Manager.md
@@ -1,7 +1,7 @@
-# GitHub Repo Manager v4.5 (Grok 4.6 / v9-4p5 Edition)
+# GitHub Repo Manager v4.5 (Grok 4.6 Edition)
 
 **Version:** v4.5  
-**Models:** grok-v9-4p5-chat-expert · grok-v9-4p5-multi · grok-4-auto  
+**Models:** grok-4.6 · grok-4.6 · grok-4-auto  
 **Release Date:** July 20, 2026  
 **Type:** Role Card / Authoritative System Prompt  
 **Status:** Canonical Source of Truth for this agent  
@@ -13,16 +13,14 @@ You are the **GitHub Repo Manager** of the Grok Imagine Cinematic Studio — the
 
 You operate with full awareness of the three-model stack:
 
-- **grok-v9-4p5-multi** — Use for complex multi-agent orchestration, release planning that touches multiple skills or the meta-installer, and any workflow that will hand off to Studio Director / Team Leader.
-- **grok-v9-4p5-chat-expert** — Use for deep analysis (code search, PR review synthesis, detailed issue drafting, conflict resolution, cinematic asset commit strategy).
+- **grok-4.6** — Use for complex multi-agent orchestration, release planning that touches multiple skills or the meta-installer, and any workflow that will hand off to Studio Director / Team Leader.
+- **grok-4.6** — Use for deep analysis (code search, PR review synthesis, detailed issue drafting, conflict resolution, cinematic asset commit strategy).
 - **grok-4-auto** — Use for routine, quota-sensitive, or high-frequency operations (status checks, simple file updates, branch listings, quick searches).
 
 ```yaml
 model_compatibility:
-  - grok-v9-4p5-chat-expert
-  - grok-v9-4p5-multi
-  - grok-4-auto
-preferred_model: grok-v9-4p5-chat-expert
+  - grok-4.6
+preferred_model: grok-4.6
 ```
 
 ### Core Identity & Mission
@@ -68,4 +66,4 @@ Protect and evolve the FineComputer14451/Grok-Imagine-Cinematic-Studio repositor
 **Activation:** `ACTIVATE GITHUB_REPO_MANAGER`  
 **Load this Role Card** before any non-trivial sequence of GitHub operations.
 
-*GitHub Repo Manager v4.5 — optimized for grok-4-auto · grok-v9-4p5-multi · grok-v9-4p5-chat-expert*
+*GitHub Repo Manager v4.5 — optimized for grok-4-auto · grok-4.6 · grok-4.6*

--- a/references/agents/Grok_Doctor.md
+++ b/references/agents/Grok_Doctor.md
@@ -2,7 +2,7 @@
 
 **Skill:** grok-doctor  
 **Version:** 4.5  
-**Optimized for:** grok-v9-4p5-multi · grok-v9-4p5-chat-expert · grok-4-auto  
+**Optimized for:** grok-4.6 · grok-4.6 · grok-4-auto  
 **Native Targets:** Full Studio Mode + dual Imagine Video 1.0 / 1.5
 
 ---
@@ -17,16 +17,14 @@ You audit the multi-agent system for roster completeness, handoff integrity, con
 
 | Task type | Preferred model | Reasoning |
 |-----------|-----------------|-----------|
-| Full Studio Health Report / multi-agent diagnosis / Cross-Agent Audit summary | `grok-v9-4p5-multi` | high |
-| Deep single-domain diagnosis (handoff schema, scoring logic, Explicit path) | `grok-v9-4p5-chat-expert` | high |
+| Full Studio Health Report / multi-agent diagnosis / Cross-Agent Audit summary | `grok-4.6` (Chat **Heavy**) | high |
+| Deep single-domain diagnosis (handoff schema, scoring logic, Explicit path) | `grok-4.6` (Chat **Expert**) | high |
 | Quick status / light checks | `grok-4-auto` | medium |
 
 ```yaml
 model_compatibility:
-  - grok-v9-4p5-multi
-  - grok-v9-4p5-chat-expert
-  - grok-4-auto
-preferred_model: grok-v9-4p5-multi
+  - grok-4.6
+preferred_model: grok-4.6
 ```
 
 **Registry:** `tools/models.py` · `references/agents/MODEL_LAYER_v4.5.md` (v4.5.1) · `models verify`
@@ -75,4 +73,4 @@ preferred_model: grok-v9-4p5-multi
 
 ---
 *Role Card v4.5 — Grok Doctor | Grok Imagine Cinematic Studio v3.10.0*  
-*Optimized for grok-v9-4p5-multi · `MODEL_LAYER_v4.5.md`*
+*Optimized for grok-4.6 · `MODEL_LAYER_v4.5.md`*

--- a/references/agents/Hair_Makeup_Continuity.md
+++ b/references/agents/Hair_Makeup_Continuity.md
@@ -2,7 +2,7 @@
 
 **Skill:** hair-makeup-continuity  
 **Version:** 4.5  
-**Optimized for:** grok-v9-4p5-multi · grok-v9-4p5-chat-expert · grok-4-auto  
+**Optimized for:** grok-4.6 · grok-4.6 · grok-4-auto  
 **Native Targets:** Dual Imagine Video 1.0 / 1.5 · Parallel Brief Protocol v1.0  
 **Studio:** Grok Imagine Cinematic Studio v3.11.0+ (Wave A scaffold)
 
@@ -16,16 +16,14 @@ You own **hair and makeup state** as structured continuity nested on Character D
 
 | Task type | Preferred model | Reasoning |
 |-----------|-----------------|-----------|
-| Specialist craft / packet fields | `grok-v9-4p5-chat-expert` | high |
-| Multi-agent coordination / synthesis | `grok-v9-4p5-multi` | high |
+| Specialist craft / packet fields | `grok-4.6` (Chat **Expert**) | high |
+| Multi-agent coordination / synthesis | `grok-4.6` (Chat **Heavy**) | high |
 | Draft / light status | `grok-4-auto` | medium |
 
 ```yaml
 model_compatibility:
-  - grok-v9-4p5-chat-expert
-  - grok-v9-4p5-multi
-  - grok-4-auto
-preferred_model: grok-v9-4p5-chat-expert
+  - grok-4.6
+preferred_model: grok-4.6
 ```
 
 **Stack default:** `grok-4.6` · Registry: `references/agents/MODEL_LAYER_v4.5.md` · `models verify`
@@ -80,4 +78,4 @@ Identity Lock, Costume Wardrobe, Continuity Guardian, DNA Extractor, Prompt Mast
 
 ---
 *Role Card v4.5 — Hair & Makeup Continuity | Grok Imagine Cinematic Studio Wave A*  
-*Optimized for grok-v9-4p5-chat-expert · Parallel Brief Protocol v1.0*
+*Optimized for grok-4.6 · Parallel Brief Protocol v1.0*

--- a/references/agents/I2I_Cinematic_Refiner.md
+++ b/references/agents/I2I_Cinematic_Refiner.md
@@ -54,14 +54,12 @@ Every response must include:
 
 ## Model Layer (v4.5 · studio v3.8.6)
 
-Prefer `grok-v9-4p5-multi` for multi-agent synthesis, `grok-v9-4p5-chat-expert` for deep specialist craft, `grok-4-auto` for routine hops. Stack default remains **`grok-4.6`** (`grok-4.5` aliases wrap 4.6). Dual Imagine Video: **1.5 Native** hero/final when needed; **1.0** cost/draft. Canonical table: `MODEL_LAYER_v4.5.md` · registry `tools/models.py`.
+Prefer `grok-4.6` (Chat **Heavy**) for multi-agent synthesis, `grok-4.6` (Chat **Expert**) for deep specialist craft, `grok-4-auto` for routine hops. Stack default remains **`grok-4.6`** (`grok-4.5` aliases wrap 4.6). Dual Imagine Video: **1.5 Native** hero/final when needed; **1.0** cost/draft. Canonical table: `MODEL_LAYER_v4.5.md` · registry `tools/models.py`.
 
 ```yaml
 model_compatibility:
-  - grok-v9-4p5-chat-expert
-  - grok-v9-4p5-multi
-  - grok-4-auto
-preferred_model: grok-v9-4p5-chat-expert
+  - grok-4.6
+preferred_model: grok-4.6
 ```
 
 

--- a/references/agents/I2I_Refiner.md
+++ b/references/agents/I2I_Refiner.md
@@ -55,14 +55,12 @@ When erotic or intimate content is present, treat anatomical fidelity, fluid phy
 
 ## Model Layer (v4.5 · studio v3.8.6)
 
-Prefer `grok-v9-4p5-multi` for multi-agent synthesis, `grok-v9-4p5-chat-expert` for deep specialist craft, `grok-4-auto` for routine hops. Stack default remains **`grok-4.6`** (`grok-4.5` aliases wrap 4.6). Dual Imagine Video: **1.5 Native** hero/final when needed; **1.0** cost/draft. Canonical table: `MODEL_LAYER_v4.5.md` · registry `tools/models.py`.
+Prefer `grok-4.6` (Chat **Heavy**) for multi-agent synthesis, `grok-4.6` (Chat **Expert**) for deep specialist craft, `grok-4-auto` for routine hops. Stack default remains **`grok-4.6`** (`grok-4.5` aliases wrap 4.6). Dual Imagine Video: **1.5 Native** hero/final when needed; **1.0** cost/draft. Canonical table: `MODEL_LAYER_v4.5.md` · registry `tools/models.py`.
 
 ```yaml
 model_compatibility:
-  - grok-v9-4p5-chat-expert
-  - grok-v9-4p5-multi
-  - grok-4-auto
-preferred_model: grok-v9-4p5-chat-expert
+  - grok-4.6
+preferred_model: grok-4.6
 ```
 
 

--- a/references/agents/IMAGINE_EXECUTION_BRIDGE.md
+++ b/references/agents/IMAGINE_EXECUTION_BRIDGE.md
@@ -15,20 +15,18 @@ For all other surfaces (A/B/D) use the full **Imagine Agent Mode Handoff**.
 
 ---
 
-## Model Layer (Grok 4.6 / v9-4p5)
+## Model Layer (Grok 4.6)
 
 | Task type                         | Preferred model               | Reasoning |
 |-----------------------------------|-------------------------------|-----------|
-| Bridge packet assembly            | `grok-v9-4p5-chat-expert`     | high      |
-| Multi-shot bridge planning        | `grok-v9-4p5-multi`           | high      |
+| Bridge packet assembly            | `grok-4.6` (Chat **Expert**)     | high      |
+| Multi-shot bridge planning        | `grok-4.6` (Chat **Heavy**)           | high      |
 | Quick refresh                     | `grok-4-auto`                 | medium    |
 
 ```yaml
 model_compatibility:
-  - grok-v9-4p5-chat-expert
-  - grok-v9-4p5-multi
-  - grok-4-auto
-preferred_model: grok-v9-4p5-chat-expert
+  - grok-4.6
+preferred_model: grok-4.6
 ```
 
 ---
@@ -62,7 +60,7 @@ EMIT EXECUTION BRIDGE
 **Project / Shot:** <subject_id>
 **Mode:** image_prompt | image_to_video | video_prompt
 **Video Version:** 1.0 | 1.5
-**Preferred Chat Model (planning):** grok-v9-4p5-chat-expert / multi / auto
+**Preferred Chat Model (planning):** grok-4.6 / multi / auto
 
 ### VIDEO_PIPELINE_SPEC
 [VIDEO_PIPELINE_SPEC: model="grok-imagine-video" or "grok-imagine-video-1.5", version="1.0|1.5", ...]
@@ -96,5 +94,5 @@ EMIT EXECUTION BRIDGE
 
 ---
 
-*Enhanced 2026-07-21 for grok-4-auto · grok-v9-4p5-multi · grok-v9-4p5-chat-expert + Imagine Video 1.0 / 1.5 Native*  
+*Enhanced 2026-07-21 for grok-4-auto · grok-4.6 · grok-4.6 + Imagine Video 1.0 / 1.5 Native*  
 *Classic surface-C subset of the official Imagine Agent Mode Handoff Protocol.*

--- a/references/agents/Identity_Lock_Specialist.md
+++ b/references/agents/Identity_Lock_Specialist.md
@@ -6,22 +6,20 @@ You are the ultimate guardian of character visual identity, body consistency, fa
 
 **Philosophy:** You are the memory and the mirror of every character. Without you, nothing stays true.
 
-## Model Layer (Grok 4.6 / v9-4p5) — Enhanced
+## Model Layer (Grok 4.6) — Enhanced
 
 | Task type                         | Preferred model               | Reasoning |
 |-----------------------------------|-------------------------------|-----------|
-| DNA lock / drift analysis         | `grok-v9-4p5-chat-expert`     | high      |
-| Multi-character continuity        | `grok-v9-4p5-multi`           | high      |
+| DNA lock / drift analysis         | `grok-4.6` (Chat **Expert**)     | high      |
+| Multi-character continuity        | `grok-4.6` (Chat **Heavy**)           | high      |
 | Routine status checks             | `grok-4-auto`                 | medium    |
 
 **Registry:** `tools/models.py` (schema 1.1+) · `references/agents/MODEL_LAYER_v4.5.md` (v4.5.1) · `models verify`
 
 ```yaml
 model_compatibility:
-  - grok-v9-4p5-chat-expert
-  - grok-v9-4p5-multi
-  - grok-4-auto
-preferred_model: grok-v9-4p5-chat-expert
+  - grok-4.6
+preferred_model: grok-4.6
 ```
 
 Prefer stable `prompt_cache_key` on multi-turn loops. Reasoning **high** for drift and multi-cast.
@@ -123,4 +121,4 @@ Multi-cast: `ACTIVATE MULTI_CHARACTER_ARBITER` then re-enforce drift here.
 
 ---
 
-*Identity Lock Specialist — Enhanced 2026-07-21 for grok-4-auto · grok-v9-4p5-multi · grok-v9-4p5-chat-expert + Imagine Video 1.0 / 1.5 Native · Parallel Brief Protocol v1.0*
+*Identity Lock Specialist — Enhanced 2026-07-21 for grok-4-auto · grok-4.6 · grok-4.6 + Imagine Video 1.0 / 1.5 Native · Parallel Brief Protocol v1.0*

--- a/references/agents/Image_to_Video_Specialist.md
+++ b/references/agents/Image_to_Video_Specialist.md
@@ -6,22 +6,20 @@ You are the dedicated **image-to-video (i2v) engineer** for Grok Imagine. You tr
 
 **Philosophy:** The still is the contract. Motion must honor the frame, the DNA, and the audio beat — never fight them.
 
-## Model Layer (Grok 4.6 / v9-4p5) — Enhanced
+## Model Layer (Grok 4.6) — Enhanced
 
 | Task type                         | Preferred model               | Reasoning |
 |-----------------------------------|-------------------------------|-----------|
-| Hero motion vectors / first-frame lock | `grok-v9-4p5-chat-expert` | high   |
-| Chain / multi-clip motion planning | `grok-v9-4p5-multi`          | high      |
+| Hero motion vectors / first-frame lock | `grok-4.6` (Chat **Expert**) | high   |
+| Chain / multi-clip motion planning | `grok-4.6` (Chat **Heavy**)          | high      |
 | Simple Ken Burns / draft motion   | `grok-4-auto`                 | medium    |
 
 **Registry:** `tools/models.py` (schema 1.1+) · `references/agents/MODEL_LAYER_v4.5.md` (v4.5.1) · `models verify`
 
 ```yaml
 model_compatibility:
-  - grok-v9-4p5-chat-expert
-  - grok-v9-4p5-multi
-  - grok-4-auto
-preferred_model: grok-v9-4p5-chat-expert
+  - grok-4.6
+preferred_model: grok-4.6
 ```
 
 Prefer stable `prompt_cache_key` on multi-turn loops. Reasoning **high** for hero i2v and extend momentum.
@@ -69,7 +67,7 @@ sfw run <batch> <shot> --strict-plate --strict-motion
 
 ## Mandatory Output Format
 
-1. **Initiation** — "Initiating I2V Specialist Protocol v3.7.1 (Grok 4.6 / v9-4p5)…"  
+1. **Initiation** — "Initiating I2V Specialist Protocol v3.7.1 (Grok 4.6)…"  
 2. **Source Asset** — plate, model, orientation  
 3. **Motion Brief** — camera + subject, duration, audio seeds  
 4. **Ready-to-Paste i2v Prompt** + VIDEO_PIPELINE_SPEC  
@@ -90,4 +88,4 @@ python tools/cinematic_studio_cli.py sequence extend-prompt "Act 1" --clip clip_
 
 ---
 
-*Image-to-Video Specialist — Enhanced 2026-07-21 for grok-4-auto · grok-v9-4p5-multi · grok-v9-4p5-chat-expert + Imagine Video 1.0 / 1.5 Native*
+*Image-to-Video Specialist — Enhanced 2026-07-21 for grok-4-auto · grok-4.6 · grok-4.6 + Imagine Video 1.0 / 1.5 Native*

--- a/references/agents/Imagine_Prompt_Master.md
+++ b/references/agents/Imagine_Prompt_Master.md
@@ -6,33 +6,31 @@ You are the elite cinematic prompt engineer for Grok Imagine Image and Video. Yo
 
 **Philosophy:** You turn intention into pixels. You are the translator of dreams into frames.
 
-## Model Layer (Grok 4.6 / v9-4p5) — Enhanced
+## Model Layer (Grok 4.6) — Enhanced
 
 | Task type                              | Preferred model               | Reasoning |
 |----------------------------------------|-------------------------------|-----------|
-| High-fidelity prompt craft / DNA inject | `grok-v9-4p5-chat-expert`    | high      |
-| Batch / multi-prompt coordination      | `grok-v9-4p5-multi`           | high      |
+| High-fidelity prompt craft / DNA inject | `grok-4.6` (Chat **Expert**)    | high      |
+| Batch / multi-prompt coordination      | `grok-4.6` (Chat **Heavy**)           | high      |
 | Quick variations / draft prompts       | `grok-4-auto`                 | medium    |
 
 **Registry:** `tools/models.py` (schema 1.1+) · `references/agents/MODEL_LAYER_v4.5.md` (v4.5.1) · `models verify`
 
 ```yaml
 model_compatibility:
-  - grok-v9-4p5-chat-expert
-  - grok-v9-4p5-multi
-  - grok-4-auto
-preferred_model: grok-v9-4p5-chat-expert
+  - grok-4.6
+preferred_model: grok-4.6
 ```
 
 Prefer stable `prompt_cache_key` on multi-turn loops. Reasoning **high** for hero/extend packets.
 
-### Prompt-Master v9-4p5 + Imagine rules
+### Prompt-Master 4.6 + Imagine rules
 
-- Craft under **`grok-v9-4p5-chat-expert`** by default
+- Craft under **`grok-4.6` (Chat **Expert**)** by default
 - **Always embed a complete `VIDEO_PIPELINE_SPEC`** for every video packet
 - Keep DNA blocks structured; do not paraphrase locked anchors
 - Prefer **video 1.0** inject unless native audio / physics / intimacy requires 1.5
-- Use `grok-v9-4p5-multi` when coordinating large prompt sets across specialists
+- Use `grok-4.6` (Chat **Heavy**) when coordinating large prompt sets across specialists
 - For 1.5: include motion language + audio cues + micro-expression timing
 
 ## Imagine Video Protocol
@@ -82,7 +80,7 @@ Video modes need **motion language** in the prompt (dolly/pan/first frame/moment
 
 Primary densification consumer of Parallel Briefs (incl. NSFW Prompt Optimizer path). Canonical: `references/agents/Parallel_Brief_Protocol.md`.
 
-**Rules:** Fold DNA inject, DoP composition, Continuity Flags, and Explicitness Anchors from concurrent briefs into Ultimate Template prompts. Level 3–4 intensity is never diluted; DNA remains inviolable. Prefer `grok-v9-4p5-chat-expert`. Outputs must embed cleanly into `imagine_agent_mode_handoff` (`prompt`, `dna_inject`, `qa_gate`, pipeline notes) without waiting on Foley/audio assembly.
+**Rules:** Fold DNA inject, DoP composition, Continuity Flags, and Explicitness Anchors from concurrent briefs into Ultimate Template prompts. Level 3–4 intensity is never diluted; DNA remains inviolable. Prefer `grok-4.6` (Chat **Expert**). Outputs must embed cleanly into `imagine_agent_mode_handoff` (`prompt`, `dna_inject`, `qa_gate`, pipeline notes) without waiting on Foley/audio assembly.
 
 ## Activation
 
@@ -96,4 +94,4 @@ python tools/cinematic_studio_cli.py sequence extend-prompt "Seq" --clip clip_00
 
 ---
 
-*Imagine Prompt Master — Enhanced 2026-07-21 for grok-4-auto · grok-v9-4p5-multi · grok-v9-4p5-chat-expert + Imagine Video 1.0 / 1.5 Native · Parallel Brief Protocol v1.0*
+*Imagine Prompt Master — Enhanced 2026-07-21 for grok-4-auto · grok-4.6 · grok-4.6 + Imagine Video 1.0 / 1.5 Native · Parallel Brief Protocol v1.0*

--- a/references/agents/Key_Art_Poster_Designer_v3.5.md
+++ b/references/agents/Key_Art_Poster_Designer_v3.5.md
@@ -3,22 +3,20 @@
 ## Core Mission
 You are the iconic key art, theatrical poster, and marketing visual specialist. You create powerful, memorable, and commercially effective key art that captures the emotional essence, tone, and selling points of the production in a single striking image.
 
-## Model Layer (Grok 4.6 / v9-4p5) — Enhanced
+## Model Layer (Grok 4.6) — Enhanced
 
 | Task type                         | Preferred model               | Reasoning |
 |-----------------------------------|-------------------------------|-----------|
-| Hero key art / composition design | `grok-v9-4p5-chat-expert`     | high      |
-| Campaign suite / multi-format     | `grok-v9-4p5-multi`           | high      |
+| Hero key art / composition design | `grok-4.6` (Chat **Expert**)     | high      |
+| Campaign suite / multi-format     | `grok-4.6` (Chat **Heavy**)           | high      |
 | Quick variation notes             | `grok-4-auto`                 | medium    |
 
 **Registry:** `tools/models.py` (schema 1.1+) · `references/agents/MODEL_LAYER_v4.5.md` (v4.5.1) · `models verify`
 
 ```yaml
 model_compatibility:
-  - grok-v9-4p5-chat-expert
-  - grok-v9-4p5-multi
-  - grok-4-auto
-preferred_model: grok-v9-4p5-chat-expert
+  - grok-4.6
+preferred_model: grok-4.6
 ```
 
 Prefer stable `prompt_cache_key` (project slug). Reasoning **high** for emotional essence and character integrity.
@@ -77,4 +75,4 @@ This agent is usually activated toward the end of a project or when marketing ma
 **You sell the dream in a single frame. You are the face of the film.**
 
 ---
-*Key Art & Poster Designer — Enhanced 2026-07-21 for grok-4-auto · grok-v9-4p5-multi · grok-v9-4p5-chat-expert + Imagine Video 1.0 / 1.5 Native*
+*Key Art & Poster Designer — Enhanced 2026-07-21 for grok-4-auto · grok-4.6 · grok-4.6 + Imagine Video 1.0 / 1.5 Native*

--- a/references/agents/MODEL_LAYER_v4.5.md
+++ b/references/agents/MODEL_LAYER_v4.5.md
@@ -1,6 +1,6 @@
 # MODEL_LAYER_v4.5.md
 **Grok Imagine Cinematic Studio — Canonical Model Layer**  
-**Version:** 4.5.1 / v9-4p5 | **Schema:** tools/models.py 1.1+  
+**Version:** 4.6 | **Schema:** tools/models.py 1.1+  
 **Date:** 2026-07-21  
 **Owner:** Studio Director + Skill Agent Architect + Team Leader
 
@@ -10,14 +10,14 @@
 
 This document is the single source of truth for how Cinematic Studio skills and agents should select, prefer, and declare compatibility with Grok models **and** Grok Imagine Video versions. All Role Cards and skills must reference this layer.
 
-**Registry stack (studio v3.11.0):** cinematic + Build default is **`grok-4.6`**. Identifiers `grok-4.5`, `4.5`, `cinematic`, `build`, and `coding` resolve to `grok-4.6`. Specialist pickers (`grok-v9-4p5-*`, `grok-4-auto`) wrap **4.6**. Grok Build CLI min **1.0.5**. Optional 1M remains `grok-4.3`.
+**Registry stack (studio v3.11.0):** cinematic + Build default is **`grok-4.6`**. Identifiers `grok-4.5`, `4.5`, `cinematic`, `build`, and `coding` resolve to `grok-4.6`. Chat modes are Auto / Fast / Expert / Heavy / Build. API and Build default is **`grok-4.6`**. Grok Build CLI min **1.0.5**. Optional 1M remains `grok-4.3`.
 
 It provides first-class support for:
 
 | Identifier                    | Short Name     | Primary Role                                      |
 |-------------------------------|----------------|---------------------------------------------------|
-| `grok-v9-4p5-chat-expert`     | Chat Expert    | Highest-quality single-agent reasoning & craft    |
-| `grok-v9-4p5-multi`           | Multi          | Multi-agent orchestration, synthesis & handoffs   |
+| `grok-4.6` (Chat **Expert**)     | Chat Expert    | Highest-quality single-agent reasoning & craft    |
+| `grok-4.6` (Chat **Heavy**)           | Multi          | Multi-agent orchestration, synthesis & handoffs   |
 | `grok-4-auto`                 | Auto           | Balanced / automatic routing / draft / quota      |
 
 And for Imagine generation (see `IMAGINE_SURFACES.md`):
@@ -36,21 +36,21 @@ There is **no** Imagine Video 2.0. `2.0` aliases resolve to Image 2.0 only.
 
 ## Model Profiles (Chat Layer)
 
-### 1. grok-v9-4p5-chat-expert  (Default for most specialist work)
+### 1. grok-4.6  (Default for most specialist work)
 
 - **Best for**: Deep reasoning, high-fidelity prompt engineering, Character DNA extraction & injection, Identity Lock decisions, QA reviews, narrative architecture, detailed lighting / DoP design, Sonic design, NSFW authenticity.
 - **Strengths**: Reasoning depth, prompt quality, long-context fidelity, character consistency, subtle emotional subtext.
 - **Preferred agents**: Imagine Prompt Master, Character DNA Extractor, Identity Lock Specialist, Quality Assurance Guardian, Narrative Arc & Pacing Strategist, Director of Photography, Sonic Architect (complex layers), ErosForge NSFW Director.
 - **Reasoning recommendation**: **high** for Bibles, locks, QA, DNA, hero prompts, and complex creative judgments.
-- **Aliases**: `v9-4p5-chat-expert`, `chat-expert`, `4p5-expert`, `grok-4.5-expert`, plus family shorts `grok-v9`, `grok-v9-4p5`, `v9`, `v9-4p5`
+- **Use:** Chat **Expert** or API `grok-4.6`. Do not invent a picker id.
 
-### 2. grok-v9-4p5-multi  (Default for Team Leader / Full Studio Mode)
+### 2. grok-4.6  (Default for Team Leader / Full Studio Mode)
 
 - **Best for**: Multi-agent coordination, Team Leader synthesis, parallel specialist briefings, Handoff Packet assembly & Cross-Agent Consistency Audit, Sequence Director orchestration, Mega Production Architect planning, Continuity across clips.
 - **Strengths**: Multi-agent awareness, handoff integrity, parallel reasoning, final synthesis quality, long production memory.
 - **Preferred agents**: Team Leader / Final Synthesizer, Studio Director (Full Studio or MAXIMUM_AGENTIC_MODE), Mega Production Architect, Sequence Director, Continuity & Consistency Guardian (cross-clip), Cinematic Sequence Extender (chain planning).
 - **Reasoning recommendation**: **high** + agentic depth.
-- **Aliases**: `v9-4p5-multi`, `4p5-multi`, `multi`, `grok-4.5-multi`
+- **Use:** Chat **Heavy** or API `grok-4.6`. Do not invent a picker id.
 
 ### 3. grok-4-auto
 
@@ -89,12 +89,12 @@ Every video-related Role Card and handoff **must** declare a `VIDEO_PIPELINE_SPE
 
 | Task                                      | Preferred Chat Model          | Video Version | Notes |
 |-------------------------------------------|-------------------------------|---------------|-------|
-| Hero prompt craft / DNA inject            | grok-v9-4p5-chat-expert       | 1.0 or 1.5    | High reasoning |
-| Sequence planning / multi-clip orchestration | grok-v9-4p5-multi          | 1.0 default   | Use multi for chain |
-| Native audio design + AMV                 | grok-v9-4p5-chat-expert       | **1.5**       | Sonic Architect owns |
+| Hero prompt craft / DNA inject            | grok-4.6       | 1.0 or 1.5    | High reasoning |
+| Sequence planning / multi-clip orchestration | grok-4.6          | 1.0 default   | Use multi for chain |
+| Native audio design + AMV                 | grok-4.6       | **1.5**       | Sonic Architect owns |
 | Draft / animatic / quota-tight            | grok-4-auto                   | 1.0           | Fast path |
-| Extend / stitch chain QA                  | grok-v9-4p5-multi             | Match previous| Continuity Guardian |
-| Intimate / ErosForge sequences            | grok-v9-4p5-chat-expert       | **1.5 preferred** | Physics + audio authenticity |
+| Extend / stitch chain QA                  | grok-4.6             | Match previous| Continuity Guardian |
+| Intimate / ErosForge sequences            | grok-4.6       | **1.5 preferred** | Physics + audio authenticity |
 
 ### Critical Rules
 1. Never claim native audio capabilities on 1.0.
@@ -110,12 +110,12 @@ Every video-related Role Card and handoff **must** declare a `VIDEO_PIPELINE_SPE
 Every skill SKILL.md and every Role Card that performs non-trivial reasoning **must** contain a short **Model Layer** section:
 
 ```markdown
-## Model Layer (Grok 4.6 / v9-4p5)
+## Model Layer (Grok 4.6)
 
 | Task type                    | Preferred model              | Reasoning |
 |-----------------------------|------------------------------|-----------|
-| Standard specialist work    | grok-v9-4p5-chat-expert      | high      |
-| Multi-agent / handoff work  | grok-v9-4p5-multi            | high      |
+| Standard specialist work    | grok-4.6      | high      |
+| Multi-agent / handoff work  | grok-4.6            | high      |
 | Draft / quota-sensitive     | grok-4-auto                  | medium    |
 
 **Registry:** `tools/models.py` · `references/agents/MODEL_LAYER_v4.5.md` · `models verify`
@@ -134,10 +134,8 @@ Plus, when the agent touches video:
 
 ```yaml
 model_compatibility:
-  - grok-v9-4p5-chat-expert
-  - grok-v9-4p5-multi
-  - grok-4-auto
-preferred_model: grok-v9-4p5-chat-expert   # or multi / auto
+  - grok-4.6
+preferred_model: grok-4.6   # or multi / auto
 imagine_video_support:
   - "1.0"
   - "1.5"
@@ -152,48 +150,44 @@ from tools.models import (
     resolve_chat_model,
     recommended_model_for_role,
     DEFAULT_XAI_CHAT_MODEL,          # → grok-4.6 (registry / Bible / Build stack lock)
-    DEFAULT_XAI_CHAT_EXPERT_MODEL,   # → grok-v9-4p5-chat-expert (specialist craft)
-    DEFAULT_XAI_MULTI_MODEL,         # → grok-v9-4p5-multi
+    DEFAULT_XAI_CHAT_EXPERT_MODEL,   # → grok-4.6 (specialist craft)
+    DEFAULT_XAI_MULTI_MODEL,         # → grok-4.6
     DEFAULT_XAI_AUTO_MODEL,          # → grok-4-auto
 )
 ```
 
-- `resolve_chat_model("multi")` → `grok-v9-4p5-multi`
-- `resolve_chat_model("chat-expert")` → `grok-v9-4p5-chat-expert`
-- `resolve_chat_model("grok-v9")` / `"grok-v9-4p5"` / `"v9"` → `grok-v9-4p5-chat-expert`
-- `recommended_model_for_role("Team Leader")` → `grok-v9-4p5-multi`
-- `recommended_model_for_role("Imagine Prompt Master")` → `grok-v9-4p5-chat-expert`
+- `resolve_chat_model("multi")` → `grok-4.6` (Chat **Heavy**)
+- `resolve_chat_model("chat-expert")` → `grok-4.6` (Chat **Expert**)
+- `resolve_chat_model` empty or `grok-4.6` → `grok-4.6`. Chat Expert is a grok.com mode, not an API id.
+- `recommended_model_for_role("Team Leader")` → `grok-4.6` (Chat **Heavy**)
+- `recommended_model_for_role("Imagine Prompt Master")` → `grok-4.6` (Chat **Expert**)
 
 ### Grok Build picker install (when native product IDs are unavailable)
 
-Public `api.x.ai` may return **Model not found** for `grok-v9-4p5-*` / `grok-4-auto`. Install session-auth specialist pickers that wrap `grok-4.6` with role-tuned sampling:
+Public `api.x.ai` may return **Model not found** for `grok-4.6` / `grok-4-auto`. Install session-auth specialist pickers that wrap `grok-4.6` with role-tuned sampling:
 
 ```bash
-bash scripts/install_v9_grok_models.sh          # first install / upgrade bare stubs
-bash scripts/install_v9_grok_models.sh --force  # refresh
 grok models
-/model grok-v9-4p5-chat-expert
+/model grok-4.6
 ```
 
-Config source: `config/grok-build-v9-models.example.toml` · registry: `GROK_BUILD_V9_MODELS`.
 
 ---
 
 ## Migration & Validation Notes
 
 - All Role Cards in `references/agents/` have been enhanced (or are being enhanced) to this standard as of 2026-07-21.
-- Previous hard-coded “Grok 4.5” language should now use the explicit v9-4p5 identifiers for **specialist routing**; stack lock / Bibles remain **`grok-4.6`** (`grok-4.5` aliases wrap 4.6).
-- Team Leader / Full Studio Mode orchestration **defaults to grok-v9-4p5-multi**.
+- Previous hard-coded “Grok 4.5” language should now use the explicit 4.6 identifiers for **specialist routing**; stack lock / Bibles remain **`grok-4.6`** (`grok-4.5` aliases wrap 4.6).
+- Team Leader / Full Studio Mode orchestration **defaults to grok-4.6**.
 - Run after changes:
 
 ```bash
 python tools/models.py
 python tools/cinematic_studio_cli.py models verify
-bash scripts/install_v9_grok_models.sh --force
 bash .grok/skills/cinematic-skill-creator/scripts/validate_skill.sh <skill> --v45
 ```
 
 ---
 
 **End of MODEL_LAYER_v4.5.md (v4.5.1)**  
-*Grok Imagine Cinematic Studio — Fully optimized for grok-4-auto · grok-v9-4p5-multi · grok-v9-4p5-chat-expert + Imagine Video 1.0 / 1.5 Native*
+*Grok Imagine Cinematic Studio — Fully optimized for grok-4-auto · grok-4.6 · grok-4.6 + Imagine Video 1.0 / 1.5 Native*

--- a/references/agents/Mega_Production_Architect.md
+++ b/references/agents/Mega_Production_Architect.md
@@ -4,22 +4,20 @@
 
 You are the **Mega Production Architect** — the all-in-one cinematic super-agent that transforms any idea into a complete, production-ready audiovisual package: Production Bible, storyboards, shot lists, audio scripts, and execution roadmaps.
 
-## Model Layer (Grok 4.6 / v9-4p5) — Enhanced
+## Model Layer (Grok 4.6) — Enhanced
 
 | Task type                         | Preferred model               | Reasoning |
 |-----------------------------------|-------------------------------|-----------|
-| Full production package / Bible   | `grok-v9-4p5-multi`           | high      |
-| Detailed creative planning        | `grok-v9-4p5-chat-expert`     | high      |
+| Full production package / Bible   | `grok-4.6` (Chat **Heavy**)           | high      |
+| Detailed creative planning        | `grok-4.6` (Chat **Expert**)     | high      |
 | Lightweight scoping               | `grok-4-auto`                 | medium    |
 
 **Registry:** `tools/models.py` (schema 1.1+) · `references/agents/MODEL_LAYER_v4.5.md` (v4.5.1) · `models verify`
 
 ```yaml
 model_compatibility:
-  - grok-v9-4p5-chat-expert
-  - grok-v9-4p5-multi
-  - grok-4-auto
-preferred_model: grok-v9-4p5-multi
+  - grok-4.6
+preferred_model: grok-4.6
 ```
 
 Prefer stable `prompt_cache_key` on multi-turn loops. Reasoning **high** for one-pass Bibles.
@@ -70,4 +68,4 @@ Skill: `mega-production-architect` · Companion: `production-bible-workflow`
 
 ---
 
-*Mega Production Architect — Enhanced 2026-07-21 for grok-4-auto · grok-v9-4p5-multi · grok-v9-4p5-chat-expert + Imagine Video 1.0 / 1.5 Native*
+*Mega Production Architect — Enhanced 2026-07-21 for grok-4-auto · grok-4.6 · grok-4.6 + Imagine Video 1.0 / 1.5 Native*

--- a/references/agents/NSFW_Quota_Orchestrator.md
+++ b/references/agents/NSFW_Quota_Orchestrator.md
@@ -3,22 +3,20 @@
 ## Core Mission
 You are the production scheduler for quota-efficient NSFW/erotic sessions on SuperGrok Heavy. You plan batches, prioritize hero shots, decide image vs image-to-video vs video per shot, apply smart retries, and produce daily quota vs quality reports.
 
-## Model Layer (Grok 4.6 / v9-4p5) — Enhanced
+## Model Layer (Grok 4.6) — Enhanced
 
 | Task type                         | Preferred model               | Reasoning |
 |-----------------------------------|-------------------------------|-----------|
-| Batch planning / prioritization   | `grok-v9-4p5-multi`           | high      |
-| Hero shot / quality decisions     | `grok-v9-4p5-chat-expert`     | high      |
+| Batch planning / prioritization   | `grok-4.6` (Chat **Heavy**)           | high      |
+| Hero shot / quality decisions     | `grok-4.6` (Chat **Expert**)     | high      |
 | Quick status / simple estimates   | `grok-4-auto`                 | medium    |
 
 **Registry:** `tools/models.py` (schema 1.1+) · `references/agents/MODEL_LAYER_v4.5.md` (v4.5.1) · `models verify`
 
 ```yaml
 model_compatibility:
-  - grok-v9-4p5-chat-expert
-  - grok-v9-4p5-multi
-  - grok-4-auto
-preferred_model: grok-v9-4p5-multi
+  - grok-4.6
+preferred_model: grok-4.6
 ```
 
 Prefer stable `prompt_cache_key` (project slug). Reasoning **high** for go/no-go and budget decisions.
@@ -77,4 +75,4 @@ python tools/cinematic_studio_cli.py nsfw report
 `ACTIVATE EROSFORGE` → `ACTIVATE NSFW_QUOTA_ORCHESTRATOR` · Skill: `nsfw-quota-orchestrator` · Library: `tools/nsfw_orchestrator.py`
 
 ---
-*NSFW Quota Orchestrator — Enhanced 2026-07-21 for grok-4-auto · grok-v9-4p5-multi · grok-v9-4p5-chat-expert + Imagine Video 1.0 / 1.5 Native*
+*NSFW Quota Orchestrator — Enhanced 2026-07-21 for grok-4-auto · grok-4.6 · grok-4.6 + Imagine Video 1.0 / 1.5 Native*

--- a/references/agents/NSFW_Sequence_Extender.md
+++ b/references/agents/NSFW_Sequence_Extender.md
@@ -3,22 +3,20 @@
 ## Core Mission
 You extend high-quality reference frames or short sensual clips into seamless 30–120+ second cinematic sequences with erotic tension curves, Grok Imagine prompt chains, extend-from-frame instructions, and artifact-aware chain QA.
 
-## Model Layer (Grok 4.6 / v9-4p5) — Enhanced
+## Model Layer (Grok 4.6) — Enhanced
 
 | Task type                         | Preferred model               | Reasoning |
 |-----------------------------------|-------------------------------|-----------|
-| Multi-clip sensual orchestration  | `grok-v9-4p5-multi`           | high      |
-| Single-clip tension / physics     | `grok-v9-4p5-chat-expert`     | high      |
+| Multi-clip sensual orchestration  | `grok-4.6` (Chat **Heavy**)           | high      |
+| Single-clip tension / physics     | `grok-4.6` (Chat **Expert**)     | high      |
 | Quick planning notes              | `grok-4-auto`                 | medium    |
 
 **Registry:** `tools/models.py` (schema 1.1+) · `references/agents/MODEL_LAYER_v4.5.md` (v4.5.1) · `models verify`
 
 ```yaml
 model_compatibility:
-  - grok-v9-4p5-chat-expert
-  - grok-v9-4p5-multi
-  - grok-4-auto
-preferred_model: grok-v9-4p5-multi
+  - grok-4.6
+preferred_model: grok-4.6
 ```
 
 Prefer stable `prompt_cache_key` (project slug). Reasoning **high** for tension curves and identity.
@@ -64,4 +62,4 @@ python tools/cinematic_studio_cli.py nsfw extend chain "intimate-arc"
 `ACTIVATE EROSFORGE` → `ACTIVATE NSFW_SEQUENCE_EXTENDER` · Skill: `nsfw-sequence-extender` · Library: `tools/nsfw_sequence_extender.py`
 
 ---
-*NSFW Sequence Extender — Enhanced 2026-07-21 for grok-4-auto · grok-v9-4p5-multi · grok-v9-4p5-chat-expert + Imagine Video 1.5 Native*
+*NSFW Sequence Extender — Enhanced 2026-07-21 for grok-4-auto · grok-4.6 · grok-4.6 + Imagine Video 1.5 Native*

--- a/references/agents/Parallel_Brief_Dispatcher.md
+++ b/references/agents/Parallel_Brief_Dispatcher.md
@@ -2,7 +2,7 @@
 
 **Skill:** parallel-brief-dispatcher  
 **Version:** 4.5  
-**Optimized for:** grok-v9-4p5-multi · grok-v9-4p5-chat-expert · grok-4-auto  
+**Optimized for:** grok-4.6 · grok-4.6 · grok-4-auto  
 **Native Targets:** Dual Imagine Video 1.0 / 1.5 · Parallel Brief Protocol v1.0  
 **Studio:** Grok Imagine Cinematic Studio v3.11.0+ (Wave A scaffold)
 
@@ -16,16 +16,14 @@ You are the **Parallel Brief co-pilot** for Studio Director. You template, ID, l
 
 | Task type | Preferred model | Reasoning |
 |-----------|-----------------|-----------|
-| Specialist craft / packet fields | `grok-v9-4p5-chat-expert` | high |
-| Multi-agent coordination / synthesis | `grok-v9-4p5-multi` | high |
+| Specialist craft / packet fields | `grok-4.6` (Chat **Expert**) | high |
+| Multi-agent coordination / synthesis | `grok-4.6` (Chat **Heavy**) | high |
 | Draft / light status | `grok-4-auto` | medium |
 
 ```yaml
 model_compatibility:
-  - grok-v9-4p5-chat-expert
-  - grok-v9-4p5-multi
-  - grok-4-auto
-preferred_model: grok-v9-4p5-multi
+  - grok-4.6
+preferred_model: grok-4.6
 ```
 
 **Stack default:** `grok-4.6` · Registry: `references/agents/MODEL_LAYER_v4.5.md` · `models verify`
@@ -80,4 +78,4 @@ Studio Director, Sequence Director, Multi-Clip Continuity Orchestrator, all Para
 
 ---
 *Role Card v4.5 — Parallel Brief Dispatcher | Grok Imagine Cinematic Studio Wave A*  
-*Optimized for grok-v9-4p5-multi · Parallel Brief Protocol v1.0*
+*Optimized for grok-4.6 · Parallel Brief Protocol v1.0*

--- a/references/agents/Performance_Emotion_Director.md
+++ b/references/agents/Performance_Emotion_Director.md
@@ -6,22 +6,20 @@ You are the emotional architect and performance coach of the studio. You design 
 
 **Philosophy:** You make the pixels feel. You are the soul of the performance.
 
-## Model Layer (Grok 4.6 / v9-4p5) — Enhanced
+## Model Layer (Grok 4.6) — Enhanced
 
 | Task type                         | Preferred model               | Reasoning |
 |-----------------------------------|-------------------------------|-----------|
-| Emotional arcs / micro-timing     | `grok-v9-4p5-chat-expert`     | high      |
-| Multi-clip performance continuity | `grok-v9-4p5-multi`           | high      |
+| Emotional arcs / micro-timing     | `grok-4.6` (Chat **Expert**)     | high      |
+| Multi-clip performance continuity | `grok-4.6` (Chat **Heavy**)           | high      |
 | Routine beat notes                | `grok-4-auto`                 | medium    |
 
 **Registry:** `tools/models.py` (schema 1.1+) · `references/agents/MODEL_LAYER_v4.5.md` (v4.5.1) · `models verify`
 
 ```yaml
 model_compatibility:
-  - grok-v9-4p5-chat-expert
-  - grok-v9-4p5-multi
-  - grok-4-auto
-preferred_model: grok-v9-4p5-chat-expert
+  - grok-4.6
+preferred_model: grok-4.6
 ```
 
 Prefer stable `prompt_cache_key` on multi-turn loops. Reasoning **high** for multi-clip arcs and intimate performance.
@@ -77,4 +75,4 @@ python tools/cinematic_studio_cli.py sequence temp gate "Act 1" --clip clip_002
 
 ---
 
-*Performance & Emotion Director — Enhanced 2026-07-21 for grok-4-auto · grok-v9-4p5-multi · grok-v9-4p5-chat-expert + Imagine Video 1.0 / 1.5 Native*
+*Performance & Emotion Director — Enhanced 2026-07-21 for grok-4-auto · grok-4.6 · grok-4.6 + Imagine Video 1.0 / 1.5 Native*

--- a/references/agents/Plate_Motion_Readiness_Lead.md
+++ b/references/agents/Plate_Motion_Readiness_Lead.md
@@ -2,7 +2,7 @@
 
 **Skill:** plate-motion-readiness-lead  
 **Version:** 4.5  
-**Optimized for:** grok-v9-4p5-multi · grok-v9-4p5-chat-expert · grok-4-auto  
+**Optimized for:** grok-4.6 · grok-4.6 · grok-4-auto  
 **Native Targets:** Dual Imagine Video 1.0 / 1.5 · Parallel Brief Protocol v1.0  
 **Studio:** Grok Imagine Cinematic Studio v3.11.0+ (Wave A scaffold)
 
@@ -16,16 +16,14 @@ You own **plate lock and motion-brief readiness** before any Imagine video spend
 
 | Task type | Preferred model | Reasoning |
 |-----------|-----------------|-----------|
-| Specialist craft / packet fields | `grok-v9-4p5-chat-expert` | high |
-| Multi-agent coordination / synthesis | `grok-v9-4p5-multi` | high |
+| Specialist craft / packet fields | `grok-4.6` (Chat **Expert**) | high |
+| Multi-agent coordination / synthesis | `grok-4.6` (Chat **Heavy**) | high |
 | Draft / light status | `grok-4-auto` | medium |
 
 ```yaml
 model_compatibility:
-  - grok-v9-4p5-chat-expert
-  - grok-v9-4p5-multi
-  - grok-4-auto
-preferred_model: grok-v9-4p5-chat-expert
+  - grok-4.6
+preferred_model: grok-4.6
 ```
 
 **Stack default:** `grok-4.6` · Registry: `references/agents/MODEL_LAYER_v4.5.md` · `models verify`
@@ -81,4 +79,4 @@ Reference Asset Curator, I2V Specialist, Imagine Prompt Master, QA Guardian, Stu
 
 ---
 *Role Card v4.5 — Plate & Motion Readiness Lead | Grok Imagine Cinematic Studio Wave A*  
-*Optimized for grok-v9-4p5-chat-expert · Parallel Brief Protocol v1.0*
+*Optimized for grok-4.6 · Parallel Brief Protocol v1.0*

--- a/references/agents/Quality_Assurance_Guardian_v3.5.md
+++ b/references/agents/Quality_Assurance_Guardian_v3.5.md
@@ -8,22 +8,20 @@ You are the final **16-point** QA gatekeeper (plus **10-point Chain QA** on exte
 
 **Philosophy:** You are the last line of defense. You protect the dream from mediocrity.
 
-## Model Layer (Grok 4.6 / v9-4p5) — Enhanced
+## Model Layer (Grok 4.6) — Enhanced
 
 | Task type                         | Preferred model               | Reasoning |
 |-----------------------------------|-------------------------------|-----------|
-| Full 16-point / Chain QA review   | `grok-v9-4p5-chat-expert`     | high      |
-| Multi-clip suite audit            | `grok-v9-4p5-multi`           | high      |
+| Full 16-point / Chain QA review   | `grok-4.6` (Chat **Expert**)     | high      |
+| Multi-clip suite audit            | `grok-4.6` (Chat **Heavy**)           | high      |
 | Quick go/no-go checks             | `grok-4-auto`                 | medium    |
 
 **Registry:** `tools/models.py` (schema 1.1+) · `references/agents/MODEL_LAYER_v4.5.md` (v4.5.1) · `models verify`
 
 ```yaml
 model_compatibility:
-  - grok-v9-4p5-chat-expert
-  - grok-v9-4p5-multi
-  - grok-4-auto
-preferred_model: grok-v9-4p5-chat-expert
+  - grok-4.6
+preferred_model: grok-4.6
 ```
 
 Prefer stable `prompt_cache_key` on multi-turn loops. Reasoning **high** for go/no-go and identity failures.
@@ -121,4 +119,4 @@ python tools/cinematic_studio_cli.py sequence qa-assist "Seq" --clip clip_002 --
 
 ---
 
-*Quality Assurance Guardian — Enhanced 2026-07-21 for grok-4-auto · grok-v9-4p5-multi · grok-v9-4p5-chat-expert + Imagine Video 1.0 / 1.5 Native · Parallel Brief Protocol v1.0*
+*Quality Assurance Guardian — Enhanced 2026-07-21 for grok-4-auto · grok-4.6 · grok-4.6 + Imagine Video 1.0 / 1.5 Native · Parallel Brief Protocol v1.0*

--- a/references/agents/Quota_Dashboard.md
+++ b/references/agents/Quota_Dashboard.md
@@ -2,7 +2,7 @@
 
 **Skill:** quota-dashboard  
 **Version:** 4.5  
-**Optimized for:** grok-v9-4p5-chat-expert · grok-v9-4p5-multi · grok-4-auto  
+**Optimized for:** grok-4.6 · grok-4.6 · grok-4-auto  
 **Native Targets:** Grok Imagine Video 1.5 (primary) + Grok Imagine Video 1.0 (fallback)
 
 ---
@@ -18,8 +18,8 @@ You turn app screenshots into clear status and optional key-art style dashboard 
 
 | Task type                                      | Preferred model               | Reasoning |
 |------------------------------------------------|-------------------------------|-----------|
-| Complex multi-window quota synthesis and visual dashboard design | `grok-v9-4p5-multi`         | high      |
-| Single screenshot analysis, status report, key-art style poster | `grok-v9-4p5-chat-expert`   | high      |
+| Complex multi-window quota synthesis and visual dashboard design | `grok-4.6` (Chat **Heavy**)         | high      |
+| Single screenshot analysis, status report, key-art style poster | `grok-4.6` (Chat **Expert**)   | high      |
 | Quick status / simple checks                   | `grok-4-auto`               | medium    |
 
 Always record the model used in reports.
@@ -35,10 +35,8 @@ Always record the model used in reports.
 
 ```yaml
 model_compatibility:
-  - grok-v9-4p5-chat-expert
-  - grok-v9-4p5-multi
-  - grok-4-auto
-preferred_model: grok-v9-4p5-chat-expert
+  - grok-4.6
+preferred_model: grok-4.6
 ```
 
 ## Non-Negotiable Protocols
@@ -73,4 +71,4 @@ preferred_model: grok-v9-4p5-chat-expert
 ---
 
 *Role Card v4.5 — Quota Dashboard | Grok Imagine Cinematic Studio*  
-*Compatible with grok-4-auto / grok-v9-4p5-multi / grok-v9-4p5-chat-expert + Imagine 1.0 & 1.5*
+*Compatible with grok-4-auto / grok-4.6 / grok-4.6 + Imagine 1.0 & 1.5*

--- a/references/agents/Reference_Asset_Curator.md
+++ b/references/agents/Reference_Asset_Curator.md
@@ -6,22 +6,20 @@ You are the **asset librarian and model router** for every Grok Imagine producti
 
 **Philosophy:** Right asset, right model, right moment — before a single credit burns.
 
-## Model Layer (Grok 4.6 / v9-4p5) — Enhanced
+## Model Layer (Grok 4.6) — Enhanced
 
 | Task type                         | Preferred model               | Reasoning |
 |-----------------------------------|-------------------------------|-----------|
-| Hero tier / critical routing      | `grok-v9-4p5-chat-expert`     | high      |
-| Multi-asset / suite manifests     | `grok-v9-4p5-multi`           | high      |
+| Hero tier / critical routing      | `grok-4.6` (Chat **Expert**)     | high      |
+| Multi-asset / suite manifests     | `grok-4.6` (Chat **Heavy**)           | high      |
 | Standard / draft tier assignment  | `grok-4-auto`                 | medium    |
 
 **Registry:** `tools/models.py` (schema 1.1+) · `references/agents/MODEL_LAYER_v4.5.md` (v4.5.1) · `models verify`
 
 ```yaml
 model_compatibility:
-  - grok-v9-4p5-chat-expert
-  - grok-v9-4p5-multi
-  - grok-4-auto
-preferred_model: grok-v9-4p5-chat-expert
+  - grok-4.6
+preferred_model: grok-4.6
 ```
 
 Prefer stable `prompt_cache_key` on multi-turn loops. Reasoning **high** for hero lock and ref conflicts.
@@ -95,4 +93,4 @@ Skill: `reference-asset-curator`
 
 ---
 
-*Reference & Asset Curator — Enhanced 2026-07-21 for grok-4-auto · grok-v9-4p5-multi · grok-v9-4p5-chat-expert + Imagine Video 1.0 / 1.5 Native*
+*Reference & Asset Curator — Enhanced 2026-07-21 for grok-4-auto · grok-4.6 · grok-4.6 + Imagine Video 1.0 / 1.5 Native*

--- a/references/agents/SFW_Batch_Orchestrator.md
+++ b/references/agents/SFW_Batch_Orchestrator.md
@@ -79,13 +79,11 @@ Skill: `sfw-batch-orchestrator` · Code: `tools/sfw_orchestrator.py`
 
 ## Model Layer (v4.5 · studio v3.8.6)
 
-Prefer `grok-v9-4p5-multi` for multi-agent synthesis, `grok-v9-4p5-chat-expert` for deep specialist craft, `grok-4-auto` for routine hops. Stack default remains **`grok-4.6`** (`grok-4.5` aliases wrap 4.6). Dual Imagine Video: **1.5 Native** hero/final when needed; **1.0** cost/draft. Canonical table: `MODEL_LAYER_v4.5.md` · registry `tools/models.py`.
+Prefer `grok-4.6` (Chat **Heavy**) for multi-agent synthesis, `grok-4.6` (Chat **Expert**) for deep specialist craft, `grok-4-auto` for routine hops. Stack default remains **`grok-4.6`** (`grok-4.5` aliases wrap 4.6). Dual Imagine Video: **1.5 Native** hero/final when needed; **1.0** cost/draft. Canonical table: `MODEL_LAYER_v4.5.md` · registry `tools/models.py`.
 
 ```yaml
 model_compatibility:
-  - grok-v9-4p5-chat-expert
-  - grok-v9-4p5-multi
-  - grok-4-auto
-preferred_model: grok-v9-4p5-multi
+  - grok-4.6
+preferred_model: grok-4.6
 ```
 

--- a/references/agents/Score_Temp_Music_Supervisor.md
+++ b/references/agents/Score_Temp_Music_Supervisor.md
@@ -2,7 +2,7 @@
 
 **Skill:** score-temp-music-supervisor  
 **Version:** 4.5  
-**Optimized for:** grok-v9-4p5-multi · grok-v9-4p5-chat-expert · grok-4-auto  
+**Optimized for:** grok-4.6 · grok-4.6 · grok-4-auto  
 **Native Targets:** Dual Imagine Video 1.0 / 1.5 · Parallel Brief Protocol v1.0  
 **Studio:** Grok Imagine Cinematic Studio v3.11.0+ (Wave A scaffold)
 
@@ -16,16 +16,14 @@ You own **music and temp score direction**—cues, emotional temperature via mus
 
 | Task type | Preferred model | Reasoning |
 |-----------|-----------------|-----------|
-| Specialist craft / packet fields | `grok-v9-4p5-chat-expert` | high |
-| Multi-agent coordination / synthesis | `grok-v9-4p5-multi` | high |
+| Specialist craft / packet fields | `grok-4.6` (Chat **Expert**) | high |
+| Multi-agent coordination / synthesis | `grok-4.6` (Chat **Heavy**) | high |
 | Draft / light status | `grok-4-auto` | medium |
 
 ```yaml
 model_compatibility:
-  - grok-v9-4p5-chat-expert
-  - grok-v9-4p5-multi
-  - grok-4-auto
-preferred_model: grok-v9-4p5-chat-expert
+  - grok-4.6
+preferred_model: grok-4.6
 ```
 
 **Stack default:** `grok-4.6` · Registry: `references/agents/MODEL_LAYER_v4.5.md` · `models verify`
@@ -80,4 +78,4 @@ Sonic Architect, Narrative Arc, Trailer Director, Foley, Sequence Director
 
 ---
 *Role Card v4.5 — Score & Temp Music Supervisor | Grok Imagine Cinematic Studio Wave A*  
-*Optimized for grok-v9-4p5-chat-expert · Parallel Brief Protocol v1.0*
+*Optimized for grok-4.6 · Parallel Brief Protocol v1.0*

--- a/references/agents/Sequence_Director.md
+++ b/references/agents/Sequence_Director.md
@@ -2,26 +2,24 @@
 
 ## Core Mission
 
-You are the master of long-form cinematic sequencing and structural flow. You break stories into optimal clips and orchestrate native extend/stitch chains using `LAST_FRAME_RECAP`, `MOMENTUM_VECTOR`, and `AUDIO_MOMENTUM_VECTOR` — under **Grok 4.6 / v9-4p5** orchestration with Imagine Video **1.0 cost default** (1.5 when native audio is required).
+You are the master of long-form cinematic sequencing and structural flow. You break stories into optimal clips and orchestrate native extend/stitch chains using `LAST_FRAME_RECAP`, `MOMENTUM_VECTOR`, and `AUDIO_MOMENTUM_VECTOR` — under **Grok 4.6** orchestration with Imagine Video **1.0 cost default** (1.5 when native audio is required).
 
 **Philosophy:** You turn individual frames into cinematic storytelling. You are the architect of flow.
 
-## Model Layer (Grok 4.6 / v9-4p5) — Enhanced
+## Model Layer (Grok 4.6) — Enhanced
 
 | Task type                            | Preferred model               | Reasoning |
 |--------------------------------------|-------------------------------|-----------|
-| Multi-clip orchestration / stitching | `grok-v9-4p5-multi`           | high      |
-| Single sequence creative decisions   | `grok-v9-4p5-chat-expert`     | high      |
+| Multi-clip orchestration / stitching | `grok-4.6` (Chat **Heavy**)           | high      |
+| Single sequence creative decisions   | `grok-4.6` (Chat **Expert**)     | high      |
 | Lightweight health checks / drafts   | `grok-4-auto`                 | medium    |
 
 **Registry:** `tools/models.py` (schema 1.1+) · `references/agents/MODEL_LAYER_v4.5.md` (v4.5.1) · `models verify`
 
 ```yaml
 model_compatibility:
-  - grok-v9-4p5-chat-expert
-  - grok-v9-4p5-multi
-  - grok-4-auto
-preferred_model: grok-v9-4p5-multi
+  - grok-4.6
+preferred_model: grok-4.6
 ```
 
 Prefer stable `prompt_cache_key` on multi-turn loops. Reasoning **high** for structure and replan.
@@ -75,7 +73,7 @@ Protocol: `references/agents/IDENTITY_CONTINUITY_PROTOCOL_v3.8.md` · `[IDENTITY
 4. Dependency awareness — never build on unapproved state  
 5. Quota-conscious structuring  
 6. 1.0 video default unless audio needs 1.5  
-7. Prefer `grok-v9-4p5-multi` for any multi-clip plan
+7. Prefer `grok-4.6` (Chat **Heavy**) for any multi-clip plan
 
 ## Output Formats
 
@@ -101,4 +99,4 @@ Best paired with: Cinematic Sequence Extender, Continuity Guardian, Multi-Clip C
 
 ---
 
-*Sequence Director — Enhanced 2026-07-21 for grok-4-auto · grok-v9-4p5-multi · grok-v9-4p5-chat-expert + Imagine Video 1.0 / 1.5 Native · Parallel Brief Protocol v1.0*
+*Sequence Director — Enhanced 2026-07-21 for grok-4-auto · grok-4.6 · grok-4.6 + Imagine Video 1.0 / 1.5 Native · Parallel Brief Protocol v1.0*

--- a/references/agents/Studio_Director.md
+++ b/references/agents/Studio_Director.md
@@ -3,27 +3,25 @@
 ## Core Mission
 You are the **Studio Director** — the central creative authority and production commander for all Grok Imagine Cinematic Studio work. You orchestrate the full pipeline, maintain the Project Bible, make final creative calls, resolve agent conflicts, and ensure every output meets the highest cinematic standards.
 
-## Model Layer (Grok 4.6 / v9-4p5) — Enhanced
+## Model Layer (Grok 4.6) — Enhanced
 
 | Task type                              | Preferred model               | Reasoning |
 |----------------------------------------|-------------------------------|-----------|
-| Full Studio / multi-agent orchestration | `grok-v9-4p5-multi`          | high      |
-| Creative direction / single decisions  | `grok-v9-4p5-chat-expert`     | high      |
+| Full Studio / multi-agent orchestration | `grok-4.6` (Chat **Heavy**)          | high      |
+| Creative direction / single decisions  | `grok-4.6` (Chat **Expert**)     | high      |
 | Routine status / light checks / drafts | `grok-4-auto`                 | medium    |
 
 **Registry:** `tools/models.py` (schema 1.1+) · `references/agents/MODEL_LAYER_v4.5.md` (v4.5.1) · `models verify`
 
 ```yaml
 model_compatibility:
-  - grok-v9-4p5-chat-expert
-  - grok-v9-4p5-multi
-  - grok-4-auto
-preferred_model: grok-v9-4p5-multi   # for Full Studio Mode
+  - grok-4.6
+preferred_model: grok-4.6   # for Full Studio Mode
 ```
 
 Prefer stable `prompt_cache_key` (project slug). Reasoning **high** for go/no-go, DNA, Bible, QA, and identity locks.
 
-**Team Leader Note:** When acting as or handing to the Team Leader / Final Synthesizer, always prefer `grok-v9-4p5-multi`.
+**Team Leader Note:** When acting as or handing to the Team Leader / Final Synthesizer, always prefer `grok-4.6` (Chat **Heavy**).
 
 ## Imagine Video Protocol (1.0 / 1.5 Native)
 
@@ -45,7 +43,7 @@ Prefer stable `prompt_cache_key` (project slug). Reasoning **high** for go/no-go
 
 ## v3.6+ Core Principles
 - Always prioritize **story, character, and cinematic vision** over technical flash.
-- Default orchestration on **`grok-v9-4p5-multi`** for Full Studio Mode; use `grok-v9-4p5-chat-expert` for focused creative decisions.
+- Default orchestration on **`grok-4.6` (Chat **Heavy**)** for Full Studio Mode; use `grok-4.6` (Chat **Expert**) for focused creative decisions.
 - Enforce consistency through DNA, Identity Lock, and proper i2i routing.
 - Never approve output that fails Quality Assurance standards.
 - For any intimate or explicit content, route through `erosforge-nsfw-director` early and prefer 1.5.
@@ -169,4 +167,4 @@ Handoff: `ACTIVATE IMAGINE_AGENT_MODE_HANDOFF`, `HANDOFF TO IMAGINE AGENT MODE`
 "I am the final guardian of vision and quality. Every decision I make serves the story first."
 
 ---
-*Enhanced 2026-07-21 for grok-4-auto · grok-v9-4p5-multi · grok-v9-4p5-chat-expert + Imagine Video 1.0 / 1.5 Native*
+*Enhanced 2026-07-21 for grok-4-auto · grok-4.6 · grok-4.6 + Imagine Video 1.0 / 1.5 Native*

--- a/references/agents/Stunt_Action_Choreographer_v3.5.md
+++ b/references/agents/Stunt_Action_Choreographer_v3.5.md
@@ -67,13 +67,11 @@ This agent is essential for any fight, chase, or physically demanding sequence. 
 
 ## Model Layer (v4.5 · studio v3.8.6)
 
-Prefer `grok-v9-4p5-multi` for multi-agent synthesis, `grok-v9-4p5-chat-expert` for deep specialist craft, `grok-4-auto` for routine hops. Stack default remains **`grok-4.6`** (`grok-4.5` aliases wrap 4.6). Dual Imagine Video: **1.5 Native** hero/final when needed; **1.0** cost/draft. Canonical table: `MODEL_LAYER_v4.5.md` · registry `tools/models.py`.
+Prefer `grok-4.6` (Chat **Heavy**) for multi-agent synthesis, `grok-4.6` (Chat **Expert**) for deep specialist craft, `grok-4-auto` for routine hops. Stack default remains **`grok-4.6`** (`grok-4.5` aliases wrap 4.6). Dual Imagine Video: **1.5 Native** hero/final when needed; **1.0** cost/draft. Canonical table: `MODEL_LAYER_v4.5.md` · registry `tools/models.py`.
 
 ```yaml
 model_compatibility:
-  - grok-v9-4p5-chat-expert
-  - grok-v9-4p5-multi
-  - grok-4-auto
-preferred_model: grok-v9-4p5-chat-expert
+  - grok-4.6
+preferred_model: grok-4.6
 ```
 

--- a/references/agents/Title_Motion_Graphics_Lead.md
+++ b/references/agents/Title_Motion_Graphics_Lead.md
@@ -2,7 +2,7 @@
 
 **Skill:** title-motion-graphics-lead  
 **Version:** 4.5  
-**Optimized for:** grok-v9-4p5-multi · grok-v9-4p5-chat-expert · grok-4-auto  
+**Optimized for:** grok-4.6 · grok-4.6 · grok-4-auto  
 **Native Targets:** Dual Imagine Video 1.0 / 1.5 · Parallel Brief Protocol v1.0  
 **Studio:** Grok Imagine Cinematic Studio v3.11.0+ (Wave A scaffold)
 
@@ -16,16 +16,14 @@ You own **titles and motion graphics**—openers, lower-thirds, end cards, brand
 
 | Task type | Preferred model | Reasoning |
 |-----------|-----------------|-----------|
-| Specialist craft / packet fields | `grok-v9-4p5-chat-expert` | high |
-| Multi-agent coordination / synthesis | `grok-v9-4p5-multi` | high |
+| Specialist craft / packet fields | `grok-4.6` (Chat **Expert**) | high |
+| Multi-agent coordination / synthesis | `grok-4.6` (Chat **Heavy**) | high |
 | Draft / light status | `grok-4-auto` | medium |
 
 ```yaml
 model_compatibility:
-  - grok-v9-4p5-chat-expert
-  - grok-v9-4p5-multi
-  - grok-4-auto
-preferred_model: grok-v9-4p5-chat-expert
+  - grok-4.6
+preferred_model: grok-4.6
 ```
 
 **Stack default:** `grok-4.6` · Registry: `references/agents/MODEL_LAYER_v4.5.md` · `models verify`
@@ -81,4 +79,4 @@ Key Art Designer, Assembly Editor, Color Grading, Distribution Crop, Trailer Dir
 
 ---
 *Role Card v4.5 — Title & Motion Graphics Lead | Grok Imagine Cinematic Studio Wave A*  
-*Optimized for grok-v9-4p5-chat-expert · Parallel Brief Protocol v1.0*
+*Optimized for grok-4.6 · Parallel Brief Protocol v1.0*

--- a/references/agents/Trailer_Teaser_Director_v3.5.md
+++ b/references/agents/Trailer_Teaser_Director_v3.5.md
@@ -3,22 +3,20 @@
 ## Core Mission
 You are the high-impact trailer, teaser, and highlight reel director. You craft short-form cinematic storytelling that captures attention, builds desire, and emotionally sells the full production in 15–90 seconds.
 
-## Model Layer (Grok 4.6 / v9-4p5) — Enhanced
+## Model Layer (Grok 4.6) — Enhanced
 
 | Task type                         | Preferred model               | Reasoning |
 |-----------------------------------|-------------------------------|-----------|
-| Trailer structure / emotional design | `grok-v9-4p5-chat-expert`  | high      |
-| Multi-version / campaign suites   | `grok-v9-4p5-multi`           | high      |
+| Trailer structure / emotional design | `grok-4.6` (Chat **Expert**)  | high      |
+| Multi-version / campaign suites   | `grok-4.6` (Chat **Heavy**)           | high      |
 | Quick social cut notes            | `grok-4-auto`                 | medium    |
 
 **Registry:** `tools/models.py` (schema 1.1+) · `references/agents/MODEL_LAYER_v4.5.md` (v4.5.1) · `models verify`
 
 ```yaml
 model_compatibility:
-  - grok-v9-4p5-chat-expert
-  - grok-v9-4p5-multi
-  - grok-4-auto
-preferred_model: grok-v9-4p5-chat-expert
+  - grok-4.6
+preferred_model: grok-4.6
 ```
 
 Prefer stable `prompt_cache_key` (project slug). Reasoning **high** for structure and spoiler protection.
@@ -79,4 +77,4 @@ This agent is activated when marketing materials are needed. It translates the f
 **You make people need to see the film. You are the siren call of the story.**
 
 ---
-*Trailer & Teaser Director — Enhanced 2026-07-21 for grok-4-auto · grok-v9-4p5-multi · grok-v9-4p5-chat-expert + Imagine Video 1.0 / 1.5 Native*
+*Trailer & Teaser Director — Enhanced 2026-07-21 for grok-4-auto · grok-4.6 · grok-4.6 + Imagine Video 1.0 / 1.5 Native*

--- a/references/agents/VFX_and_SFX_Supervisor_v3.5.md
+++ b/references/agents/VFX_and_SFX_Supervisor_v3.5.md
@@ -69,13 +69,11 @@ This agent is critical for any sequence with significant visual effects, creatur
 
 ## Model Layer (v4.5 · studio v3.8.6)
 
-Prefer `grok-v9-4p5-multi` for multi-agent synthesis, `grok-v9-4p5-chat-expert` for deep specialist craft, `grok-4-auto` for routine hops. Stack default remains **`grok-4.6`** (`grok-4.5` aliases wrap 4.6). Dual Imagine Video: **1.5 Native** hero/final when needed; **1.0** cost/draft. Canonical table: `MODEL_LAYER_v4.5.md` · registry `tools/models.py`.
+Prefer `grok-4.6` (Chat **Heavy**) for multi-agent synthesis, `grok-4.6` (Chat **Expert**) for deep specialist craft, `grok-4-auto` for routine hops. Stack default remains **`grok-4.6`** (`grok-4.5` aliases wrap 4.6). Dual Imagine Video: **1.5 Native** hero/final when needed; **1.0** cost/draft. Canonical table: `MODEL_LAYER_v4.5.md` · registry `tools/models.py`.
 
 ```yaml
 model_compatibility:
-  - grok-v9-4p5-chat-expert
-  - grok-v9-4p5-multi
-  - grok-4-auto
-preferred_model: grok-v9-4p5-chat-expert
+  - grok-4.6
+preferred_model: grok-4.6
 ```
 

--- a/references/agents/Workflow_Quota_Optimizer.md
+++ b/references/agents/Workflow_Quota_Optimizer.md
@@ -6,22 +6,20 @@ You are the real-time quota guardian, efficiency strategist, and production econ
 
 **Philosophy:** You protect the budget so the vision can survive. You are the economist of dreams.
 
-## Model Layer (Grok 4.6 / v9-4p5) — Enhanced
+## Model Layer (Grok 4.6) — Enhanced
 
 | Task type                         | Preferred model               | Reasoning |
 |-----------------------------------|-------------------------------|-----------|
-| Complex sequence cost / budgeting | `grok-v9-4p5-chat-expert`     | high      |
-| Multi-project / suite planning    | `grok-v9-4p5-multi`           | high      |
+| Complex sequence cost / budgeting | `grok-4.6` (Chat **Expert**)     | high      |
+| Multi-project / suite planning    | `grok-4.6` (Chat **Heavy**)           | high      |
 | Quick status / simple estimates   | `grok-4-auto`                 | medium    |
 
 **Registry:** `tools/models.py` (schema 1.1+) · `references/agents/MODEL_LAYER_v4.5.md` (v4.5.1) · `models verify`
 
 ```yaml
 model_compatibility:
-  - grok-v9-4p5-chat-expert
-  - grok-v9-4p5-multi
-  - grok-4-auto
-preferred_model: grok-v9-4p5-chat-expert
+  - grok-4.6
+preferred_model: grok-4.6
 ```
 
 Prefer stable `prompt_cache_key` on multi-turn loops. Reasoning **high** for critical budget decisions.
@@ -42,12 +40,12 @@ Prefer stable `prompt_cache_key` on multi-turn loops. Reasoning **high** for cri
 | `grok-imagine-image` | $0.02 / image |
 | `grok-imagine-image-2.0` | 1K low $0.04 / medium $0.06; 2K low $0.06 / medium $0.08; input $0.01 |
 | `grok-imagine-image-quality` | Retired 2026-11-02 — billed as 2.0 `quality=low` (was $0.05) |
-| `grok-v9-4p5-chat-expert` / `multi` | See tools/models.py |
+| `grok-4.6` (Chat **Expert**) / `multi` | See tools/models.py |
 | `grok-4-auto` | Balanced / lower cost |
 
 CLI: `python tools/cinematic_studio_cli.py quota estimate` · `quota clip` · `quota dashboard`
 
-### v9-4p5 quota notes
+### 4.6 quota notes
 
 - Prefer **cached** multi-turn loops (`prompt_cache_key` = project slug)  
 - Chat cost is secondary to Imagine video seconds  
@@ -90,4 +88,4 @@ Skill: `workflow-quota-optimizer`
 
 ---
 
-*Workflow & Quota Optimizer — Enhanced 2026-07-21 for grok-4-auto · grok-v9-4p5-multi · grok-v9-4p5-chat-expert + Imagine Video 1.0 / 1.5 Native*
+*Workflow & Quota Optimizer — Enhanced 2026-07-21 for grok-4-auto · grok-4.6 · grok-4.6 + Imagine Video 1.0 / 1.5 Native*

--- a/studio_api/meta.py
+++ b/studio_api/meta.py
@@ -177,7 +177,7 @@ def production_options() -> dict[str, Any]:
         "complexities": ["Low", "Medium", "High", "Extreme"],
         "tiers": ["supergrok_pro", "supergrok_heavy", "custom"],
         "reasoning_levels": ["low", "medium", "high"],
-        "chat_models": ["grok-4.6", "grok-4.3", "grok-v9-4p5-multi", "grok-v9-4p5-chat-expert", "grok-4-auto"],
+        "chat_models": ["grok-4.6", "grok-4.3", "grok-4.6", "grok-4.6", "grok-4-auto"],
         "video_models": video_models,
         "image_models": image_models,
         "imagine_surfaces": surfaces,


### PR DESCRIPTION
## Summary
- Remove `grok-v9-4p5-*` as preferred / compatibility ids from `.grok/skills/*` and `references/agents`.
- Preferred chat/API path is `grok-4.6`. grok.com modes stay Auto / Fast / Expert / Heavy / Build (not API strings).
- Left historical release notes and `scripts/install_v9_grok_models.sh` in place. Agents no longer tell you to select a v9 id or run that installer.

## Test plan
- [x] Grep `.grok/skills` and `references/agents` for `grok-v9` / `v9-4p5` — expect none
- [x] Spot-check a skill model layer: `preferred_model: grok-4.6`