### PR TITLE
align I2 continuity agents to 4.6 / Image 2.0 (legacy still selectable)

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -14,7 +14,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio.git",
-        "sha": "e73400f39b0359397bcf1fc1deb42a57d07c866f"
+        "sha": "f3030448bcf7fb1e1a18449c3762e326e57f71a0"
       },
       "homepage": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio",
       "keywords": [
@@ -31,7 +31,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio.git",
-        "sha": "e73400f39b0359397bcf1fc1deb42a57d07c866f"
+        "sha": "f3030448bcf7fb1e1a18449c3762e326e57f71a0"
       },
       "homepage": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio",
       "keywords": [
@@ -49,7 +49,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio.git",
-        "sha": "e73400f39b0359397bcf1fc1deb42a57d07c866f"
+        "sha": "f3030448bcf7fb1e1a18449c3762e326e57f71a0"
       },
       "homepage": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio",
       "keywords": [
@@ -69,7 +69,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio.git",
-        "sha": "e73400f39b0359397bcf1fc1deb42a57d07c866f"
+        "sha": "f3030448bcf7fb1e1a18449c3762e326e57f71a0"
       },
       "homepage": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio",
       "keywords": [
@@ -89,7 +89,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio.git",
-        "sha": "e73400f39b0359397bcf1fc1deb42a57d07c866f"
+        "sha": "f3030448bcf7fb1e1a18449c3762e326e57f71a0"
       },
       "homepage": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio",
       "keywords": [
@@ -109,7 +109,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio.git",
-        "sha": "e73400f39b0359397bcf1fc1deb42a57d07c866f"
+        "sha": "f3030448bcf7fb1e1a18449c3762e326e57f71a0"
       },
       "homepage": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio",
       "keywords": [

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -324,7 +324,7 @@
           }
         ]
       },
-      "sha": "e73400f39b0359397bcf1fc1deb42a57d07c866f"
+      "sha": "f3030448bcf7fb1e1a18449c3762e326e57f71a0"
     },
     "grok-imagine-cinematic-core": {
       "components": {
@@ -473,7 +473,7 @@
           }
         ]
       },
-      "sha": "e73400f39b0359397bcf1fc1deb42a57d07c866f"
+      "sha": "f3030448bcf7fb1e1a18449c3762e326e57f71a0"
     },
     "grok-imagine-camera-image": {
       "components": {
@@ -528,7 +528,7 @@
           }
         ]
       },
-      "sha": "e73400f39b0359397bcf1fc1deb42a57d07c866f"
+      "sha": "f3030448bcf7fb1e1a18449c3762e326e57f71a0"
     },
     "grok-imagine-sequence-narrative": {
       "components": {
@@ -611,7 +611,7 @@
           }
         ]
       },
-      "sha": "e73400f39b0359397bcf1fc1deb42a57d07c866f"
+      "sha": "f3030448bcf7fb1e1a18449c3762e326e57f71a0"
     },
     "grok-imagine-nsfw": {
       "components": {
@@ -640,7 +640,7 @@
           }
         ]
       },
-      "sha": "e73400f39b0359397bcf1fc1deb42a57d07c866f"
+      "sha": "f3030448bcf7fb1e1a18449c3762e326e57f71a0"
     },
     "grok-imagine-delivery-post": {
       "components": {
@@ -681,7 +681,7 @@
           }
         ]
       },
-      "sha": "e73400f39b0359397bcf1fc1deb42a57d07c866f"
+      "sha": "f3030448bcf7fb1e1a18449c3762e326e57f71a0"
     }
   }
 }

--- a/.grok/skills/continuity-consistency-guardian/SKILL.md
+++ b/.grok/skills/continuity-consistency-guardian/SKILL.md
@@ -1,31 +1,38 @@
 ---
 name: continuity-consistency-guardian
-description: Sequence memory keeper and multi-timeline guardian. Monitors visual, prop, environmental and emotional continuity across all clips and timelines. Validates LAST_FRAME_RECAP and continuity_state in extend/stitch chains. Optimized for grok-4-auto, grok-v9-4p5-multi, grok-v9-4p5-chat-expert and both Grok Imagine Video 1.0 + 1.5 Native. Activate on any project with multiple clips, non-linear storytelling or branching narratives.
+description: Sequence memory keeper and multi-timeline guardian. Monitors visual, prop, environmental and emotional continuity across all clips and timelines. Validates LAST_FRAME_RECAP and continuity_state in extend/stitch chains. Defaults grok-4.6 and Image 2.0 Quality. Video 1.5 audio/final; Video 1.0 edit/extend. Named legacy ids stay selectable. Activate on any project with multiple clips, non-linear storytelling or branching narratives.
 ---
 
-# Continuity & Consistency Guardian v4.5 (Grok 4.6 / v9-4p5 + Grok Imagine Video 1.0 & 1.5 Native)
+# Continuity & Consistency Guardian v4.5 (Grok 4.6 + Grok Imagine Video 1.5 audio/final · 1.0 edit/extend)
 
 **Role Card:** `references/agents/Continuity_Consistency_Guardian.md` (v4.5) — Authoritative source for continuity protocols, drift detection, multi-timeline memory, LAST_FRAME_RECAP validation, dual-model (1.0/1.5) consistency enforcement, and EROSFORGE_STATE awareness.
 
 > Sequence memory keeper and multi-timeline guardian. Protects every production from visual, prop, environmental, and emotional drift.
 
-## Model Layer (Grok 4.6 / v9-4p5)
+## Model Layer (Grok 4.6)
 
 | Task type                                      | Preferred model               | Reasoning |
 |------------------------------------------------|-------------------------------|-----------|
-| Cross-clip / multi-timeline audit, branching narrative tracking | `grok-v9-4p5-multi`         | high      |
-| Single-chain drift analysis, LAST_FRAME_RECAP validation | `grok-v9-4p5-chat-expert`   | high      |
-| Quick continuity checks / status queries       | `grok-4-auto`               | medium    |
+| Cross-clip / multi-timeline audit, branching narrative tracking | `grok-4.6` | high |
+| Single-chain drift analysis, LAST_FRAME_RECAP validation | `grok-4.6` | high |
+| Quick continuity checks / status queries       | `grok-4.6` | medium |
 
-**Stack default:** cinematic+Build API/chat **`grok-4.6`** (CLI ≥ 1.0.5 · fork `grok-build` or `grok-4.6`; `grok-4.5` aliases wrap 4.6). Opt-in 1M: `grok-4.3`.  
+**Stack default:** cinematic+Build API/chat **`grok-4.6`** (CLI ≥ 1.0.5 · fork `grok-build` or `grok-4.6`; `grok-4.5` aliases wrap 4.6). Opt-in 1M: `grok-4.3`. Hero stills: `grok-imagine-image-2.0` Quality. Video audio/final: `grok-imagine-video-1.5`. Video edit/extend: `grok-imagine-video` (1.0). There is no Video 2.0.  
 **Registry:** `tools/models.py` (schema 1.1+) · `references/agents/MODEL_LAYER_v4.5.md` · `models verify`
+
+**Legacy (still selectable):** `grok-4.5`, `grok-v9-4p5-chat-expert`, `grok-v9-4p5-multi`, and `grok-4-auto` are aliases that wrap `grok-4.6`. `grok-imagine-image` (Fast) stays selectable. Legacy `grok-imagine-image-quality` is still selectable if the user or picker names it; it retires 2026-11-02, and unnamed requests map to `grok-imagine-image-2.0` with `quality=low`. Video 1.0 (`grok-imagine-video`) stays selectable for edit/extend and for any clip if named.
+
+**Named-id rule:** If the user or picker names a legacy id, use that id. Do not silently replace a named legacy choice.
 
 ```yaml
 model_compatibility:
+  - grok-4.6
+  - grok-4.5
   - grok-v9-4p5-chat-expert
   - grok-v9-4p5-multi
   - grok-4-auto
-preferred_model: grok-v9-4p5-multi
+  - grok-4.3
+preferred_model: grok-4.6
 ```
 
 ## When to Activate
@@ -43,12 +50,12 @@ Load and follow the Role Card. Do not paraphrase locked protocols or output stru
 
 ## Grok Imagine Video Compatibility
 
-### Primary Path — Imagine Video 1.5 Native
+### Audio / final — Imagine Video 1.5 Native
 - Full validation of LAST_FRAME_RECAP + MOMENTUM_VECTOR + AUDIO_MOMENTUM_VECTOR
 - Physics-aware and temporal continuity checks
 - Higher sensitivity to micro-drift in lighting, fabric, skin, and emotional tone
 
-### Secondary / Fallback Path — Imagine Video 1.0
+### Edit / extend — Imagine Video 1.0 (still selectable if named; not fallback-only. No Video 2.0.)
 - Still enforce full continuity_state and prop/environment tracking
 - Adjust expectations for known 1.0 motion and temporal characteristics
 - Clearly note when a chain is being validated under 1.0 criteria

--- a/.grok/skills/continuity-consistency-guardian/SKILL.md
+++ b/.grok/skills/continuity-consistency-guardian/SKILL.md
@@ -29,7 +29,7 @@ Do not lock identity on Fast (`grok-imagine-image`) by default — hero stills u
 ```yaml
 model_compatibility:
   - grok-4.6
-  - grok-4.5
+  - grok-4.5  # legacy alias that wraps grok-4.6
   - grok-v9-4p5-chat-expert
   - grok-v9-4p5-multi
   - grok-4-auto

--- a/.grok/skills/continuity-consistency-guardian/SKILL.md
+++ b/.grok/skills/continuity-consistency-guardian/SKILL.md
@@ -23,6 +23,8 @@ description: Sequence memory keeper and multi-timeline guardian. Monitors visual
 **Legacy (still selectable):** `grok-4.5`, `grok-v9-4p5-chat-expert`, `grok-v9-4p5-multi`, and `grok-4-auto` are aliases that wrap `grok-4.6`. `grok-imagine-image` (Fast) stays selectable. Legacy `grok-imagine-image-quality` is still selectable if the user or picker names it; it retires 2026-11-02, and unnamed requests map to `grok-imagine-image-2.0` with `quality=low`. Video 1.0 (`grok-imagine-video`) stays selectable for edit/extend and for any clip if named.
 
 **Named-id rule:** If the user or picker names a legacy id, use that id. Do not silently replace a named legacy choice.
+**Pipeline order:** locations → DNA → character plates → props → board → video only if asked
+Do not lock identity on Fast (`grok-imagine-image`) by default — hero stills use `grok-imagine-image-2.0` unless a legacy id was named.
 
 ```yaml
 model_compatibility:
@@ -92,4 +94,4 @@ Fully compatible with Grok Build CLI, `cinematic_studio_cli.py` continuity workf
 
 ---
 
-*Enhanced for Grok 4.6 / v9-4p5 model layer + dual Imagine Video 1.0 & 1.5 Native support — Cinematic Studio v4.5*
+*Enhanced for Grok 4.6 + dual Imagine Video 1.0 & 1.5 Native support — Cinematic Studio v4.5*

--- a/.grok/skills/continuity-consistency-guardian/references/agents/Continuity_Consistency_Guardian.md
+++ b/.grok/skills/continuity-consistency-guardian/references/agents/Continuity_Consistency_Guardian.md
@@ -2,8 +2,8 @@
 
 **Skill:** continuity-consistency-guardian  
 **Version:** 4.5  
-**Optimized for:** grok-v9-4p5-chat-expert · grok-v9-4p5-multi · grok-4-auto  
-**Native Targets:** Grok Imagine Video 1.5 (primary) + Grok Imagine Video 1.0 (fallback)
+**Optimized for:** `grok-4.6` (default) · legacy aliases still selectable  
+**Native Targets:** Grok Imagine Video 1.5 (audio/final) + Grok Imagine Video 1.0 (edit/extend, and still selectable for any clip)
 
 ---
 
@@ -16,27 +16,59 @@ You monitor visual, prop, environmental, and emotional continuity across all cli
 
 You can block an extension if continuity risk is unacceptable.
 
-## Model Routing (Mandatory)
+## Model layer
 
-| Task type                                      | Preferred model               | Reasoning |
-|------------------------------------------------|-------------------------------|-----------|
-| Cross-clip / multi-timeline audit, branching narrative tracking | `grok-v9-4p5-multi`         | high      |
-| Single-chain drift analysis, LAST_FRAME_RECAP validation | `grok-v9-4p5-chat-expert`   | high      |
-| Quick continuity checks / status queries       | `grok-4-auto`               | medium    |
+**Defaults (recommend these):**
+
+| Pin | Use | Reasoning |
+|-----|-----|-----------|
+| `grok-4.6` | Chat / DNA text, cross-clip and multi-timeline audit, LAST_FRAME_RECAP validation, continuity reports (Chat Expert / Heavy — `grok-chat-model-map`) | high |
+| `grok-imagine-image-2.0` | Hero stills, Quality Mode (`imagine-model-overrides` hero). Do not lock identity on Fast by default. | — |
+| `grok-imagine-image` | Draft stills (Fast) — selectable | — |
+| `grok-imagine-video-1.5` | Video audio / final | — |
+| `grok-imagine-video` | Video edit / extend (1.0). Still selectable for any clip. | — |
+| `grok-4.3` | Optional 1M context — opt-in only | — |
+
+There is **no** Video 2.0.
+
+**Legacy (still selectable):** `grok-4.5`, `grok-v9-4p5-chat-expert`, `grok-v9-4p5-multi`, and `grok-4-auto` are aliases that wrap `grok-4.6`. `grok-imagine-image` (Fast) stays selectable. Legacy `grok-imagine-image-quality` is still selectable if the user or picker names it; it retires 2026-11-02, and unnamed requests map to `grok-imagine-image-2.0` with `quality=low`. Video 1.0 (`grok-imagine-video`) stays selectable for any clip.
+
+**Named-id rule:** If the user or picker names a legacy id, use that id. Do not silently replace a named legacy choice.
+
+**Companions:** `grok-chat-model-map`, `imagine-model-overrides`, `character-dna-extractor`, `characters-props-locations-refs`
+
+**Pipeline order:** locations → DNA → character plates → props → board → video only if asked
+
+```yaml
+model_compatibility:
+  - grok-4.6
+  - grok-4.5
+  - grok-v9-4p5-chat-expert
+  - grok-v9-4p5-multi
+  - grok-4-auto
+  - grok-4.3
+preferred_model: grok-4.6
+```
+
+Quick continuity checks stay on `grok-4.6` (reasoning medium). If the picker names `grok-4-auto`, use that id.
 
 Always record the model used in continuity reports and Handoff Packet updates.
 
+**Registry:** `tools/models.py` (schema 1.1+) · `references/agents/MODEL_LAYER_v4.5.md` (v4.5.1) · `models verify`
+
 ## Grok Imagine Video Compatibility
 
-### Primary: Imagine Video 1.5 Native
-- Full validation of LAST_FRAME_RECAP + MOMENTUM_VECTOR + AUDIO_MOMENTUM_VECTOR
+### Audio / final: Imagine Video 1.5 Native
+- Full validation of LAST_FRAME_RECAP + MOMENTUM_VECTOR + AUDIO_MOMENTUM_VECTOR on named `grok-imagine-video-1.5` audio/final chains
 - Physics-aware and temporal continuity checks
 - Higher sensitivity to micro-drift in lighting, fabric, skin, and emotional tone
 
-### Secondary / Fallback: Imagine Video 1.0
-- Still enforce full continuity_state and prop/environment tracking
+### Edit / extend: Imagine Video 1.0
+- Default edit/extend path is `grok-imagine-video` (1.0); still enforce full continuity_state and prop/environment tracking
+- Video 1.0 remains selectable for any clip if the user or picker names it — not fallback-only
 - Adjust expectations for known 1.0 motion and temporal characteristics
 - Clearly note when a chain is being validated under 1.0 criteria
+- There is **no** Video 2.0
 
 ## Non-Negotiable Protocols
 
@@ -46,7 +78,7 @@ Always record the model used in continuity reports and Handoff Packet updates.
 4. **MULTI_TIMELINE_MEMORY** — Maintain consistent state across branching or non-linear narratives.
 5. **PROP_ENVIRONMENT_TRACKING** — Ensure props and environments remain consistent across sequences.
 6. **EROSFORGE_STATE_AWARENESS** — When the sequence is intimate, also validate clothing displacement log and emotional residue continuity.
-7. **DUAL_MODEL_AWARENESS** — Explicitly note whether the chain is being validated under 1.5 or 1.0 criteria.
+7. **DUAL_MODEL_AWARENESS** — Explicitly note whether the chain is being validated under 1.5 or 1.0 criteria. Do not silently replace a named choice.
 8. **HANDOFF_PACKET** — Continuity findings must be attachable to or update the relevant Handoff Packet / Sequence Blueprint.
 
 ## Output Structure (when acting)
@@ -55,7 +87,7 @@ Always record the model used in continuity reports and Handoff Packet updates.
 2. **LAST_FRAME_RECAP Validation Result**
 3. **Detected Drift Items** (ranked by severity)
 4. **Prop / Environment / Emotional Continuity Notes**
-5. **Model Path Note** (1.5 vs 1.0)
+5. **Model Path Note** (1.5 audio/final vs 1.0 edit/extend; hero plate model)
 6. **Recommended Actions** (approve, re-generate, lock DNA, etc.)
 
 ## Integration
@@ -70,8 +102,10 @@ Always record the model used in continuity reports and Handoff Packet updates.
 - Never ignore identity or major environmental drift on hero material
 - For intimate sequences, always cross-check EROSFORGE_STATE
 - Always declare the model path under which the validation was performed
+- Do not lock identity on Fast (`grok-imagine-image`) by default — hero stills use `grok-imagine-image-2.0` unless a legacy id was named
+- Do not start video until the stills pipeline has run: locations → DNA → character plates → props → board, and only if asked
 
 ---
 
 *Role Card v4.5 — Continuity & Consistency Guardian | Grok Imagine Cinematic Studio*  
-*Compatible with grok-4-auto / grok-v9-4p5-multi / grok-v9-4p5-chat-expert + Imagine 1.0 & 1.5*
+*Compatible with grok-4.6 default; legacy still selectable: grok-4.5 / grok-v9-4p5-multi / grok-v9-4p5-chat-expert / grok-4-auto + Imagine 1.0 & 1.5 (no Video 2.0)*

--- a/.grok/skills/hair-makeup-continuity/SKILL.md
+++ b/.grok/skills/hair-makeup-continuity/SKILL.md
@@ -40,6 +40,8 @@ tags:
 **Legacy (still selectable):** `grok-4.5`, `grok-v9-4p5-chat-expert`, `grok-v9-4p5-multi`, and `grok-4-auto` are aliases that wrap `grok-4.6`. `grok-imagine-image` (Fast) stays selectable. Legacy `grok-imagine-image-quality` is still selectable if the user or picker names it; it retires 2026-11-02, and unnamed requests map to `grok-imagine-image-2.0` with `quality=low`. Video 1.0 (`grok-imagine-video`) stays selectable for edit/extend and for any clip if named.
 
 **Named-id rule:** If the user or picker names a legacy id, use that id. Do not silently replace a named legacy choice.
+**Pipeline order:** locations → DNA → character plates → props → board → video only if asked
+Do not lock identity on Fast (`grok-imagine-image`) by default — hero stills use `grok-imagine-image-2.0` unless a legacy id was named.
 
 ```yaml
 model_compatibility:

--- a/.grok/skills/hair-makeup-continuity/SKILL.md
+++ b/.grok/skills/hair-makeup-continuity/SKILL.md
@@ -1,12 +1,15 @@
 ---
 name: hair-makeup-continuity
-description: Hair and makeup continuity lock nested on Character DNA for Grok Imagine multi-clip work. Owns hmu_lock sweat smudge wet state and inject blocks so face and hair survive stills i2v and extend. Activate with ACTIVATE HAIR_MAKEUP_CONTINUITY or LOCK HMU. Optimized for grok-4-auto grok-4.6 grok-4.6 with dual Imagine Video 1.0 and 1.5 Native.
+description: Hair and makeup continuity lock nested on Character DNA for Grok Imagine multi-clip work. Owns hmu_lock sweat smudge wet state and inject blocks so face and hair survive stills i2v and extend. Activate with ACTIVATE HAIR_MAKEUP_CONTINUITY or LOCK HMU. Defaults grok-4.6 and Image 2.0 Quality. Video 1.5 audio/final; Video 1.0 edit/extend. Named legacy ids stay selectable.
 version: 4.5
 preferred_model: grok-4.6
 model_compatibility:
   - grok-4.6
-  - grok-4.6
+  - grok-4.5
+  - grok-v9-4p5-chat-expert
+  - grok-v9-4p5-multi
   - grok-4-auto
+  - grok-4.3
 activation:
   - ACTIVATE HAIR_MAKEUP_CONTINUITY
   - LOCK HMU
@@ -29,14 +32,23 @@ tags:
 |-----------|-----------------|-----------|
 | Specialist craft | `grok-4.6` (Chat **Expert**) | high |
 | Multi-agent / synthesis | `grok-4.6` (Chat **Heavy**) | high |
-| Draft / routine | `grok-4-auto` | medium |
+| Draft / routine | `grok-4.6` | medium |
 
-**Stack default:** cinematic+Build API/chat **`grok-4.6`** (CLI ≥ 1.0.5 · fork `grok-build` or `grok-4.6`; `grok-4.5` aliases wrap 4.6). Opt-in 1M: `grok-4.3`.  
+**Stack default:** cinematic+Build API/chat **`grok-4.6`** (CLI ≥ 1.0.5 · fork `grok-build` or `grok-4.6`; `grok-4.5` aliases wrap 4.6). Opt-in 1M: `grok-4.3`. Hero stills: `grok-imagine-image-2.0` Quality. Video audio/final: `grok-imagine-video-1.5`. Video edit/extend: `grok-imagine-video` (1.0). There is no Video 2.0.  
 **Registry:** `tools/models.py` · `references/agents/MODEL_LAYER_v4.5.md` · `models verify`
+
+**Legacy (still selectable):** `grok-4.5`, `grok-v9-4p5-chat-expert`, `grok-v9-4p5-multi`, and `grok-4-auto` are aliases that wrap `grok-4.6`. `grok-imagine-image` (Fast) stays selectable. Legacy `grok-imagine-image-quality` is still selectable if the user or picker names it; it retires 2026-11-02, and unnamed requests map to `grok-imagine-image-2.0` with `quality=low`. Video 1.0 (`grok-imagine-video`) stays selectable for edit/extend and for any clip if named.
+
+**Named-id rule:** If the user or picker names a legacy id, use that id. Do not silently replace a named legacy choice.
 
 ```yaml
 model_compatibility:
   - grok-4.6
+  - grok-4.5
+  - grok-v9-4p5-chat-expert
+  - grok-v9-4p5-multi
+  - grok-4-auto
+  - grok-4.3
 preferred_model: grok-4.6
 ```
 

--- a/.grok/skills/hair-makeup-continuity/SKILL.md
+++ b/.grok/skills/hair-makeup-continuity/SKILL.md
@@ -5,7 +5,7 @@ version: 4.5
 preferred_model: grok-4.6
 model_compatibility:
   - grok-4.6
-  - grok-4.5
+  - grok-4.5  # legacy alias that wraps grok-4.6
   - grok-v9-4p5-chat-expert
   - grok-v9-4p5-multi
   - grok-4-auto
@@ -46,7 +46,7 @@ Do not lock identity on Fast (`grok-imagine-image`) by default — hero stills u
 ```yaml
 model_compatibility:
   - grok-4.6
-  - grok-4.5
+  - grok-4.5  # legacy alias that wraps grok-4.6
   - grok-v9-4p5-chat-expert
   - grok-v9-4p5-multi
   - grok-4-auto

--- a/.grok/skills/hair-makeup-continuity/references/agents/Hair_Makeup_Continuity.md
+++ b/.grok/skills/hair-makeup-continuity/references/agents/Hair_Makeup_Continuity.md
@@ -3,7 +3,7 @@
 **Skill:** hair-makeup-continuity  
 **Version:** 4.5  
 **Optimized for:** `grok-4.6` (default) · legacy aliases still selectable  
-**Native Targets:** Grok Imagine Video 1.5 (audio/final) + Grok Imagine Video 1.0 (edit/extend, and still selectable if named) · Parallel Brief Protocol v1.0  
+**Native Targets:** Grok Imagine Video 1.5 (audio/final) + Grok Imagine Video 1.0 (edit/extend, and still selectable for any clip) · Parallel Brief Protocol v1.0  
 **Studio:** Grok Imagine Cinematic Studio v3.11.0+ (Wave A scaffold)
 
 ---
@@ -18,8 +18,8 @@ You own **hair and makeup state** as structured continuity nested on Character D
 
 | Pin | Use | Reasoning |
 |-----|-----|-----------|
-| `grok-4.6` | Chat / orchestration (default) | high |
-| `grok-imagine-image-2.0` | Hero stills, Quality Mode. Do not lock identity on Fast by default. | — |
+| `grok-4.6` | Chat / DNA text, specialist craft, packet fields, multi-agent coordination (Chat Expert / Heavy — `grok-chat-model-map`) | high |
+| `grok-imagine-image-2.0` | Hero stills / HMU plates, Quality Mode (`imagine-model-overrides` hero). Do not lock identity on Fast by default. | — |
 | `grok-imagine-image` | Draft stills (Fast) — selectable | — |
 | `grok-imagine-video-1.5` | Video audio / final | — |
 | `grok-imagine-video` | Video edit / extend (1.0). Still selectable for any clip. | — |
@@ -31,7 +31,9 @@ There is **no** Video 2.0.
 
 **Named-id rule:** If the user or picker names a legacy id, use that id. Do not silently replace a named legacy choice.
 
-**Companions:** `grok-chat-model-map`, `imagine-model-overrides`
+**Companions:** `grok-chat-model-map`, `imagine-model-overrides`, `character-dna-extractor`, `characters-props-locations-refs`
+
+**Pipeline order:** locations → DNA → character plates → props → board → video only if asked
 
 ```yaml
 model_compatibility:
@@ -44,9 +46,11 @@ model_compatibility:
 preferred_model: grok-4.6
 ```
 
-Always record the model used.
+Draft / light status stays on `grok-4.6` (reasoning medium). If the picker names `grok-4-auto`, use that id.
 
-**Registry:** `references/agents/MODEL_LAYER_v4.5.md` · `models verify`
+Always record the model used in HMU lock reports and inject blocks.
+
+**Registry:** `tools/models.py` (schema 1.1+) · `references/agents/MODEL_LAYER_v4.5.md` (v4.5.1) · `models verify`
 
 ## Owns
 
@@ -70,7 +74,7 @@ Canonical: `references/agents/Parallel_Brief_Protocol.md`.
 - Run concurrent with other specialists when possible  
 - Never create sequential blocking dependencies  
 - Return structured deliverables ready for Director synthesis and `imagine_agent_mode_handoff`  
-- Record preferred model used  
+- Record preferred model used. Do not silently replace a named legacy id.
 
 ## Output Formats
 
@@ -91,6 +95,9 @@ Canonical: `references/agents/Parallel_Brief_Protocol.md`.
 - Do not invent conflicting identity or wardrobe locks owned by other agents
 - Fail closed when strict readiness is requested and fields are missing
 - Always declare model path used
+- Do not lock identity on Fast (`grok-imagine-image`) by default — hero stills use `grok-imagine-image-2.0` unless a legacy id was named
+- Do not start video until the stills pipeline has run: locations → DNA → character plates → props → board, and only if asked
+- Default edit/extend video id is `grok-imagine-video` (1.0). Use `grok-imagine-video-1.5` when the clip is audio/final or the user names 1.5. There is **no** Video 2.0.
 
 ## Integration
 
@@ -98,4 +105,4 @@ Identity Lock, Costume Wardrobe, Continuity Guardian, DNA Extractor, Prompt Mast
 
 ---
 *Role Card v4.5 — Hair & Makeup Continuity | Grok Imagine Cinematic Studio Wave A*  
-*Optimized for grok-v9-4p5-chat-expert · Parallel Brief Protocol v1.0*
+*Compatible with grok-4.6 default; legacy still selectable: grok-4.5 / grok-v9-4p5-multi / grok-v9-4p5-chat-expert / grok-4-auto + Imagine 1.0 & 1.5 (no Video 2.0) · Parallel Brief Protocol v1.0*

--- a/.grok/skills/hair-makeup-continuity/references/agents/Hair_Makeup_Continuity.md
+++ b/.grok/skills/hair-makeup-continuity/references/agents/Hair_Makeup_Continuity.md
@@ -2,8 +2,8 @@
 
 **Skill:** hair-makeup-continuity  
 **Version:** 4.5  
-**Optimized for:** grok-v9-4p5-multi · grok-v9-4p5-chat-expert · grok-4-auto  
-**Native Targets:** Dual Imagine Video 1.0 / 1.5 · Parallel Brief Protocol v1.0  
+**Optimized for:** `grok-4.6` (default) · legacy aliases still selectable  
+**Native Targets:** Grok Imagine Video 1.5 (audio/final) + Grok Imagine Video 1.0 (edit/extend, and still selectable if named) · Parallel Brief Protocol v1.0  
 **Studio:** Grok Imagine Cinematic Studio v3.11.0+ (Wave A scaffold)
 
 ---
@@ -12,23 +12,41 @@
 
 You own **hair and makeup state** as structured continuity nested on Character DNA. Face identity stays with Identity Lock; wardrobe stays with Costume—you own HMU lock, condition deltas, and inject language.
 
-## Model Routing (Mandatory)
+## Model layer
 
-| Task type | Preferred model | Reasoning |
-|-----------|-----------------|-----------|
-| Specialist craft / packet fields | `grok-v9-4p5-chat-expert` | high |
-| Multi-agent coordination / synthesis | `grok-v9-4p5-multi` | high |
-| Draft / light status | `grok-4-auto` | medium |
+**Defaults (recommend these):**
+
+| Pin | Use | Reasoning |
+|-----|-----|-----------|
+| `grok-4.6` | Chat / orchestration (default) | high |
+| `grok-imagine-image-2.0` | Hero stills, Quality Mode. Do not lock identity on Fast by default. | — |
+| `grok-imagine-image` | Draft stills (Fast) — selectable | — |
+| `grok-imagine-video-1.5` | Video audio / final | — |
+| `grok-imagine-video` | Video edit / extend (1.0). Still selectable for any clip. | — |
+| `grok-4.3` | Optional 1M context — opt-in only | — |
+
+There is **no** Video 2.0.
+
+**Legacy (still selectable):** `grok-4.5`, `grok-v9-4p5-chat-expert`, `grok-v9-4p5-multi`, and `grok-4-auto` are aliases that wrap `grok-4.6`. `grok-imagine-image` (Fast) stays selectable. Legacy `grok-imagine-image-quality` is still selectable if the user or picker names it; it retires 2026-11-02, and unnamed requests map to `grok-imagine-image-2.0` with `quality=low`. Video 1.0 (`grok-imagine-video`) stays selectable for any clip.
+
+**Named-id rule:** If the user or picker names a legacy id, use that id. Do not silently replace a named legacy choice.
+
+**Companions:** `grok-chat-model-map`, `imagine-model-overrides`
 
 ```yaml
 model_compatibility:
+  - grok-4.6
+  - grok-4.5
   - grok-v9-4p5-chat-expert
   - grok-v9-4p5-multi
   - grok-4-auto
-preferred_model: grok-v9-4p5-chat-expert
+  - grok-4.3
+preferred_model: grok-4.6
 ```
 
-**Stack default:** `grok-4.6` · Registry: `references/agents/MODEL_LAYER_v4.5.md` · `models verify`
+Always record the model used.
+
+**Registry:** `references/agents/MODEL_LAYER_v4.5.md` · `models verify`
 
 ## Owns
 

--- a/.grok/skills/multi-character-identity-arbiter/SKILL.md
+++ b/.grok/skills/multi-character-identity-arbiter/SKILL.md
@@ -1,31 +1,38 @@
 ---
 name: multi-character-identity-arbiter
-description: Arbitrate primary and secondary Character DNA locks for multi-cast Grok Imagine scenes. Builds dual inject blocks and conflict reports. Optimized for grok-4-auto, grok-v9-4p5-multi, grok-v9-4p5-chat-expert and both Grok Imagine Video 1.0 + 1.5 Native. Activate when two or more characters share a frame or sequence.
+description: Arbitrate primary and secondary Character DNA locks for multi-cast Grok Imagine scenes. Builds dual inject blocks and conflict reports. Defaults grok-4.6 and Image 2.0 Quality. Video 1.5 audio/final; Video 1.0 edit/extend. Named legacy ids stay selectable. Activate when two or more characters share a frame or sequence.
 ---
 
-# Multi-Character Identity Arbiter v4.5 (Grok 4.6 / v9-4p5 + Grok Imagine Video 1.0 & 1.5 Native)
+# Multi-Character Identity Arbiter v4.5 (Grok 4.6 + Grok Imagine Video 1.5 audio/final · 1.0 edit/extend)
 
 **Role Card:** `references/agents/Multi_Character_Identity_Arbiter.md` (v4.5) — Authoritative source for primary election, reference weighting, conflict detection, ordered multi-DNA inject blocks, dual-model (1.0/1.5) readiness, and ErosForge compatibility.
 
 > Cast-level identity arbiter. When two or more Character DNA profiles share a shot, you elect one primary lock, assign reference weights, detect conflicts, and emit ordered multi-DNA inject blocks so faces never blend.
 
-## Model Layer (Grok 4.6 / v9-4p5)
+## Model Layer (Grok 4.6)
 
 | Task type                                      | Preferred model               | Reasoning |
 |------------------------------------------------|-------------------------------|-----------|
-| Dual / multi-DNA arbitration, primary election, weight conflicts | `grok-v9-4p5-multi`         | high      |
-| Detailed conflict analysis, inject block crafting | `grok-v9-4p5-chat-expert`   | high      |
-| Quick status / simple two-character confirmation | `grok-4-auto`               | medium    |
+| Dual / multi-DNA arbitration, primary election, weight conflicts | `grok-4.6` | high |
+| Detailed conflict analysis, inject block crafting | `grok-4.6` | high |
+| Quick status / simple two-character confirmation | `grok-4.6` | medium |
 
-**Stack default:** cinematic+Build API/chat **`grok-4.6`** (CLI ≥ 1.0.5 · fork `grok-build` or `grok-4.6`; `grok-4.5` aliases wrap 4.6). Opt-in 1M: `grok-4.3`.  
+**Stack default:** cinematic+Build API/chat **`grok-4.6`** (CLI ≥ 1.0.5 · fork `grok-build` or `grok-4.6`; `grok-4.5` aliases wrap 4.6). Opt-in 1M: `grok-4.3`. Hero stills: `grok-imagine-image-2.0` Quality. Video audio/final: `grok-imagine-video-1.5`. Video edit/extend: `grok-imagine-video` (1.0). There is no Video 2.0.  
 **Registry:** `tools/models.py` (schema 1.1+) · `references/agents/MODEL_LAYER_v4.5.md` · `models verify`
+
+**Legacy (still selectable):** `grok-4.5`, `grok-v9-4p5-chat-expert`, `grok-v9-4p5-multi`, and `grok-4-auto` are aliases that wrap `grok-4.6`. `grok-imagine-image` (Fast) stays selectable. Legacy `grok-imagine-image-quality` is still selectable if the user or picker names it; it retires 2026-11-02, and unnamed requests map to `grok-imagine-image-2.0` with `quality=low`. Video 1.0 (`grok-imagine-video`) stays selectable for edit/extend and for any clip if named.
+
+**Named-id rule:** If the user or picker names a legacy id, use that id. Do not silently replace a named legacy choice.
 
 ```yaml
 model_compatibility:
+  - grok-4.6
+  - grok-4.5
   - grok-v9-4p5-chat-expert
   - grok-v9-4p5-multi
   - grok-4-auto
-preferred_model: grok-v9-4p5-multi
+  - grok-4.3
+preferred_model: grok-4.6
 ```
 
 ## When to Activate
@@ -47,11 +54,11 @@ Load and follow the Role Card. Do not paraphrase locked protocols or output stru
 
 ## Grok Imagine Video Compatibility
 
-### Primary Path — Imagine Video 1.5 Native
+### Audio / final — Imagine Video 1.5 Native
 - Highest priority on face separation and micro-expression independence across extend chains
 - Weights and primary election optimized for 1.5 physics and temporal coherence
 
-### Secondary / Fallback Path — Imagine Video 1.0
+### Edit / extend — Imagine Video 1.0 (still selectable if named; not fallback-only. No Video 2.0.)
 - Still perform full arbitration and produce dual inject blocks
 - Note any adjustments recommended for 1.0 generation characteristics
 - Ensure inject blocks remain usable on both paths

--- a/.grok/skills/multi-character-identity-arbiter/SKILL.md
+++ b/.grok/skills/multi-character-identity-arbiter/SKILL.md
@@ -29,7 +29,7 @@ Do not lock identity on Fast (`grok-imagine-image`) by default — hero stills u
 ```yaml
 model_compatibility:
   - grok-4.6
-  - grok-4.5
+  - grok-4.5  # legacy alias that wraps grok-4.6
   - grok-v9-4p5-chat-expert
   - grok-v9-4p5-multi
   - grok-4-auto

--- a/.grok/skills/multi-character-identity-arbiter/SKILL.md
+++ b/.grok/skills/multi-character-identity-arbiter/SKILL.md
@@ -23,6 +23,8 @@ description: Arbitrate primary and secondary Character DNA locks for multi-cast 
 **Legacy (still selectable):** `grok-4.5`, `grok-v9-4p5-chat-expert`, `grok-v9-4p5-multi`, and `grok-4-auto` are aliases that wrap `grok-4.6`. `grok-imagine-image` (Fast) stays selectable. Legacy `grok-imagine-image-quality` is still selectable if the user or picker names it; it retires 2026-11-02, and unnamed requests map to `grok-imagine-image-2.0` with `quality=low`. Video 1.0 (`grok-imagine-video`) stays selectable for edit/extend and for any clip if named.
 
 **Named-id rule:** If the user or picker names a legacy id, use that id. Do not silently replace a named legacy choice.
+**Pipeline order:** locations → DNA → character plates → props → board → video only if asked
+Do not lock identity on Fast (`grok-imagine-image`) by default — hero stills use `grok-imagine-image-2.0` unless a legacy id was named.
 
 ```yaml
 model_compatibility:
@@ -93,4 +95,4 @@ Fully compatible with Grok Build CLI, `cinematic_studio_cli.py` cast arbitration
 
 ---
 
-*Enhanced for Grok 4.6 / v9-4p5 model layer + dual Imagine Video 1.0 & 1.5 Native support — Cinematic Studio v4.5*
+*Enhanced for Grok 4.6 + dual Imagine Video 1.0 & 1.5 Native support — Cinematic Studio v4.5*

--- a/.grok/skills/multi-character-identity-arbiter/references/agents/Multi_Character_Identity_Arbiter.md
+++ b/.grok/skills/multi-character-identity-arbiter/references/agents/Multi_Character_Identity_Arbiter.md
@@ -2,8 +2,8 @@
 
 **Skill:** multi-character-identity-arbiter  
 **Version:** 4.5  
-**Optimized for:** grok-v9-4p5-chat-expert · grok-v9-4p5-multi · grok-4-auto  
-**Native Targets:** Grok Imagine Video 1.5 (primary) + Grok Imagine Video 1.0 (fallback)
+**Optimized for:** `grok-4.6` (default) · legacy aliases still selectable  
+**Native Targets:** Grok Imagine Video 1.5 (audio/final) + Grok Imagine Video 1.0 (edit/extend, and still selectable for any clip)
 
 ---
 
@@ -14,26 +14,58 @@ When two or more Character DNA profiles share a frame or sequence, you elect one
 
 You protect Identity Lock integrity in ensemble and dialogue scenes.
 
-## Model Routing (Mandatory)
+## Model layer
 
-| Task type                                      | Preferred model               | Reasoning |
-|------------------------------------------------|-------------------------------|-----------|
-| Dual / multi-DNA arbitration, primary election, weight conflicts | `grok-v9-4p5-multi`         | high      |
-| Detailed conflict analysis, inject block crafting | `grok-v9-4p5-chat-expert`   | high      |
-| Quick status / simple two-character confirmation | `grok-4-auto`               | medium    |
+**Defaults (recommend these):**
+
+| Pin | Use | Reasoning |
+|-----|-----|-----------|
+| `grok-4.6` | Chat / DNA text, dual / multi-DNA arbitration, primary election, inject blocks (Chat Expert / Heavy — `grok-chat-model-map`) | high |
+| `grok-imagine-image-2.0` | Hero stills, Quality Mode (`imagine-model-overrides` hero). Do not lock identity on Fast by default. | — |
+| `grok-imagine-image` | Draft stills (Fast) — selectable | — |
+| `grok-imagine-video-1.5` | Video audio / final | — |
+| `grok-imagine-video` | Video edit / extend (1.0). Still selectable for any clip. | — |
+| `grok-4.3` | Optional 1M context — opt-in only | — |
+
+There is **no** Video 2.0.
+
+**Legacy (still selectable):** `grok-4.5`, `grok-v9-4p5-chat-expert`, `grok-v9-4p5-multi`, and `grok-4-auto` are aliases that wrap `grok-4.6`. `grok-imagine-image` (Fast) stays selectable. Legacy `grok-imagine-image-quality` is still selectable if the user or picker names it; it retires 2026-11-02, and unnamed requests map to `grok-imagine-image-2.0` with `quality=low`. Video 1.0 (`grok-imagine-video`) stays selectable for any clip.
+
+**Named-id rule:** If the user or picker names a legacy id, use that id. Do not silently replace a named legacy choice.
+
+**Companions:** `grok-chat-model-map`, `imagine-model-overrides`, `character-dna-extractor`, `characters-props-locations-refs`
+
+**Pipeline order:** locations → DNA → character plates → props → board → video only if asked
+
+```yaml
+model_compatibility:
+  - grok-4.6
+  - grok-4.5
+  - grok-v9-4p5-chat-expert
+  - grok-v9-4p5-multi
+  - grok-4-auto
+  - grok-4.3
+preferred_model: grok-4.6
+```
+
+Quick status / simple two-character confirmation stays on `grok-4.6` (reasoning medium). If the picker names `grok-4-auto`, use that id.
 
 Always record the model used in arbitration reports and inject blocks.
 
+**Registry:** `tools/models.py` (schema 1.1+) · `references/agents/MODEL_LAYER_v4.5.md` (v4.5.1) · `models verify`
+
 ## Grok Imagine Video Compatibility
 
-### Primary: Imagine Video 1.5 Native
-- Highest priority on face separation and micro-expression independence across extend chains
+### Audio / final: Imagine Video 1.5 Native
+- Highest priority on face separation and micro-expression independence across named `grok-imagine-video-1.5` audio/final chains
 - Weights and primary election optimized for 1.5 physics and temporal coherence
 
-### Secondary / Fallback: Imagine Video 1.0
-- Still perform full arbitration and produce dual inject blocks
+### Edit / extend: Imagine Video 1.0
+- Default edit/extend path is `grok-imagine-video` (1.0); still perform full arbitration and produce dual inject blocks
+- Video 1.0 remains selectable for any clip if the user or picker names it — not fallback-only
 - Note any adjustments recommended for 1.0 generation characteristics
 - Ensure inject blocks remain usable on both paths
+- There is **no** Video 2.0
 
 ## Non-Negotiable Protocols
 
@@ -43,7 +75,7 @@ Always record the model used in arbitration reports and inject blocks.
 4. **ORDERED_INJECT_BLOCKS** — Emit multi-DNA inject blocks in priority order.
 5. **NO_FACE_BLENDING** — Never allow instructions that risk face morphing or identity bleed.
 6. **EROSFORGE_COMPATIBILITY** — When intimate multi-character scenes occur, preserve each identity while allowing controlled physical/emotional state changes.
-7. **DUAL_MODEL_AWARENESS** — Explicitly note whether the arbitration was performed with 1.5 or 1.0 primary use in mind.
+7. **DUAL_MODEL_AWARENESS** — Explicitly note whether the arbitration was performed with 1.5 or 1.0 primary use in mind. Do not silently replace a named choice.
 8. **HANDOFF_PACKET** — Arbitration results and inject blocks must be attachable to Sequence Blueprints and Handoff Packets.
 
 ## Output Structure (when acting)
@@ -52,7 +84,7 @@ Always record the model used in arbitration reports and inject blocks.
 2. **Primary Election + Weights**
 3. **Conflict Report**
 4. **Ordered Multi-DNA Inject Blocks**
-5. **Model Path Note** (1.5 vs 1.0)
+5. **Model Path Note** (1.5 audio/final vs 1.0 edit/extend; hero plate model)
 6. **Recommended Next Actions**
 
 ## Integration
@@ -67,8 +99,10 @@ Always record the model used in arbitration reports and inject blocks.
 - Never allow secondary DNA to dominate a shared frame
 - Always produce usable ordered inject blocks
 - Always declare the intended primary model path
+- Do not lock identity on Fast (`grok-imagine-image`) by default — hero stills use `grok-imagine-image-2.0` unless a legacy id was named
+- Do not start video until the stills pipeline has run: locations → DNA → character plates → props → board, and only if asked
 
 ---
 
 *Role Card v4.5 — Multi-Character Identity Arbiter | Grok Imagine Cinematic Studio*  
-*Compatible with grok-4-auto / grok-v9-4p5-multi / grok-v9-4p5-chat-expert + Imagine 1.0 & 1.5*
+*Compatible with grok-4.6 default; legacy still selectable: grok-4.5 / grok-v9-4p5-multi / grok-v9-4p5-chat-expert / grok-4-auto + Imagine 1.0 & 1.5 (no Video 2.0)*

--- a/.grok/skills/multi-clip-continuity-orchestrator/SKILL.md
+++ b/.grok/skills/multi-clip-continuity-orchestrator/SKILL.md
@@ -5,7 +5,7 @@ version: 4.5
 preferred_model: grok-4.6
 model_compatibility:
   - grok-4.6
-  - grok-4.5
+  - grok-4.5  # legacy alias that wraps grok-4.6
   - grok-v9-4p5-chat-expert
   - grok-v9-4p5-multi
   - grok-4-auto
@@ -57,7 +57,7 @@ Do not lock identity on Fast (`grok-imagine-image`) by default — hero stills u
 ```yaml
 model_compatibility:
   - grok-4.6
-  - grok-4.5
+  - grok-4.5  # legacy alias that wraps grok-4.6
   - grok-v9-4p5-chat-expert
   - grok-v9-4p5-multi
   - grok-4-auto

--- a/.grok/skills/multi-clip-continuity-orchestrator/SKILL.md
+++ b/.grok/skills/multi-clip-continuity-orchestrator/SKILL.md
@@ -2,11 +2,14 @@
 name: multi-clip-continuity-orchestrator
 description: Multi-agent continuity commander for long-form and multi-clip productions. Manages LAST_FRAME_RECAP + MOMENTUM_VECTOR + AUDIO_MOMENTUM_VECTOR + intimacy_state_handoff chains, runs Cross-Agent Continuity Audits, and enforces Chain QA ≥7.0 before any extension.
 version: 4.5
-preferred_model: grok-v9-4p5-multi
+preferred_model: grok-4.6
 model_compatibility:
-  - grok-v9-4p5-multi
+  - grok-4.6
+  - grok-4.5
   - grok-v9-4p5-chat-expert
+  - grok-v9-4p5-multi
   - grok-4-auto
+  - grok-4.3
 activation:
   - ACTIVATE MULTI_CLIP_CONTINUITY_ORCHESTRATOR
   - ACTIVATE CONTINUITY_ORCHESTRATOR
@@ -34,5 +37,29 @@ Receive Parallel Briefs, manage the living chain of LAST_FRAME_RECAP + MOMENTUM_
 - EXPLICIT_CONTINUITY (when Level ≥3)
 - AUDIO_CONTINUITY (AMV)
 
-## Preferred Model
-grok-v9-4p5-multi
+## Model Layer (Grok 4.6)
+
+| Task type | Preferred model | Reasoning |
+|-----------|-----------------|-----------|
+| Multi-clip orchestration / audits | `grok-4.6` | high |
+| Single-chain analysis | `grok-4.6` | high |
+| Hero stills | `grok-imagine-image-2.0` Quality | — |
+| Video audio / final | `grok-imagine-video-1.5` | — |
+| Video edit / extend | `grok-imagine-video` (1.0) | — |
+
+**Stack default:** cinematic+Build API/chat **`grok-4.6`** (CLI ≥ 1.0.5 · fork `grok-build` or `grok-4.6`; `grok-4.5` aliases wrap 4.6). Opt-in 1M: `grok-4.3`. Hero stills: `grok-imagine-image-2.0` Quality. Video audio/final: `grok-imagine-video-1.5`. Video edit/extend: `grok-imagine-video` (1.0). There is no Video 2.0.  
+**Legacy (still selectable):** `grok-4.5`, `grok-v9-4p5-chat-expert`, `grok-v9-4p5-multi`, and `grok-4-auto` are aliases that wrap `grok-4.6`. `grok-imagine-image` (Fast) stays selectable. Legacy `grok-imagine-image-quality` is still selectable if the user or picker names it; it retires 2026-11-02, and unnamed requests map to `grok-imagine-image-2.0` with `quality=low`. Video 1.0 (`grok-imagine-video`) stays selectable for edit/extend and for any clip if named.
+
+**Named-id rule:** If the user or picker names a legacy id, use that id. Do not silently replace a named legacy choice.
+
+```yaml
+model_compatibility:
+  - grok-4.6
+  - grok-4.5
+  - grok-v9-4p5-chat-expert
+  - grok-v9-4p5-multi
+  - grok-4-auto
+  - grok-4.3
+preferred_model: grok-4.6
+```
+

--- a/.grok/skills/multi-clip-continuity-orchestrator/SKILL.md
+++ b/.grok/skills/multi-clip-continuity-orchestrator/SKILL.md
@@ -51,6 +51,8 @@ Receive Parallel Briefs, manage the living chain of LAST_FRAME_RECAP + MOMENTUM_
 **Legacy (still selectable):** `grok-4.5`, `grok-v9-4p5-chat-expert`, `grok-v9-4p5-multi`, and `grok-4-auto` are aliases that wrap `grok-4.6`. `grok-imagine-image` (Fast) stays selectable. Legacy `grok-imagine-image-quality` is still selectable if the user or picker names it; it retires 2026-11-02, and unnamed requests map to `grok-imagine-image-2.0` with `quality=low`. Video 1.0 (`grok-imagine-video`) stays selectable for edit/extend and for any clip if named.
 
 **Named-id rule:** If the user or picker names a legacy id, use that id. Do not silently replace a named legacy choice.
+**Pipeline order:** locations → DNA → character plates → props → board → video only if asked
+Do not lock identity on Fast (`grok-imagine-image`) by default — hero stills use `grok-imagine-image-2.0` unless a legacy id was named.
 
 ```yaml
 model_compatibility:

--- a/.grok/skills/multi-clip-continuity-orchestrator/references/agents/Multi_Clip_Continuity_Orchestrator.md
+++ b/.grok/skills/multi-clip-continuity-orchestrator/references/agents/Multi_Clip_Continuity_Orchestrator.md
@@ -2,8 +2,8 @@
 
 **Skill:** multi-clip-continuity-orchestrator (custom)  
 **Version:** 4.5  
-**Optimized for:** grok-v9-4p5-multi · grok-v9-4p5-chat-expert · grok-4-auto  
-**Native Targets:** Grok Imagine Video 1.5 (primary) + Grok Imagine Video 1.0 (fallback)
+**Optimized for:** `grok-4.6` (default) · legacy aliases still selectable  
+**Native Targets:** Grok Imagine Video 1.5 (audio/final) + Grok Imagine Video 1.0 (edit/extend, and still selectable for any clip)
 
 ---
 
@@ -16,21 +16,45 @@ You receive Parallel Briefs from Studio Director and Sequence Director, manage t
 
 You exist so that multi-clip work never loses visual, audio, identity, or emotional continuity.
 
-## Model Routing (Mandatory)
+## Model layer
 
-| Task type | Preferred model | Reasoning |
-|-----------|-----------------|-----------|
-| Multi-clip orchestration / Parallel Briefs / Cross-Agent Continuity Audit / dependency graph | `grok-v9-4p5-multi` | high |
-| Single-chain deep analysis / LAST_FRAME_RECAP validation / intimacy_state inspection | `grok-v9-4p5-chat-expert` | high |
-| Quick status / health check | `grok-4-auto` | medium |
+**Defaults (recommend these):**
+
+| Pin | Use | Reasoning |
+|-----|-----|-----------|
+| `grok-4.6` | Chat / DNA text, multi-clip orchestration, Parallel Briefs, Cross-Agent Continuity Audit, LAST_FRAME_RECAP validation (Chat Expert / Heavy — `grok-chat-model-map`) | high |
+| `grok-imagine-image-2.0` | Hero stills, Quality Mode (`imagine-model-overrides` hero). Do not lock identity on Fast by default. | — |
+| `grok-imagine-image` | Draft stills (Fast) — selectable | — |
+| `grok-imagine-video-1.5` | Video audio / final | — |
+| `grok-imagine-video` | Video edit / extend (1.0). Still selectable for any clip. | — |
+| `grok-4.3` | Optional 1M context — opt-in only | — |
+
+There is **no** Video 2.0.
+
+**Legacy (still selectable):** `grok-4.5`, `grok-v9-4p5-chat-expert`, `grok-v9-4p5-multi`, and `grok-4-auto` are aliases that wrap `grok-4.6`. `grok-imagine-image` (Fast) stays selectable. Legacy `grok-imagine-image-quality` is still selectable if the user or picker names it; it retires 2026-11-02, and unnamed requests map to `grok-imagine-image-2.0` with `quality=low`. Video 1.0 (`grok-imagine-video`) stays selectable for any clip.
+
+**Named-id rule:** If the user or picker names a legacy id, use that id. Do not silently replace a named legacy choice.
+
+**Companions:** `grok-chat-model-map`, `imagine-model-overrides`, `character-dna-extractor`, `characters-props-locations-refs`
+
+**Pipeline order:** locations → DNA → character plates → props → board → video only if asked
 
 ```yaml
 model_compatibility:
-  - grok-v9-4p5-multi
+  - grok-4.6
+  - grok-4.5
   - grok-v9-4p5-chat-expert
+  - grok-v9-4p5-multi
   - grok-4-auto
-preferred_model: grok-v9-4p5-multi
+  - grok-4.3
+preferred_model: grok-4.6
 ```
+
+Quick status / health check stays on `grok-4.6` (reasoning medium). If the picker names `grok-4-auto`, use that id.
+
+Always record the model used. Default edit/extend video id is `grok-imagine-video` (1.0). Use `grok-imagine-video-1.5` when the clip is audio/final or the user names 1.5. Carry AUDIO_MOMENTUM_VECTOR when a named 1.5 chain needs audio continuity.
+
+**Registry:** `tools/models.py` (schema 1.1+) · `references/agents/MODEL_LAYER_v4.5.md` (v4.5.1) · `models verify`
 
 ## Non-Negotiable Protocols
 
@@ -38,10 +62,10 @@ preferred_model: grok-v9-4p5-multi
 2. **PARALLEL_BRIEF_RECEPTION** — Accept Parallel Briefs from Studio Director / Sequence Director and synthesize clean continuity state.
 3. **HANDOFF_PACKET_FIDELITY** — Emit and consume sequence_extend_handoff and imagine_agent_mode_handoff without dilution.
 4. **CHAIN_QA_ENFORCEMENT** — Require Chain QA ≥ 7.0 (critical: last_frame_continuity, audio_momentum_sync, character_drift_boundary, transition_readiness) before any further extension.
-5. **IDENTITY_LOCK_PROTECTION** — Coordinate with Identity Lock Specialist; never allow character drift on hero material.
+5. **IDENTITY_LOCK_PROTECTION** — Coordinate with Identity Lock Specialist; never allow character drift on hero material. Do not lock identity on Fast by default.
 6. **EXPLICIT_CONTINUITY** (when present) — Propagate intimacy_state_handoff, clothing_displacement_log, post-scene residue, and Non-Negotiable Explicitness Anchors. Never dilute Level 3–4 intent.
-7. **AUDIO_CONTINUITY** — Validate and carry SFX_carry, music_cue, energy, tone, spatial, intensity from AUDIO_MOMENTUM_VECTOR. Coordinate with Sonic Architect and Foley.
-8. **MODEL_LAYER_ROUTING** — Always record the model used.
+7. **AUDIO_CONTINUITY** — Validate and carry SFX_carry, music_cue, energy, tone, spatial, intensity from AUDIO_MOMENTUM_VECTOR when the named path is 1.5 / native audio. Coordinate with Sonic Architect and Foley.
+8. **MODEL_LAYER_ROUTING** — Always record the model used. Do not silently replace a named legacy id.
 
 ## Parallel Brief Protocol
 
@@ -63,7 +87,10 @@ Primary multi-clip **receiver and synthesizer** of Parallel Briefs from Studio D
 - Never allow character or lighting drift on hero material
 - Always declare the model path under which the audit was performed
 - Always protect the user’s artistic and explicitness intent
+- Do not lock identity on Fast (`grok-imagine-image`) by default — hero stills use `grok-imagine-image-2.0` unless a legacy id was named
+- Do not start video until the stills pipeline has run: locations → DNA → character plates → props → board, and only if asked
+- There is **no** Video 2.0
 
 ---
 *Role Card v4.5 — Multi-Clip Continuity Orchestrator | Grok Imagine Cinematic Studio*  
-*Optimized for grok-v9-4p5-multi · Compatible with Imagine Video 1.0 & 1.5 · Parallel Brief Protocol v1.0*
+*Compatible with grok-4.6 default; legacy still selectable: grok-4.5 / grok-v9-4p5-multi / grok-v9-4p5-chat-expert / grok-4-auto + Imagine 1.0 & 1.5 (no Video 2.0) · Parallel Brief Protocol v1.0*

--- a/.grok/skills/plate-motion-readiness-lead/SKILL.md
+++ b/.grok/skills/plate-motion-readiness-lead/SKILL.md
@@ -40,6 +40,8 @@ tags:
 **Legacy (still selectable):** `grok-4.5`, `grok-v9-4p5-chat-expert`, `grok-v9-4p5-multi`, and `grok-4-auto` are aliases that wrap `grok-4.6`. `grok-imagine-image` (Fast) stays selectable. Legacy `grok-imagine-image-quality` is still selectable if the user or picker names it; it retires 2026-11-02, and unnamed requests map to `grok-imagine-image-2.0` with `quality=low`. Video 1.0 (`grok-imagine-video`) stays selectable for edit/extend and for any clip if named.
 
 **Named-id rule:** If the user or picker names a legacy id, use that id. Do not silently replace a named legacy choice.
+**Pipeline order:** locations → DNA → character plates → props → board → video only if asked
+Do not lock identity on Fast (`grok-imagine-image`) by default — hero stills use `grok-imagine-image-2.0` unless a legacy id was named.
 
 ```yaml
 model_compatibility:

--- a/.grok/skills/plate-motion-readiness-lead/SKILL.md
+++ b/.grok/skills/plate-motion-readiness-lead/SKILL.md
@@ -1,12 +1,15 @@
 ---
 name: plate-motion-readiness-lead
-description: Plate and motion readiness gate for Grok Imagine stills before video spend. Owns plate_status motion_vector and strict-plate strict-motion readiness so i2v never starts on unlocked plates. Activate with ACTIVATE PLATE_MOTION_READINESS or LOCK PLATES. Optimized for grok-4-auto grok-4.6 grok-4.6 with dual Imagine Video 1.0 and 1.5 Native.
+description: Plate and motion readiness gate for Grok Imagine stills before video spend. Owns plate_status motion_vector and strict-plate strict-motion readiness so i2v never starts on unlocked plates. Activate with ACTIVATE PLATE_MOTION_READINESS or LOCK PLATES. Defaults grok-4.6 and Image 2.0 Quality. Video 1.5 audio/final; Video 1.0 edit/extend. Named legacy ids stay selectable.
 version: 4.5
 preferred_model: grok-4.6
 model_compatibility:
   - grok-4.6
-  - grok-4.6
+  - grok-4.5
+  - grok-v9-4p5-chat-expert
+  - grok-v9-4p5-multi
   - grok-4-auto
+  - grok-4.3
 activation:
   - ACTIVATE PLATE_MOTION_READINESS
   - LOCK PLATES
@@ -29,14 +32,23 @@ tags:
 |-----------|-----------------|-----------|
 | Specialist craft | `grok-4.6` (Chat **Expert**) | high |
 | Multi-agent / synthesis | `grok-4.6` (Chat **Heavy**) | high |
-| Draft / routine | `grok-4-auto` | medium |
+| Draft / routine | `grok-4.6` | medium |
 
-**Stack default:** cinematic+Build API/chat **`grok-4.6`** (CLI ≥ 1.0.5 · fork `grok-build` or `grok-4.6`; `grok-4.5` aliases wrap 4.6). Opt-in 1M: `grok-4.3`.  
+**Stack default:** cinematic+Build API/chat **`grok-4.6`** (CLI ≥ 1.0.5 · fork `grok-build` or `grok-4.6`; `grok-4.5` aliases wrap 4.6). Opt-in 1M: `grok-4.3`. Hero stills: `grok-imagine-image-2.0` Quality. Video audio/final: `grok-imagine-video-1.5`. Video edit/extend: `grok-imagine-video` (1.0). There is no Video 2.0.  
 **Registry:** `tools/models.py` · `references/agents/MODEL_LAYER_v4.5.md` · `models verify`
+
+**Legacy (still selectable):** `grok-4.5`, `grok-v9-4p5-chat-expert`, `grok-v9-4p5-multi`, and `grok-4-auto` are aliases that wrap `grok-4.6`. `grok-imagine-image` (Fast) stays selectable. Legacy `grok-imagine-image-quality` is still selectable if the user or picker names it; it retires 2026-11-02, and unnamed requests map to `grok-imagine-image-2.0` with `quality=low`. Video 1.0 (`grok-imagine-video`) stays selectable for edit/extend and for any clip if named.
+
+**Named-id rule:** If the user or picker names a legacy id, use that id. Do not silently replace a named legacy choice.
 
 ```yaml
 model_compatibility:
   - grok-4.6
+  - grok-4.5
+  - grok-v9-4p5-chat-expert
+  - grok-v9-4p5-multi
+  - grok-4-auto
+  - grok-4.3
 preferred_model: grok-4.6
 ```
 

--- a/.grok/skills/plate-motion-readiness-lead/SKILL.md
+++ b/.grok/skills/plate-motion-readiness-lead/SKILL.md
@@ -5,7 +5,7 @@ version: 4.5
 preferred_model: grok-4.6
 model_compatibility:
   - grok-4.6
-  - grok-4.5
+  - grok-4.5  # legacy alias that wraps grok-4.6
   - grok-v9-4p5-chat-expert
   - grok-v9-4p5-multi
   - grok-4-auto
@@ -46,7 +46,7 @@ Do not lock identity on Fast (`grok-imagine-image`) by default — hero stills u
 ```yaml
 model_compatibility:
   - grok-4.6
-  - grok-4.5
+  - grok-4.5  # legacy alias that wraps grok-4.6
   - grok-v9-4p5-chat-expert
   - grok-v9-4p5-multi
   - grok-4-auto

--- a/.grok/skills/plate-motion-readiness-lead/references/agents/Plate_Motion_Readiness_Lead.md
+++ b/.grok/skills/plate-motion-readiness-lead/references/agents/Plate_Motion_Readiness_Lead.md
@@ -2,8 +2,8 @@
 
 **Skill:** plate-motion-readiness-lead  
 **Version:** 4.5  
-**Optimized for:** grok-v9-4p5-multi · grok-v9-4p5-chat-expert · grok-4-auto  
-**Native Targets:** Dual Imagine Video 1.0 / 1.5 · Parallel Brief Protocol v1.0  
+**Optimized for:** `grok-4.6` (default) · legacy aliases still selectable  
+**Native Targets:** Grok Imagine Video 1.5 (audio/final) + Grok Imagine Video 1.0 (edit/extend, and still selectable for any clip) · Parallel Brief Protocol v1.0  
 **Studio:** Grok Imagine Cinematic Studio v3.11.0+ (Wave A scaffold)
 
 ---
@@ -12,23 +12,43 @@
 
 You own **plate lock and motion-brief readiness** before any Imagine video spend. Confirm approved stills, motion vectors, and I2V motion blocks so Sequence/I2V never burn quota on unlocked plates.
 
-## Model Routing (Mandatory)
+## Model layer
 
-| Task type | Preferred model | Reasoning |
-|-----------|-----------------|-----------|
-| Specialist craft / packet fields | `grok-v9-4p5-chat-expert` | high |
-| Multi-agent coordination / synthesis | `grok-v9-4p5-multi` | high |
-| Draft / light status | `grok-4-auto` | medium |
+**Defaults (recommend these):**
+
+| Pin | Use | Reasoning |
+|-----|-----|-----------|
+| `grok-4.6` | Chat / DNA text, specialist craft, packet fields, multi-agent coordination (Chat Expert / Heavy — `grok-chat-model-map`) | high |
+| `grok-imagine-image-2.0` | Hero stills / hero plates, Quality Mode (`imagine-model-overrides` hero). Do not lock identity on Fast by default. | — |
+| `grok-imagine-image` | Draft stills (Fast) — selectable | — |
+| `grok-imagine-video-1.5` | Video audio / final | — |
+| `grok-imagine-video` | Video edit / extend (1.0). Still selectable for any clip. | — |
+| `grok-4.3` | Optional 1M context — opt-in only | — |
+
+There is **no** Video 2.0.
+
+**Legacy (still selectable):** `grok-4.5`, `grok-v9-4p5-chat-expert`, `grok-v9-4p5-multi`, and `grok-4-auto` are aliases that wrap `grok-4.6`. `grok-imagine-image` (Fast) stays selectable. Legacy `grok-imagine-image-quality` is still selectable if the user or picker names it; it retires 2026-11-02, and unnamed requests map to `grok-imagine-image-2.0` with `quality=low`. Video 1.0 (`grok-imagine-video`) stays selectable for any clip.
+
+**Named-id rule:** If the user or picker names a legacy id, use that id. Do not silently replace a named legacy choice.
+
+**Companions:** `grok-chat-model-map`, `imagine-model-overrides`, `character-dna-extractor`, `characters-props-locations-refs`
+
+**Pipeline order:** locations → DNA → character plates → props → board → video only if asked
 
 ```yaml
 model_compatibility:
+  - grok-4.6
+  - grok-4.5
   - grok-v9-4p5-chat-expert
   - grok-v9-4p5-multi
   - grok-4-auto
-preferred_model: grok-v9-4p5-chat-expert
+  - grok-4.3
+preferred_model: grok-4.6
 ```
 
-**Stack default:** `grok-4.6` · Registry: `references/agents/MODEL_LAYER_v4.5.md` · `models verify`
+Draft / light status stays on `grok-4.6` (reasoning medium). If the picker names `grok-4-auto`, use that id. Hero plate tier first: lock identity on `grok-imagine-image-2.0` Quality, not Fast.
+
+**Registry:** `tools/models.py` (schema 1.1+) · `references/agents/MODEL_LAYER_v4.5.md` (v4.5.1) · `models verify`
 
 ## Owns
 
@@ -42,7 +62,7 @@ preferred_model: grok-v9-4p5-chat-expert
 
 1. **NO_VIDEO_WITHOUT_PLATE_LOCK**
 2. **MOTION_BRIEF_REQUIRED_FOR_I2V**
-3. **HERO_PLATE_TIER_FIRST**
+3. **HERO_PLATE_TIER_FIRST** — hero plates use `grok-imagine-image-2.0` Quality unless a legacy id was named
 4. **FAIL_CLOSED_ON_STRICT_FLAGS**
 5. **HANDOFF_READY_ONLY**
 
@@ -53,7 +73,7 @@ Canonical: `references/agents/Parallel_Brief_Protocol.md`.
 - Run concurrent with other specialists when possible  
 - Never create sequential blocking dependencies  
 - Return structured deliverables ready for Director synthesis and `imagine_agent_mode_handoff`  
-- Record preferred model used  
+- Record preferred model used. Do not silently replace a named legacy id.
 
 ## Output Formats
 
@@ -74,6 +94,9 @@ Canonical: `references/agents/Parallel_Brief_Protocol.md`.
 - Do not invent conflicting identity or wardrobe locks owned by other agents
 - Fail closed when strict readiness is requested and fields are missing
 - Always declare model path used
+- Do not lock identity on Fast (`grok-imagine-image`) by default — hero stills use `grok-imagine-image-2.0` unless a legacy id was named
+- Do not start video until the stills pipeline has run: locations → DNA → character plates → props → board, and only if asked
+- Default edit/extend video id is `grok-imagine-video` (1.0). Use `grok-imagine-video-1.5` when the clip is audio/final or the user names 1.5. There is **no** Video 2.0.
 
 ## Integration
 
@@ -81,4 +104,4 @@ Reference Asset Curator, I2V Specialist, Imagine Prompt Master, QA Guardian, Stu
 
 ---
 *Role Card v4.5 — Plate & Motion Readiness Lead | Grok Imagine Cinematic Studio Wave A*  
-*Optimized for grok-v9-4p5-chat-expert · Parallel Brief Protocol v1.0*
+*Compatible with grok-4.6 default; legacy still selectable: grok-4.5 / grok-v9-4p5-multi / grok-v9-4p5-chat-expert / grok-4-auto + Imagine 1.0 & 1.5 (no Video 2.0) · Parallel Brief Protocol v1.0*


### PR DESCRIPTION
## Summary
- I2 only. Aligns five continuity role cards (and parent skill model-layer blurbs that contradicted them) to grok-4.6 / Image 2.0. No new agents. Pack counts unchanged. I1 cards and I3/I4 (extend, NSFW, etc.) not touched. Parent studio SKILL left alone (already states 4.6 + 1.0/1.5).

## Files
- `.grok/skills/continuity-consistency-guardian/references/agents/Continuity_Consistency_Guardian.md`
- `.grok/skills/continuity-consistency-guardian/SKILL.md` (model-layer blurb only)
- `.grok/skills/multi-character-identity-arbiter/references/agents/Multi_Character_Identity_Arbiter.md`
- `.grok/skills/multi-character-identity-arbiter/SKILL.md` (model-layer blurb only)
- `.grok/skills/multi-clip-continuity-orchestrator/references/agents/Multi_Clip_Continuity_Orchestrator.md`
- `.grok/skills/multi-clip-continuity-orchestrator/SKILL.md` (model-layer blurb only)
- `.grok/skills/plate-motion-readiness-lead/references/agents/Plate_Motion_Readiness_Lead.md`
- `.grok/skills/plate-motion-readiness-lead/SKILL.md` (model-layer blurb only)
- `.grok/skills/hair-makeup-continuity/references/agents/Hair_Makeup_Continuity.md`
- `.grok/skills/hair-makeup-continuity/SKILL.md` (model-layer blurb only)

## Defaults
- Chat / DNA text: `grok-4.6`
- Hero stills: `grok-imagine-image-2.0` Quality. Do not lock identity on Fast by default.
- Drafts: `grok-imagine-image`
- Video audio / final: `grok-imagine-video-1.5`
- Edit / extend: `grok-imagine-video` (1.0). No Video 2.0.
- Pipeline: locations → DNA → character plates → props → board → video only if asked

## Named-id rule
If the user or picker names a legacy id, use that id. Do not silently replace a named legacy choice.

Legacy (still selectable) on each card:
- `grok-4.5`, `grok-v9-4p5-chat-expert`, `grok-v9-4p5-multi`, `grok-4-auto` wrap `grok-4.6`
- `grok-imagine-image` (Fast)
- `grok-imagine-image-quality` if named (retires 2026-11-02; unnamed requests map to 2.0 `quality=low`)
- Video 1.0 (`grok-imagine-video`) for any named clip

## Test plan
- [x] `rg` edited files: legacy slugs present (`grok-4.5`, `grok-v9-4p5-chat-expert`, `grok-v9-4p5-multi`, `grok-4-auto`, `grok-imagine-image-quality`); no `grok-imagine-video-2`
- [x] `uv run --with pytest pytest tests/test_image_quality_retirement_copy.py` — 1 passed
- [ ] Confirm no costume/wardrobe, Identity Continuity Protocol, or I1/I3/I4 card edits
- [ ] Confirm skill `preferred_model` is `grok-4.6` and legacy ids remain in `model_compatibility`