### PR TITLE
align I3 agents to 4.6 / Image 2.0 (legacy still selectable)

### DIFF
--- a/.grok-plugin/marketplace.json
+++ b/.grok-plugin/marketplace.json
@@ -14,7 +14,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio.git",
-        "sha": "f3030448bcf7fb1e1a18449c3762e326e57f71a0"
+        "sha": "517942831b5d0281c98adbeef60ae7565d039754"
       },
       "homepage": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio",
       "keywords": [
@@ -31,7 +31,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio.git",
-        "sha": "f3030448bcf7fb1e1a18449c3762e326e57f71a0"
+        "sha": "517942831b5d0281c98adbeef60ae7565d039754"
       },
       "homepage": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio",
       "keywords": [
@@ -49,7 +49,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio.git",
-        "sha": "f3030448bcf7fb1e1a18449c3762e326e57f71a0"
+        "sha": "517942831b5d0281c98adbeef60ae7565d039754"
       },
       "homepage": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio",
       "keywords": [
@@ -69,7 +69,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio.git",
-        "sha": "f3030448bcf7fb1e1a18449c3762e326e57f71a0"
+        "sha": "517942831b5d0281c98adbeef60ae7565d039754"
       },
       "homepage": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio",
       "keywords": [
@@ -89,7 +89,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio.git",
-        "sha": "f3030448bcf7fb1e1a18449c3762e326e57f71a0"
+        "sha": "517942831b5d0281c98adbeef60ae7565d039754"
       },
       "homepage": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio",
       "keywords": [
@@ -109,7 +109,7 @@
       "source": {
         "source": "url",
         "url": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio.git",
-        "sha": "f3030448bcf7fb1e1a18449c3762e326e57f71a0"
+        "sha": "517942831b5d0281c98adbeef60ae7565d039754"
       },
       "homepage": "https://github.com/FineComputer14451/Grok-Imagine-Cinematic-Studio",
       "keywords": [

--- a/.grok-plugin/plugin-index.json
+++ b/.grok-plugin/plugin-index.json
@@ -324,7 +324,7 @@
           }
         ]
       },
-      "sha": "f3030448bcf7fb1e1a18449c3762e326e57f71a0"
+      "sha": "517942831b5d0281c98adbeef60ae7565d039754"
     },
     "grok-imagine-cinematic-core": {
       "components": {
@@ -473,7 +473,7 @@
           }
         ]
       },
-      "sha": "f3030448bcf7fb1e1a18449c3762e326e57f71a0"
+      "sha": "517942831b5d0281c98adbeef60ae7565d039754"
     },
     "grok-imagine-camera-image": {
       "components": {
@@ -528,7 +528,7 @@
           }
         ]
       },
-      "sha": "f3030448bcf7fb1e1a18449c3762e326e57f71a0"
+      "sha": "517942831b5d0281c98adbeef60ae7565d039754"
     },
     "grok-imagine-sequence-narrative": {
       "components": {
@@ -611,7 +611,7 @@
           }
         ]
       },
-      "sha": "f3030448bcf7fb1e1a18449c3762e326e57f71a0"
+      "sha": "517942831b5d0281c98adbeef60ae7565d039754"
     },
     "grok-imagine-nsfw": {
       "components": {
@@ -640,7 +640,7 @@
           }
         ]
       },
-      "sha": "f3030448bcf7fb1e1a18449c3762e326e57f71a0"
+      "sha": "517942831b5d0281c98adbeef60ae7565d039754"
     },
     "grok-imagine-delivery-post": {
       "components": {
@@ -681,7 +681,7 @@
           }
         ]
       },
-      "sha": "f3030448bcf7fb1e1a18449c3762e326e57f71a0"
+      "sha": "517942831b5d0281c98adbeef60ae7565d039754"
     }
   }
 }

--- a/.grok/skills/cinematic-sequence-extender/SKILL.md
+++ b/.grok/skills/cinematic-sequence-extender/SKILL.md
@@ -15,16 +15,26 @@ description: Specialist for expanding short clips into longer seamless cinematic
 |------------------------------------------------|-------------------------------|-----------|
 | Multi-clip structure planning, dependency + health management | `grok-4.6` (Chat **Heavy**)         | high      |
 | Single extension craft, momentum design, stitch planning | `grok-4.6` (Chat **Expert**)   | high      |
-| Quick status / simple extension checks         | `grok-4-auto`               | medium    |
+| Quick status / simple extension checks         | `grok-4.6` | medium |
 
 **Stack default:** cinematic+Build API/chat **`grok-4.6`** (CLI ≥ 1.0.5 · fork `grok-build` or `grok-4.6`; `grok-4.5` aliases wrap 4.6). Opt-in 1M: `grok-4.3`.  
 **Registry:** `tools/models.py` (schema 1.1+) · `references/agents/MODEL_LAYER_v4.5.md` · `models verify`
 
+**Legacy (still selectable):** `grok-4.5` (legacy alias that wraps `grok-4.6`), `grok-v9-4p5-chat-expert`, `grok-v9-4p5-multi`, and `grok-4-auto` are aliases that wrap `grok-4.6`. `grok-imagine-image` (Fast) stays selectable. Legacy `grok-imagine-image-quality` is still selectable if the user or picker names it; it retires 2026-11-02, and unnamed requests map to `grok-imagine-image-2.0` with `quality=low`. Video 1.0 (`grok-imagine-video`) stays selectable for edit/extend and for any clip if named.
+
+**Named-id rule:** If the user or picker names a legacy id, use that id. Do not silently replace a named legacy choice.
+
 ```yaml
 model_compatibility:
   - grok-4.6
+  - grok-4.5  # legacy alias that wraps grok-4.6
+  - grok-v9-4p5-chat-expert
+  - grok-v9-4p5-multi
+  - grok-4-auto
+  - grok-4.3
 preferred_model: grok-4.6
 ```
+
 
 ## When to Activate
 
@@ -40,11 +50,11 @@ Load and follow the Role Card.
 
 ## Grok Imagine Video Compatibility
 
-### Primary Path — Imagine Video 1.5 Native
+### Audio / final — Imagine Video 1.5 Native
 - Preferred for all serious long-form expansion
 - Full native extend-from-frame with LAST_FRAME_RECAP + MOMENTUM_VECTOR + AUDIO_MOMENTUM_VECTOR
 
-### Secondary / Fallback Path — Imagine Video 1.0
+### Edit / extend — Imagine Video 1.0 (still selectable if named; not fallback-only. No Video 2.0.)
 - Supported for cost-efficient drafts and shorter expansions
 - Clearly label 1.0 vs 1.5 in Sequence Blueprints and handoffs
 

--- a/.grok/skills/cinematic-sequence-extender/references/agents/Cinematic_Sequence_Extender.md
+++ b/.grok/skills/cinematic-sequence-extender/references/agents/Cinematic_Sequence_Extender.md
@@ -2,8 +2,8 @@
 
 **Skill:** cinematic-sequence-extender  
 **Version:** 4.5  
-**Optimized for:** grok-v9-4p5-chat-expert · grok-v9-4p5-multi · grok-4-auto  
-**Native Targets:** Grok Imagine Video 1.5 (primary) + Grok Imagine Video 1.0 (fallback)
+**Optimized for:** `grok-4.6` (default) · legacy aliases still selectable  
+**Native Targets:** Grok Imagine Video 1.5 (audio/final) + Grok Imagine Video 1.0 (edit/extend, and still selectable if named)
 
 ---
 
@@ -16,19 +16,19 @@ You expand short clips into longer seamless cinematic sequences (60–180s+) usi
 
 | Task type                                      | Preferred model               | Reasoning |
 |------------------------------------------------|-------------------------------|-----------|
-| Multi-clip structure planning, dependency + health management | `grok-v9-4p5-multi`         | high      |
-| Single extension craft, momentum design, stitch planning | `grok-v9-4p5-chat-expert`   | high      |
-| Quick status / simple extension checks         | `grok-4-auto`               | medium    |
+| Multi-clip structure planning, dependency + health management | `grok-4.6`         | high      |
+| Single extension craft, momentum design, stitch planning | `grok-4.6`   | high      |
+| Quick status / simple extension checks         | `grok-4.6` | medium |
 
 Always record the model used in Sequence Blueprints and Handoff Packets.
 
 ## Grok Imagine Video Compatibility
 
-### Primary: Imagine Video 1.5 Native
+### Audio / final: Imagine Video 1.5 Native
 - Preferred for all serious long-form expansion
 - Full native extend-from-frame with LAST_FRAME_RECAP + MOMENTUM_VECTOR + AUDIO_MOMENTUM_VECTOR
 
-### Secondary / Fallback: Imagine Video 1.0
+### Edit / extend: Imagine Video 1.0 (still selectable if named; not fallback-only. No Video 2.0.)
 - Supported for cost-efficient drafts and shorter expansions
 - Clearly label 1.0 vs 1.5 in Sequence Blueprints and handoffs
 
@@ -66,3 +66,18 @@ Always record the model used in Sequence Blueprints and Handoff Packets.
 
 *Role Card v4.5 — Cinematic Sequence Extender | Grok Imagine Cinematic Studio*  
 *Compatible with grok-4-auto / grok-v9-4p5-multi / grok-v9-4p5-chat-expert + Imagine 1.0 & 1.5*
+
+**Legacy (still selectable):** `grok-4.5` (legacy alias that wraps `grok-4.6`), `grok-v9-4p5-chat-expert`, `grok-v9-4p5-multi`, and `grok-4-auto` are aliases that wrap `grok-4.6`. `grok-imagine-image` (Fast) stays selectable. Legacy `grok-imagine-image-quality` is still selectable if the user or picker names it; it retires 2026-11-02, and unnamed requests map to `grok-imagine-image-2.0` with `quality=low`. Video 1.0 (`grok-imagine-video`) stays selectable for edit/extend and for any clip if named.
+
+**Named-id rule:** If the user or picker names a legacy id, use that id. Do not silently replace a named legacy choice.
+
+```yaml
+model_compatibility:
+  - grok-4.6
+  - grok-4.5  # legacy alias that wraps grok-4.6
+  - grok-v9-4p5-chat-expert
+  - grok-v9-4p5-multi
+  - grok-4-auto
+  - grok-4.3
+preferred_model: grok-4.6
+```

--- a/.grok/skills/contact-micro-physics-specialist/SKILL.md
+++ b/.grok/skills/contact-micro-physics-specialist/SKILL.md
@@ -2,7 +2,7 @@
 name: contact-micro-physics-specialist
 description: Contact and micro-physics specialist for hands cloth grip weight transfer liquids and object interaction in Grok Imagine stills and video. Owns contact briefs that keep micro-physics believable across i2v and extend. Activate with ACTIVATE CONTACT_MICRO_PHYSICS. Optimized for grok-4-auto grok-v9-4p5-multi grok-v9-4p5-chat-expert with dual Imagine Video 1.0 and 1.5 Native.
 version: 4.5
-preferred_model: grok-v9-4p5-chat-expert
+preferred_model: grok-4.6
 model_compatibility:
   - grok-v9-4p5-chat-expert
   - grok-v9-4p5-multi
@@ -27,20 +27,28 @@ tags:
 
 | Task type | Preferred model | Reasoning |
 |-----------|-----------------|-----------|
-| Specialist craft | `grok-v9-4p5-chat-expert` | high |
-| Multi-agent / synthesis | `grok-v9-4p5-multi` | high |
-| Draft / routine | `grok-4-auto` | medium |
+| Specialist craft | `grok-4.6` | high |
+| Multi-agent / synthesis | `grok-4.6` | high |
+| Draft / routine | `grok-4.6` | medium |
 
 **Stack default:** cinematic+Build API/chat **`grok-4.6`** (CLI ≥ 1.0.5 · fork `grok-build` or `grok-4.6`; `grok-4.5` aliases wrap 4.6). Opt-in 1M: `grok-4.3`.  
 **Registry:** `tools/models.py` · `references/agents/MODEL_LAYER_v4.5.md` · `models verify`
 
+**Legacy (still selectable):** `grok-4.5` (legacy alias that wraps `grok-4.6`), `grok-v9-4p5-chat-expert`, `grok-v9-4p5-multi`, and `grok-4-auto` are aliases that wrap `grok-4.6`. `grok-imagine-image` (Fast) stays selectable. Legacy `grok-imagine-image-quality` is still selectable if the user or picker names it; it retires 2026-11-02, and unnamed requests map to `grok-imagine-image-2.0` with `quality=low`. Video 1.0 (`grok-imagine-video`) stays selectable for edit/extend and for any clip if named.
+
+**Named-id rule:** If the user or picker names a legacy id, use that id. Do not silently replace a named legacy choice.
+
 ```yaml
 model_compatibility:
+  - grok-4.6
+  - grok-4.5  # legacy alias that wraps grok-4.6
   - grok-v9-4p5-chat-expert
   - grok-v9-4p5-multi
   - grok-4-auto
-preferred_model: grok-v9-4p5-chat-expert
+  - grok-4.3
+preferred_model: grok-4.6
 ```
+
 
 ## When to Activate
 

--- a/.grok/skills/contact-micro-physics-specialist/references/agents/Contact_Micro_Physics_Specialist.md
+++ b/.grok/skills/contact-micro-physics-specialist/references/agents/Contact_Micro_Physics_Specialist.md
@@ -2,7 +2,7 @@
 
 **Skill:** contact-micro-physics-specialist  
 **Version:** 4.5  
-**Optimized for:** grok-v9-4p5-multi · grok-v9-4p5-chat-expert · grok-4-auto  
+**Optimized for:** `grok-4.6` (default) · legacy aliases still selectable  
 **Native Targets:** Dual Imagine Video 1.0 / 1.5 · Parallel Brief Protocol v1.0  
 **Studio:** Grok Imagine Cinematic Studio v3.11.0+ (Wave A scaffold)
 
@@ -16,17 +16,25 @@ You own **believable contact and micro-physics** (hands, cloth, grip, weight, li
 
 | Task type | Preferred model | Reasoning |
 |-----------|-----------------|-----------|
-| Specialist craft / packet fields | `grok-v9-4p5-chat-expert` | high |
-| Multi-agent coordination / synthesis | `grok-v9-4p5-multi` | high |
-| Draft / light status | `grok-4-auto` | medium |
+| Specialist craft / packet fields | `grok-4.6` | high |
+| Multi-agent coordination / synthesis | `grok-4.6` | high |
+| Draft / light status | `grok-4.6` | medium |
+
+**Legacy (still selectable):** `grok-4.5` (legacy alias that wraps `grok-4.6`), `grok-v9-4p5-chat-expert`, `grok-v9-4p5-multi`, and `grok-4-auto` are aliases that wrap `grok-4.6`. `grok-imagine-image` (Fast) stays selectable. Legacy `grok-imagine-image-quality` is still selectable if the user or picker names it; it retires 2026-11-02, and unnamed requests map to `grok-imagine-image-2.0` with `quality=low`. Video 1.0 (`grok-imagine-video`) stays selectable for edit/extend and for any clip if named.
+
+**Named-id rule:** If the user or picker names a legacy id, use that id. Do not silently replace a named legacy choice.
 
 ```yaml
 model_compatibility:
+  - grok-4.6
+  - grok-4.5  # legacy alias that wraps grok-4.6
   - grok-v9-4p5-chat-expert
   - grok-v9-4p5-multi
   - grok-4-auto
-preferred_model: grok-v9-4p5-chat-expert
+  - grok-4.3
+preferred_model: grok-4.6
 ```
+
 
 **Stack default:** `grok-4.6` · Registry: `references/agents/MODEL_LAYER_v4.5.md` · `models verify`
 

--- a/.grok/skills/dialogue-adr-director/SKILL.md
+++ b/.grok/skills/dialogue-adr-director/SKILL.md
@@ -29,16 +29,26 @@ tags:
 |-----------|-----------------|-----------|
 | Specialist craft | `grok-4.6` (Chat **Expert**) | high |
 | Multi-agent / synthesis | `grok-4.6` (Chat **Heavy**) | high |
-| Draft / routine | `grok-4-auto` | medium |
+| Draft / routine | `grok-4.6` | medium |
 
 **Stack default:** cinematic+Build API/chat **`grok-4.6`** (CLI ≥ 1.0.5 · fork `grok-build` or `grok-4.6`; `grok-4.5` aliases wrap 4.6). Opt-in 1M: `grok-4.3`.  
 **Registry:** `tools/models.py` · `references/agents/MODEL_LAYER_v4.5.md` · `models verify`
 
+**Legacy (still selectable):** `grok-4.5` (legacy alias that wraps `grok-4.6`), `grok-v9-4p5-chat-expert`, `grok-v9-4p5-multi`, and `grok-4-auto` are aliases that wrap `grok-4.6`. `grok-imagine-image` (Fast) stays selectable. Legacy `grok-imagine-image-quality` is still selectable if the user or picker names it; it retires 2026-11-02, and unnamed requests map to `grok-imagine-image-2.0` with `quality=low`. Video 1.0 (`grok-imagine-video`) stays selectable for edit/extend and for any clip if named.
+
+**Named-id rule:** If the user or picker names a legacy id, use that id. Do not silently replace a named legacy choice.
+
 ```yaml
 model_compatibility:
   - grok-4.6
+  - grok-4.5  # legacy alias that wraps grok-4.6
+  - grok-v9-4p5-chat-expert
+  - grok-v9-4p5-multi
+  - grok-4-auto
+  - grok-4.3
 preferred_model: grok-4.6
 ```
+
 
 ## When to Activate
 

--- a/.grok/skills/dialogue-adr-director/references/agents/Dialogue_ADR_Director.md
+++ b/.grok/skills/dialogue-adr-director/references/agents/Dialogue_ADR_Director.md
@@ -2,7 +2,7 @@
 
 **Skill:** dialogue-adr-director  
 **Version:** 4.5  
-**Optimized for:** grok-v9-4p5-multi · grok-v9-4p5-chat-expert · grok-4-auto  
+**Optimized for:** `grok-4.6` (default) · legacy aliases still selectable  
 **Native Targets:** Dual Imagine Video 1.0 / 1.5 · Parallel Brief Protocol v1.0  
 **Studio:** Grok Imagine Cinematic Studio v3.11.0+ (Wave A scaffold)
 
@@ -16,17 +16,25 @@ You own **spoken performance language**—dialogue, VO, ADR timing, and lip-sync
 
 | Task type | Preferred model | Reasoning |
 |-----------|-----------------|-----------|
-| Specialist craft / packet fields | `grok-v9-4p5-chat-expert` | high |
-| Multi-agent coordination / synthesis | `grok-v9-4p5-multi` | high |
-| Draft / light status | `grok-4-auto` | medium |
+| Specialist craft / packet fields | `grok-4.6` | high |
+| Multi-agent coordination / synthesis | `grok-4.6` | high |
+| Draft / light status | `grok-4.6` | medium |
+
+**Legacy (still selectable):** `grok-4.5` (legacy alias that wraps `grok-4.6`), `grok-v9-4p5-chat-expert`, `grok-v9-4p5-multi`, and `grok-4-auto` are aliases that wrap `grok-4.6`. `grok-imagine-image` (Fast) stays selectable. Legacy `grok-imagine-image-quality` is still selectable if the user or picker names it; it retires 2026-11-02, and unnamed requests map to `grok-imagine-image-2.0` with `quality=low`. Video 1.0 (`grok-imagine-video`) stays selectable for edit/extend and for any clip if named.
+
+**Named-id rule:** If the user or picker names a legacy id, use that id. Do not silently replace a named legacy choice.
 
 ```yaml
 model_compatibility:
+  - grok-4.6
+  - grok-4.5  # legacy alias that wraps grok-4.6
   - grok-v9-4p5-chat-expert
   - grok-v9-4p5-multi
   - grok-4-auto
-preferred_model: grok-v9-4p5-chat-expert
+  - grok-4.3
+preferred_model: grok-4.6
 ```
+
 
 **Stack default:** `grok-4.6` · Registry: `references/agents/MODEL_LAYER_v4.5.md` · `models verify`
 

--- a/.grok/skills/distribution-crop-strategist/SKILL.md
+++ b/.grok/skills/distribution-crop-strategist/SKILL.md
@@ -2,7 +2,7 @@
 name: distribution-crop-strategist
 description: Distribution and crop strategist for 16x9 9x16 1x1 safe-action framing before polish and ffmpeg delivery. Owns platform crop plans so cinematic-ffmpeg executes without guessing. Activate with ACTIVATE DISTRIBUTION_CROP. Optimized for grok-4-auto grok-4.6 grok-4.6 with dual Imagine Video 1.0 and 1.5 Native.
 version: 4.5
-preferred_model: grok-4-auto
+preferred_model: grok-4.6
 model_compatibility:
   - grok-4.6
   - grok-4.6
@@ -29,18 +29,26 @@ tags:
 |-----------|-----------------|-----------|
 | Specialist craft | `grok-4.6` (Chat **Expert**) | high |
 | Multi-agent / synthesis | `grok-4.6` (Chat **Heavy**) | high |
-| Draft / routine | `grok-4-auto` | medium |
+| Draft / routine | `grok-4.6` | medium |
 
 **Stack default:** cinematic+Build API/chat **`grok-4.6`** (CLI ≥ 1.0.5 · fork `grok-build` or `grok-4.6`; `grok-4.5` aliases wrap 4.6). Opt-in 1M: `grok-4.3`.  
 **Registry:** `tools/models.py` · `references/agents/MODEL_LAYER_v4.5.md` · `models verify`
 
+**Legacy (still selectable):** `grok-4.5` (legacy alias that wraps `grok-4.6`), `grok-v9-4p5-chat-expert`, `grok-v9-4p5-multi`, and `grok-4-auto` are aliases that wrap `grok-4.6`. `grok-imagine-image` (Fast) stays selectable. Legacy `grok-imagine-image-quality` is still selectable if the user or picker names it; it retires 2026-11-02, and unnamed requests map to `grok-imagine-image-2.0` with `quality=low`. Video 1.0 (`grok-imagine-video`) stays selectable for edit/extend and for any clip if named.
+
+**Named-id rule:** If the user or picker names a legacy id, use that id. Do not silently replace a named legacy choice.
+
 ```yaml
 model_compatibility:
   - grok-4.6
-  - grok-4.6
+  - grok-4.5  # legacy alias that wraps grok-4.6
+  - grok-v9-4p5-chat-expert
+  - grok-v9-4p5-multi
   - grok-4-auto
-preferred_model: grok-4-auto
+  - grok-4.3
+preferred_model: grok-4.6
 ```
+
 
 ## When to Activate
 

--- a/.grok/skills/distribution-crop-strategist/references/agents/Distribution_Crop_Strategist.md
+++ b/.grok/skills/distribution-crop-strategist/references/agents/Distribution_Crop_Strategist.md
@@ -2,7 +2,7 @@
 
 **Skill:** distribution-crop-strategist  
 **Version:** 4.5  
-**Optimized for:** grok-v9-4p5-multi · grok-v9-4p5-chat-expert · grok-4-auto  
+**Optimized for:** `grok-4.6` (default) · legacy aliases still selectable  
 **Native Targets:** Dual Imagine Video 1.0 / 1.5 · Parallel Brief Protocol v1.0  
 **Studio:** Grok Imagine Cinematic Studio v3.11.0+ (Wave A scaffold)
 
@@ -16,17 +16,25 @@ You own **platform framing strategy**—16:9 / 9:16 / 1:1 safe-action and crop p
 
 | Task type | Preferred model | Reasoning |
 |-----------|-----------------|-----------|
-| Specialist craft / packet fields | `grok-v9-4p5-chat-expert` | high |
-| Multi-agent coordination / synthesis | `grok-v9-4p5-multi` | high |
-| Draft / light status | `grok-4-auto` | medium |
+| Specialist craft / packet fields | `grok-4.6` | high |
+| Multi-agent coordination / synthesis | `grok-4.6` | high |
+| Draft / light status | `grok-4.6` | medium |
+
+**Legacy (still selectable):** `grok-4.5` (legacy alias that wraps `grok-4.6`), `grok-v9-4p5-chat-expert`, `grok-v9-4p5-multi`, and `grok-4-auto` are aliases that wrap `grok-4.6`. `grok-imagine-image` (Fast) stays selectable. Legacy `grok-imagine-image-quality` is still selectable if the user or picker names it; it retires 2026-11-02, and unnamed requests map to `grok-imagine-image-2.0` with `quality=low`. Video 1.0 (`grok-imagine-video`) stays selectable for edit/extend and for any clip if named.
+
+**Named-id rule:** If the user or picker names a legacy id, use that id. Do not silently replace a named legacy choice.
 
 ```yaml
 model_compatibility:
+  - grok-4.6
+  - grok-4.5  # legacy alias that wraps grok-4.6
   - grok-v9-4p5-chat-expert
   - grok-v9-4p5-multi
   - grok-4-auto
-preferred_model: grok-4-auto
+  - grok-4.3
+preferred_model: grok-4.6
 ```
+
 
 **Stack default:** `grok-4.6` · Registry: `references/agents/MODEL_LAYER_v4.5.md` · `models verify`
 

--- a/.grok/skills/extend-frame-to-video/SKILL.md
+++ b/.grok/skills/extend-frame-to-video/SKILL.md
@@ -15,16 +15,26 @@ description: Create cinematic rough-cut animatics and storyboards from Grok Imag
 |------------------------------------------------|-------------------------------|-----------|
 | Complex multi-clip assembly planning, EDL + storyboard synthesis | `grok-4.6` (Chat **Heavy**)         | high      |
 | Single-sequence extend planning, prompt crafting, Ken Burns design | `grok-4.6` (Chat **Expert**)   | high      |
-| Quick status / simple assembly checks          | `grok-4-auto`               | medium    |
+| Quick status / simple assembly checks          | `grok-4.6` | medium |
 
 **Stack default:** cinematic+Build API/chat **`grok-4.6`** (CLI ≥ 1.0.5 · fork `grok-build` or `grok-4.6`; `grok-4.5` aliases wrap 4.6). Opt-in 1M: `grok-4.3`.  
 **Registry:** `tools/models.py` (schema 1.1+) · `references/agents/MODEL_LAYER_v4.5.md` · `models verify`
 
+**Legacy (still selectable):** `grok-4.5` (legacy alias that wraps `grok-4.6`), `grok-v9-4p5-chat-expert`, `grok-v9-4p5-multi`, and `grok-4-auto` are aliases that wrap `grok-4.6`. `grok-imagine-image` (Fast) stays selectable. Legacy `grok-imagine-image-quality` is still selectable if the user or picker names it; it retires 2026-11-02, and unnamed requests map to `grok-imagine-image-2.0` with `quality=low`. Video 1.0 (`grok-imagine-video`) stays selectable for edit/extend and for any clip if named.
+
+**Named-id rule:** If the user or picker names a legacy id, use that id. Do not silently replace a named legacy choice.
+
 ```yaml
 model_compatibility:
   - grok-4.6
+  - grok-4.5  # legacy alias that wraps grok-4.6
+  - grok-v9-4p5-chat-expert
+  - grok-v9-4p5-multi
+  - grok-4-auto
+  - grok-4.3
 preferred_model: grok-4.6
 ```
+
 
 ## When to Activate
 
@@ -41,11 +51,11 @@ Load and follow the Role Card. Do not paraphrase locked protocols or output stru
 
 ## Grok Imagine Video Compatibility
 
-### Primary Path — Imagine Video 1.5 Native
+### Audio / final — Imagine Video 1.5 Native
 - Preferred for high-fidelity extend-from-frame chains
 - Full support for LAST_FRAME_RECAP, momentum vectors, and native audio continuity
 
-### Secondary / Fallback Path — Imagine Video 1.0
+### Edit / extend — Imagine Video 1.0 (still selectable if named; not fallback-only. No Video 2.0.)
 - Fully supported for cost-efficient pre-viz and draft animatics
 - Clearly label 1.0 vs 1.5 outputs in project manifests and EDLs
 

--- a/.grok/skills/i2i-cinematic-refiner/SKILL.md
+++ b/.grok/skills/i2i-cinematic-refiner/SKILL.md
@@ -17,16 +17,26 @@ description: General-purpose Image-to-Image cinematic refinement specialist for 
 |-----------|-----------------|-----------|
 | Multi-agent orchestration / handoff synthesis | `grok-4.6` (Chat **Heavy**) | high |
 | Specialist deep craft / QA / identity-critical | `grok-4.6` (Chat **Expert**) | high |
-| Routine status / draft passes | `grok-4-auto` | medium |
+| Routine status / draft passes | `grok-4.6` | medium |
 
 **Stack default:** cinematic+Build API/chat **`grok-4.6`** (CLI ≥ 1.0.5 · fork `grok-build` or `grok-4.6`; `grok-4.5` aliases wrap 4.6). Opt-in 1M: `grok-4.3`.  
 **Registry:** `tools/models.py` · `references/agents/MODEL_LAYER_v4.5.md` · `models verify`
 
+**Legacy (still selectable):** `grok-4.5` (legacy alias that wraps `grok-4.6`), `grok-v9-4p5-chat-expert`, `grok-v9-4p5-multi`, and `grok-4-auto` are aliases that wrap `grok-4.6`. `grok-imagine-image` (Fast) stays selectable. Legacy `grok-imagine-image-quality` is still selectable if the user or picker names it; it retires 2026-11-02, and unnamed requests map to `grok-imagine-image-2.0` with `quality=low`. Video 1.0 (`grok-imagine-video`) stays selectable for edit/extend and for any clip if named.
+
+**Named-id rule:** If the user or picker names a legacy id, use that id. Do not silently replace a named legacy choice.
+
 ```yaml
 model_compatibility:
   - grok-4.6
+  - grok-4.5  # legacy alias that wraps grok-4.6
+  - grok-v9-4p5-chat-expert
+  - grok-v9-4p5-multi
+  - grok-4-auto
+  - grok-4.3
 preferred_model: grok-4.6
 ```
+
 
 ### Imagine Video dual-path (when this skill touches video)
 - **1.5 Native** — preferred for hero / final motion with audio when budget allows

--- a/.grok/skills/i2i-cinematic-refiner/references/agents/I2I_Cinematic_Refiner.md
+++ b/.grok/skills/i2i-cinematic-refiner/references/agents/I2I_Cinematic_Refiner.md
@@ -50,3 +50,18 @@ Every response must include:
 
 ## Core Philosophy
 "Refine with precision and restraint. Every pass should elevate cinematic quality while protecting the integrity of the original vision and character identity."
+
+**Legacy (still selectable):** `grok-4.5` (legacy alias that wraps `grok-4.6`), `grok-v9-4p5-chat-expert`, `grok-v9-4p5-multi`, and `grok-4-auto` are aliases that wrap `grok-4.6`. `grok-imagine-image` (Fast) stays selectable. Legacy `grok-imagine-image-quality` is still selectable if the user or picker names it; it retires 2026-11-02, and unnamed requests map to `grok-imagine-image-2.0` with `quality=low`. Video 1.0 (`grok-imagine-video`) stays selectable for edit/extend and for any clip if named.
+
+**Named-id rule:** If the user or picker names a legacy id, use that id. Do not silently replace a named legacy choice.
+
+```yaml
+model_compatibility:
+  - grok-4.6
+  - grok-4.5  # legacy alias that wraps grok-4.6
+  - grok-v9-4p5-chat-expert
+  - grok-v9-4p5-multi
+  - grok-4-auto
+  - grok-4.3
+preferred_model: grok-4.6
+```

--- a/.grok/skills/i2i-refiner/SKILL.md
+++ b/.grok/skills/i2i-refiner/SKILL.md
@@ -14,16 +14,26 @@ description: Advanced Image-to-Image refinement specialist for Grok Imagine cine
 |-----------|-----------------|-----------|
 | Multi-agent orchestration / handoff synthesis | `grok-4.6` (Chat **Heavy**) | high |
 | Specialist deep craft / QA / identity-critical | `grok-4.6` (Chat **Expert**) | high |
-| Routine status / draft passes | `grok-4-auto` | medium |
+| Routine status / draft passes | `grok-4.6` | medium |
 
 **Stack default:** cinematic+Build API/chat **`grok-4.6`** (CLI ≥ 1.0.5 · fork `grok-build` or `grok-4.6`; `grok-4.5` aliases wrap 4.6). Opt-in 1M: `grok-4.3`.  
 **Registry:** `tools/models.py` · `references/agents/MODEL_LAYER_v4.5.md` · `models verify`
 
+**Legacy (still selectable):** `grok-4.5` (legacy alias that wraps `grok-4.6`), `grok-v9-4p5-chat-expert`, `grok-v9-4p5-multi`, and `grok-4-auto` are aliases that wrap `grok-4.6`. `grok-imagine-image` (Fast) stays selectable. Legacy `grok-imagine-image-quality` is still selectable if the user or picker names it; it retires 2026-11-02, and unnamed requests map to `grok-imagine-image-2.0` with `quality=low`. Video 1.0 (`grok-imagine-video`) stays selectable for edit/extend and for any clip if named.
+
+**Named-id rule:** If the user or picker names a legacy id, use that id. Do not silently replace a named legacy choice.
+
 ```yaml
 model_compatibility:
   - grok-4.6
+  - grok-4.5  # legacy alias that wraps grok-4.6
+  - grok-v9-4p5-chat-expert
+  - grok-v9-4p5-multi
+  - grok-4-auto
+  - grok-4.3
 preferred_model: grok-4.6
 ```
+
 
 ### Imagine Video dual-path (when this skill touches video)
 - **1.5 Native** — preferred for hero / final motion with audio when budget allows

--- a/.grok/skills/i2i-refiner/references/agents/I2I_Refiner.md
+++ b/.grok/skills/i2i-refiner/references/agents/I2I_Refiner.md
@@ -51,3 +51,18 @@ When erotic or intimate content is present, treat anatomical fidelity, fluid phy
 
 ## Core Philosophy
 "Every pixel that survives i2i refinement must serve the story, the character, and the cinematic vision. Strength is a scalpel, not a hammer. Identity is sacred — especially when the scene is intimate."
+
+**Legacy (still selectable):** `grok-4.5` (legacy alias that wraps `grok-4.6`), `grok-v9-4p5-chat-expert`, `grok-v9-4p5-multi`, and `grok-4-auto` are aliases that wrap `grok-4.6`. `grok-imagine-image` (Fast) stays selectable. Legacy `grok-imagine-image-quality` is still selectable if the user or picker names it; it retires 2026-11-02, and unnamed requests map to `grok-imagine-image-2.0` with `quality=low`. Video 1.0 (`grok-imagine-video`) stays selectable for edit/extend and for any clip if named.
+
+**Named-id rule:** If the user or picker names a legacy id, use that id. Do not silently replace a named legacy choice.
+
+```yaml
+model_compatibility:
+  - grok-4.6
+  - grok-4.5  # legacy alias that wraps grok-4.6
+  - grok-v9-4p5-chat-expert
+  - grok-v9-4p5-multi
+  - grok-4-auto
+  - grok-4.3
+preferred_model: grok-4.6
+```

--- a/.grok/skills/parallel-brief-dispatcher/SKILL.md
+++ b/.grok/skills/parallel-brief-dispatcher/SKILL.md
@@ -29,16 +29,26 @@ tags:
 |-----------|-----------------|-----------|
 | Specialist craft | `grok-4.6` (Chat **Expert**) | high |
 | Multi-agent / synthesis | `grok-4.6` (Chat **Heavy**) | high |
-| Draft / routine | `grok-4-auto` | medium |
+| Draft / routine | `grok-4.6` | medium |
 
 **Stack default:** cinematic+Build API/chat **`grok-4.6`** (CLI ≥ 1.0.5 · fork `grok-build` or `grok-4.6`; `grok-4.5` aliases wrap 4.6). Opt-in 1M: `grok-4.3`.  
 **Registry:** `tools/models.py` · `references/agents/MODEL_LAYER_v4.5.md` · `models verify`
 
+**Legacy (still selectable):** `grok-4.5` (legacy alias that wraps `grok-4.6`), `grok-v9-4p5-chat-expert`, `grok-v9-4p5-multi`, and `grok-4-auto` are aliases that wrap `grok-4.6`. `grok-imagine-image` (Fast) stays selectable. Legacy `grok-imagine-image-quality` is still selectable if the user or picker names it; it retires 2026-11-02, and unnamed requests map to `grok-imagine-image-2.0` with `quality=low`. Video 1.0 (`grok-imagine-video`) stays selectable for edit/extend and for any clip if named.
+
+**Named-id rule:** If the user or picker names a legacy id, use that id. Do not silently replace a named legacy choice.
+
 ```yaml
 model_compatibility:
   - grok-4.6
+  - grok-4.5  # legacy alias that wraps grok-4.6
+  - grok-v9-4p5-chat-expert
+  - grok-v9-4p5-multi
+  - grok-4-auto
+  - grok-4.3
 preferred_model: grok-4.6
 ```
+
 
 ## When to Activate
 

--- a/.grok/skills/parallel-brief-dispatcher/references/agents/Parallel_Brief_Dispatcher.md
+++ b/.grok/skills/parallel-brief-dispatcher/references/agents/Parallel_Brief_Dispatcher.md
@@ -2,7 +2,7 @@
 
 **Skill:** parallel-brief-dispatcher  
 **Version:** 4.5  
-**Optimized for:** grok-v9-4p5-multi · grok-v9-4p5-chat-expert · grok-4-auto  
+**Optimized for:** `grok-4.6` (default) · legacy aliases still selectable  
 **Native Targets:** Dual Imagine Video 1.0 / 1.5 · Parallel Brief Protocol v1.0  
 **Studio:** Grok Imagine Cinematic Studio v3.11.0+ (Wave A scaffold)
 
@@ -16,17 +16,25 @@ You are the **Parallel Brief co-pilot** for Studio Director. You template, ID, l
 
 | Task type | Preferred model | Reasoning |
 |-----------|-----------------|-----------|
-| Specialist craft / packet fields | `grok-v9-4p5-chat-expert` | high |
-| Multi-agent coordination / synthesis | `grok-v9-4p5-multi` | high |
-| Draft / light status | `grok-4-auto` | medium |
+| Specialist craft / packet fields | `grok-4.6` | high |
+| Multi-agent coordination / synthesis | `grok-4.6` | high |
+| Draft / light status | `grok-4.6` | medium |
+
+**Legacy (still selectable):** `grok-4.5` (legacy alias that wraps `grok-4.6`), `grok-v9-4p5-chat-expert`, `grok-v9-4p5-multi`, and `grok-4-auto` are aliases that wrap `grok-4.6`. `grok-imagine-image` (Fast) stays selectable. Legacy `grok-imagine-image-quality` is still selectable if the user or picker names it; it retires 2026-11-02, and unnamed requests map to `grok-imagine-image-2.0` with `quality=low`. Video 1.0 (`grok-imagine-video`) stays selectable for edit/extend and for any clip if named.
+
+**Named-id rule:** If the user or picker names a legacy id, use that id. Do not silently replace a named legacy choice.
 
 ```yaml
 model_compatibility:
+  - grok-4.6
+  - grok-4.5  # legacy alias that wraps grok-4.6
   - grok-v9-4p5-chat-expert
   - grok-v9-4p5-multi
   - grok-4-auto
-preferred_model: grok-v9-4p5-multi
+  - grok-4.3
+preferred_model: grok-4.6
 ```
+
 
 **Stack default:** `grok-4.6` · Registry: `references/agents/MODEL_LAYER_v4.5.md` · `models verify`
 

--- a/.grok/skills/quality-assurance-guardian/SKILL.md
+++ b/.grok/skills/quality-assurance-guardian/SKILL.md
@@ -15,16 +15,26 @@ description: Final quality gatekeeper and production quality commander. Runs man
 |------------------------------------------------|-------------------------------|-----------|
 | Full 16-point review + nuanced artistic judgment | `grok-4.6` (Chat **Expert**)   | high      |
 | Multi-clip suite audit / sequence-level health  | `grok-4.6` (Chat **Heavy**)         | high      |
-| Quick go/no-go checks / routine validation      | `grok-4-auto`               | medium    |
+| Quick go/no-go checks / routine validation      | `grok-4.6` | medium |
 
 **Stack default:** cinematic+Build API/chat **`grok-4.6`** (CLI ≥ 1.0.5 · fork `grok-build` or `grok-4.6`; `grok-4.5` aliases wrap 4.6). Opt-in 1M: `grok-4.3`.  
 **Registry:** `tools/models.py` (schema 1.1+) · `references/agents/MODEL_LAYER_v4.5.md` · `models verify`
 
+**Legacy (still selectable):** `grok-4.5` (legacy alias that wraps `grok-4.6`), `grok-v9-4p5-chat-expert`, `grok-v9-4p5-multi`, and `grok-4-auto` are aliases that wrap `grok-4.6`. `grok-imagine-image` (Fast) stays selectable. Legacy `grok-imagine-image-quality` is still selectable if the user or picker names it; it retires 2026-11-02, and unnamed requests map to `grok-imagine-image-2.0` with `quality=low`. Video 1.0 (`grok-imagine-video`) stays selectable for edit/extend and for any clip if named.
+
+**Named-id rule:** If the user or picker names a legacy id, use that id. Do not silently replace a named legacy choice.
+
 ```yaml
 model_compatibility:
   - grok-4.6
+  - grok-4.5  # legacy alias that wraps grok-4.6
+  - grok-v9-4p5-chat-expert
+  - grok-v9-4p5-multi
+  - grok-4-auto
+  - grok-4.3
 preferred_model: grok-4.6
 ```
+
 
 ## When to Activate
 
@@ -42,11 +52,11 @@ Load and follow the Role Card. Do not paraphrase locked protocols or output stru
 
 ## Grok Imagine Video Compatibility
 
-### Primary Path — Imagine Video 1.5 Native
+### Audio / final — Imagine Video 1.5 Native
 - Full Chain QA including LAST_FRAME_RECAP, MOMENTUM_VECTOR, AUDIO_MOMENTUM_VECTOR, physics continuity, temporal consistency, and native audio sync
 - Higher thresholds for hero and final deliverables
 
-### Secondary / Fallback Path — Imagine Video 1.0
+### Edit / extend — Imagine Video 1.0 (still selectable if named; not fallback-only. No Video 2.0.)
 - Still enforce full 16-point and 10-point Chain QA
 - Adjust expectations for known 1.0 limitations (no native audio, different motion characteristics)
 - Clearly note when a clip is approved under 1.0 criteria so downstream agents are aware

--- a/.grok/skills/quota-dashboard/SKILL.md
+++ b/.grok/skills/quota-dashboard/SKILL.md
@@ -15,16 +15,26 @@ description: Mobile-optimized Quota Dashboard for Grok Imagine with full Weekly 
 |------------------------------------------------|-------------------------------|-----------|
 | Complex multi-window quota synthesis and visual dashboard design | `grok-4.6` (Chat **Heavy**)         | high      |
 | Single screenshot analysis, status report, key-art style poster | `grok-4.6` (Chat **Expert**)   | high      |
-| Quick status / simple checks                   | `grok-4-auto`               | medium    |
+| Quick status / simple checks                   | `grok-4.6` | medium |
 
 **Stack default:** cinematic+Build API/chat **`grok-4.6`** (CLI ≥ 1.0.5 · fork `grok-build` or `grok-4.6`; `grok-4.5` aliases wrap 4.6). Opt-in 1M: `grok-4.3`.  
 **Registry:** `tools/models.py` (schema 1.1+) · `references/agents/MODEL_LAYER_v4.5.md` · `models verify`
 
+**Legacy (still selectable):** `grok-4.5` (legacy alias that wraps `grok-4.6`), `grok-v9-4p5-chat-expert`, `grok-v9-4p5-multi`, and `grok-4-auto` are aliases that wrap `grok-4.6`. `grok-imagine-image` (Fast) stays selectable. Legacy `grok-imagine-image-quality` is still selectable if the user or picker names it; it retires 2026-11-02, and unnamed requests map to `grok-imagine-image-2.0` with `quality=low`. Video 1.0 (`grok-imagine-video`) stays selectable for edit/extend and for any clip if named.
+
+**Named-id rule:** If the user or picker names a legacy id, use that id. Do not silently replace a named legacy choice.
+
 ```yaml
 model_compatibility:
   - grok-4.6
+  - grok-4.5  # legacy alias that wraps grok-4.6
+  - grok-v9-4p5-chat-expert
+  - grok-v9-4p5-multi
+  - grok-4-auto
+  - grok-4.3
 preferred_model: grok-4.6
 ```
+
 
 ## When to Activate
 
@@ -40,10 +50,10 @@ Load and follow the Role Card.
 
 ## Grok Imagine Video Compatibility
 
-### Primary Path — Imagine Video 1.5 Native
+### Audio / final — Imagine Video 1.5 Native
 - Track and report 1.5 usage distinctly when data is available
 
-### Secondary / Fallback Path — Imagine Video 1.0
+### Edit / extend — Imagine Video 1.0 (still selectable if named; not fallback-only. No Video 2.0.)
 - Track and report 1.0 usage distinctly when data is available
 
 Both paths share the same dashboard and visual reporting framework.

--- a/.grok/skills/score-temp-music-supervisor/SKILL.md
+++ b/.grok/skills/score-temp-music-supervisor/SKILL.md
@@ -29,16 +29,26 @@ tags:
 |-----------|-----------------|-----------|
 | Specialist craft | `grok-4.6` (Chat **Expert**) | high |
 | Multi-agent / synthesis | `grok-4.6` (Chat **Heavy**) | high |
-| Draft / routine | `grok-4-auto` | medium |
+| Draft / routine | `grok-4.6` | medium |
 
 **Stack default:** cinematic+Build API/chat **`grok-4.6`** (CLI ≥ 1.0.5 · fork `grok-build` or `grok-4.6`; `grok-4.5` aliases wrap 4.6). Opt-in 1M: `grok-4.3`.  
 **Registry:** `tools/models.py` · `references/agents/MODEL_LAYER_v4.5.md` · `models verify`
 
+**Legacy (still selectable):** `grok-4.5` (legacy alias that wraps `grok-4.6`), `grok-v9-4p5-chat-expert`, `grok-v9-4p5-multi`, and `grok-4-auto` are aliases that wrap `grok-4.6`. `grok-imagine-image` (Fast) stays selectable. Legacy `grok-imagine-image-quality` is still selectable if the user or picker names it; it retires 2026-11-02, and unnamed requests map to `grok-imagine-image-2.0` with `quality=low`. Video 1.0 (`grok-imagine-video`) stays selectable for edit/extend and for any clip if named.
+
+**Named-id rule:** If the user or picker names a legacy id, use that id. Do not silently replace a named legacy choice.
+
 ```yaml
 model_compatibility:
   - grok-4.6
+  - grok-4.5  # legacy alias that wraps grok-4.6
+  - grok-v9-4p5-chat-expert
+  - grok-v9-4p5-multi
+  - grok-4-auto
+  - grok-4.3
 preferred_model: grok-4.6
 ```
+
 
 ## When to Activate
 

--- a/.grok/skills/score-temp-music-supervisor/references/agents/Score_Temp_Music_Supervisor.md
+++ b/.grok/skills/score-temp-music-supervisor/references/agents/Score_Temp_Music_Supervisor.md
@@ -2,7 +2,7 @@
 
 **Skill:** score-temp-music-supervisor  
 **Version:** 4.5  
-**Optimized for:** grok-v9-4p5-multi · grok-v9-4p5-chat-expert · grok-4-auto  
+**Optimized for:** `grok-4.6` (default) · legacy aliases still selectable  
 **Native Targets:** Dual Imagine Video 1.0 / 1.5 · Parallel Brief Protocol v1.0  
 **Studio:** Grok Imagine Cinematic Studio v3.11.0+ (Wave A scaffold)
 
@@ -16,17 +16,25 @@ You own **music and temp score direction**—cues, emotional temperature via mus
 
 | Task type | Preferred model | Reasoning |
 |-----------|-----------------|-----------|
-| Specialist craft / packet fields | `grok-v9-4p5-chat-expert` | high |
-| Multi-agent coordination / synthesis | `grok-v9-4p5-multi` | high |
-| Draft / light status | `grok-4-auto` | medium |
+| Specialist craft / packet fields | `grok-4.6` | high |
+| Multi-agent coordination / synthesis | `grok-4.6` | high |
+| Draft / light status | `grok-4.6` | medium |
+
+**Legacy (still selectable):** `grok-4.5` (legacy alias that wraps `grok-4.6`), `grok-v9-4p5-chat-expert`, `grok-v9-4p5-multi`, and `grok-4-auto` are aliases that wrap `grok-4.6`. `grok-imagine-image` (Fast) stays selectable. Legacy `grok-imagine-image-quality` is still selectable if the user or picker names it; it retires 2026-11-02, and unnamed requests map to `grok-imagine-image-2.0` with `quality=low`. Video 1.0 (`grok-imagine-video`) stays selectable for edit/extend and for any clip if named.
+
+**Named-id rule:** If the user or picker names a legacy id, use that id. Do not silently replace a named legacy choice.
 
 ```yaml
 model_compatibility:
+  - grok-4.6
+  - grok-4.5  # legacy alias that wraps grok-4.6
   - grok-v9-4p5-chat-expert
   - grok-v9-4p5-multi
   - grok-4-auto
-preferred_model: grok-v9-4p5-chat-expert
+  - grok-4.3
+preferred_model: grok-4.6
 ```
+
 
 **Stack default:** `grok-4.6` · Registry: `references/agents/MODEL_LAYER_v4.5.md` · `models verify`
 

--- a/.grok/skills/title-motion-graphics-lead/SKILL.md
+++ b/.grok/skills/title-motion-graphics-lead/SKILL.md
@@ -29,16 +29,26 @@ tags:
 |-----------|-----------------|-----------|
 | Specialist craft | `grok-4.6` (Chat **Expert**) | high |
 | Multi-agent / synthesis | `grok-4.6` (Chat **Heavy**) | high |
-| Draft / routine | `grok-4-auto` | medium |
+| Draft / routine | `grok-4.6` | medium |
 
 **Stack default:** cinematic+Build API/chat **`grok-4.6`** (CLI ≥ 1.0.5 · fork `grok-build` or `grok-4.6`; `grok-4.5` aliases wrap 4.6). Opt-in 1M: `grok-4.3`.  
 **Registry:** `tools/models.py` · `references/agents/MODEL_LAYER_v4.5.md` · `models verify`
 
+**Legacy (still selectable):** `grok-4.5` (legacy alias that wraps `grok-4.6`), `grok-v9-4p5-chat-expert`, `grok-v9-4p5-multi`, and `grok-4-auto` are aliases that wrap `grok-4.6`. `grok-imagine-image` (Fast) stays selectable. Legacy `grok-imagine-image-quality` is still selectable if the user or picker names it; it retires 2026-11-02, and unnamed requests map to `grok-imagine-image-2.0` with `quality=low`. Video 1.0 (`grok-imagine-video`) stays selectable for edit/extend and for any clip if named.
+
+**Named-id rule:** If the user or picker names a legacy id, use that id. Do not silently replace a named legacy choice.
+
 ```yaml
 model_compatibility:
   - grok-4.6
+  - grok-4.5  # legacy alias that wraps grok-4.6
+  - grok-v9-4p5-chat-expert
+  - grok-v9-4p5-multi
+  - grok-4-auto
+  - grok-4.3
 preferred_model: grok-4.6
 ```
+
 
 ## When to Activate
 

--- a/.grok/skills/title-motion-graphics-lead/references/agents/Title_Motion_Graphics_Lead.md
+++ b/.grok/skills/title-motion-graphics-lead/references/agents/Title_Motion_Graphics_Lead.md
@@ -2,7 +2,7 @@
 
 **Skill:** title-motion-graphics-lead  
 **Version:** 4.5  
-**Optimized for:** grok-v9-4p5-multi · grok-v9-4p5-chat-expert · grok-4-auto  
+**Optimized for:** `grok-4.6` (default) · legacy aliases still selectable  
 **Native Targets:** Dual Imagine Video 1.0 / 1.5 · Parallel Brief Protocol v1.0  
 **Studio:** Grok Imagine Cinematic Studio v3.11.0+ (Wave A scaffold)
 
@@ -16,17 +16,25 @@ You own **titles and motion graphics**—openers, lower-thirds, end cards, brand
 
 | Task type | Preferred model | Reasoning |
 |-----------|-----------------|-----------|
-| Specialist craft / packet fields | `grok-v9-4p5-chat-expert` | high |
-| Multi-agent coordination / synthesis | `grok-v9-4p5-multi` | high |
-| Draft / light status | `grok-4-auto` | medium |
+| Specialist craft / packet fields | `grok-4.6` | high |
+| Multi-agent coordination / synthesis | `grok-4.6` | high |
+| Draft / light status | `grok-4.6` | medium |
+
+**Legacy (still selectable):** `grok-4.5` (legacy alias that wraps `grok-4.6`), `grok-v9-4p5-chat-expert`, `grok-v9-4p5-multi`, and `grok-4-auto` are aliases that wrap `grok-4.6`. `grok-imagine-image` (Fast) stays selectable. Legacy `grok-imagine-image-quality` is still selectable if the user or picker names it; it retires 2026-11-02, and unnamed requests map to `grok-imagine-image-2.0` with `quality=low`. Video 1.0 (`grok-imagine-video`) stays selectable for edit/extend and for any clip if named.
+
+**Named-id rule:** If the user or picker names a legacy id, use that id. Do not silently replace a named legacy choice.
 
 ```yaml
 model_compatibility:
+  - grok-4.6
+  - grok-4.5  # legacy alias that wraps grok-4.6
   - grok-v9-4p5-chat-expert
   - grok-v9-4p5-multi
   - grok-4-auto
-preferred_model: grok-v9-4p5-chat-expert
+  - grok-4.3
+preferred_model: grok-4.6
 ```
+
 
 **Stack default:** `grok-4.6` · Registry: `references/agents/MODEL_LAYER_v4.5.md` · `models verify`
 

--- a/.grok/skills/workflow-quota-optimizer/SKILL.md
+++ b/.grok/skills/workflow-quota-optimizer/SKILL.md
@@ -15,16 +15,26 @@ description: Real-time quota guardian and production economist for Grok Imagine.
 |------------------------------------------------|-------------------------------|-----------|
 | Complex session / multi-sequence cost modeling and optimization | `grok-4.6` (Chat **Heavy**)         | high      |
 | Single sequence cost estimation, Fast mode recommendations | `grok-4.6` (Chat **Expert**)   | high      |
-| Quick status / simple quota checks             | `grok-4-auto`               | medium    |
+| Quick status / simple quota checks             | `grok-4.6` | medium |
 
 **Stack default:** cinematic+Build API/chat **`grok-4.6`** (CLI ≥ 1.0.5 · fork `grok-build` or `grok-4.6`; `grok-4.5` aliases wrap 4.6). Opt-in 1M: `grok-4.3`.  
 **Registry:** `tools/models.py` (schema 1.1+) · `references/agents/MODEL_LAYER_v4.5.md` · `models verify`
 
+**Legacy (still selectable):** `grok-4.5` (legacy alias that wraps `grok-4.6`), `grok-v9-4p5-chat-expert`, `grok-v9-4p5-multi`, and `grok-4-auto` are aliases that wrap `grok-4.6`. `grok-imagine-image` (Fast) stays selectable. Legacy `grok-imagine-image-quality` is still selectable if the user or picker names it; it retires 2026-11-02, and unnamed requests map to `grok-imagine-image-2.0` with `quality=low`. Video 1.0 (`grok-imagine-video`) stays selectable for edit/extend and for any clip if named.
+
+**Named-id rule:** If the user or picker names a legacy id, use that id. Do not silently replace a named legacy choice.
+
 ```yaml
 model_compatibility:
   - grok-4.6
+  - grok-4.5  # legacy alias that wraps grok-4.6
+  - grok-v9-4p5-chat-expert
+  - grok-v9-4p5-multi
+  - grok-4-auto
+  - grok-4.3
 preferred_model: grok-4.6
 ```
+
 
 ## When to Activate
 
@@ -40,10 +50,10 @@ Load and follow the Role Card.
 
 ## Grok Imagine Video Compatibility
 
-### Primary Path — Imagine Video 1.5 Native
+### Audio / final — Imagine Video 1.5 Native
 - Higher cost, higher fidelity — recommend only when justified by hero needs
 
-### Secondary / Fallback Path — Imagine Video 1.0
+### Edit / extend — Imagine Video 1.0 (still selectable if named; not fallback-only. No Video 2.0.)
 - Preferred for drafts, support shots, and quota-constrained work
 - Always surface the cost difference clearly
 

--- a/.grok/skills/workflow-quota-optimizer/references/agents/Workflow_Quota_Optimizer.md
+++ b/.grok/skills/workflow-quota-optimizer/references/agents/Workflow_Quota_Optimizer.md
@@ -2,8 +2,8 @@
 
 **Skill:** workflow-quota-optimizer  
 **Version:** 4.5  
-**Optimized for:** grok-v9-4p5-chat-expert · grok-v9-4p5-multi · grok-4-auto  
-**Native Targets:** Grok Imagine Video 1.5 (primary) + Grok Imagine Video 1.0 (fallback)
+**Optimized for:** `grok-4.6` (default) · legacy aliases still selectable  
+**Native Targets:** Grok Imagine Video 1.5 (audio/final) + Grok Imagine Video 1.0 (edit/extend, and still selectable if named)
 
 ---
 
@@ -16,18 +16,18 @@ You are the real-time quota guardian and production economist for Grok Imagine. 
 
 | Task type                                      | Preferred model               | Reasoning |
 |------------------------------------------------|-------------------------------|-----------|
-| Complex session / multi-sequence cost modeling and optimization | `grok-v9-4p5-multi`         | high      |
-| Single sequence cost estimation, Fast mode recommendations | `grok-v9-4p5-chat-expert`   | high      |
-| Quick status / simple quota checks             | `grok-4-auto`               | medium    |
+| Complex session / multi-sequence cost modeling and optimization | `grok-4.6`         | high      |
+| Single sequence cost estimation, Fast mode recommendations | `grok-4.6`   | high      |
+| Quick status / simple quota checks             | `grok-4.6` | medium |
 
 Always record the model used in recommendations.
 
 ## Grok Imagine Video Compatibility
 
-### Primary: Imagine Video 1.5 Native
+### Audio / final: Imagine Video 1.5 Native
 - Higher cost, higher fidelity — recommend only when justified by hero needs
 
-### Secondary / Fallback: Imagine Video 1.0
+### Edit / extend: Imagine Video 1.0 (still selectable if named; not fallback-only. No Video 2.0.)
 - Preferred for drafts, support shots, and quota-constrained work
 - Always surface the cost difference clearly
 
@@ -64,3 +64,18 @@ Always record the model used in recommendations.
 
 *Role Card v4.5 — Workflow Quota Optimizer | Grok Imagine Cinematic Studio*  
 *Compatible with grok-4-auto / grok-v9-4p5-multi / grok-v9-4p5-chat-expert + Imagine 1.0 & 1.5*
+
+**Legacy (still selectable):** `grok-4.5` (legacy alias that wraps `grok-4.6`), `grok-v9-4p5-chat-expert`, `grok-v9-4p5-multi`, and `grok-4-auto` are aliases that wrap `grok-4.6`. `grok-imagine-image` (Fast) stays selectable. Legacy `grok-imagine-image-quality` is still selectable if the user or picker names it; it retires 2026-11-02, and unnamed requests map to `grok-imagine-image-2.0` with `quality=low`. Video 1.0 (`grok-imagine-video`) stays selectable for edit/extend and for any clip if named.
+
+**Named-id rule:** If the user or picker names a legacy id, use that id. Do not silently replace a named legacy choice.
+
+```yaml
+model_compatibility:
+  - grok-4.6
+  - grok-4.5  # legacy alias that wraps grok-4.6
+  - grok-v9-4p5-chat-expert
+  - grok-v9-4p5-multi
+  - grok-4-auto
+  - grok-4.3
+preferred_model: grok-4.6
+```

--- a/references/agents/Extend_Frame_to_Video.md
+++ b/references/agents/Extend_Frame_to_Video.md
@@ -3,7 +3,7 @@
 **Skill:** extend-frame-to-video  
 **Version:** 4.5  
 **Optimized for:** grok-4.6 · grok-4.6 · grok-4-auto  
-**Native Targets:** Grok Imagine Video 1.5 (primary) + Grok Imagine Video 1.0 (fallback)
+**Native Targets:** Grok Imagine Video 1.5 (audio/final) + Grok Imagine Video 1.0 (edit/extend, and still selectable if named)
 
 ---
 
@@ -20,26 +20,36 @@ You are the bridge between approved stills and full video spend.
 |------------------------------------------------|-------------------------------|-----------|
 | Complex multi-clip assembly planning, EDL + storyboard synthesis | `grok-4.6` (Chat **Heavy**)         | high      |
 | Single-sequence extend planning, prompt crafting, Ken Burns design | `grok-4.6` (Chat **Expert**)   | high      |
-| Quick status / simple assembly checks          | `grok-4-auto`               | medium    |
+| Quick status / simple assembly checks          | `grok-4.6` | medium |
 
 Always record the model used in assembly reports and Handoff Packets.
 
 ## Grok Imagine Video Compatibility
 
-### Primary: Imagine Video 1.5 Native
+### Audio / final: Imagine Video 1.5 Native
 - Preferred for high-fidelity extend-from-frame chains
 - Full support for LAST_FRAME_RECAP, momentum vectors, and native audio continuity
 
-### Secondary / Fallback: Imagine Video 1.0
+### Edit / extend: Imagine Video 1.0 (still selectable if named; not fallback-only. No Video 2.0.)
 - Fully supported for cost-efficient pre-viz and draft animatics
 - Clearly label 1.0 vs 1.5 outputs in project manifests and EDLs
 
 
+**Legacy (still selectable):** `grok-4.5` (legacy alias that wraps `grok-4.6`), `grok-v9-4p5-chat-expert`, `grok-v9-4p5-multi`, and `grok-4-auto` are aliases that wrap `grok-4.6`. `grok-imagine-image` (Fast) stays selectable. Legacy `grok-imagine-image-quality` is still selectable if the user or picker names it; it retires 2026-11-02, and unnamed requests map to `grok-imagine-image-2.0` with `quality=low`. Video 1.0 (`grok-imagine-video`) stays selectable for edit/extend and for any clip if named.
+
+**Named-id rule:** If the user or picker names a legacy id, use that id. Do not silently replace a named legacy choice.
+
 ```yaml
 model_compatibility:
   - grok-4.6
+  - grok-4.5  # legacy alias that wraps grok-4.6
+  - grok-v9-4p5-chat-expert
+  - grok-v9-4p5-multi
+  - grok-4-auto
+  - grok-4.3
 preferred_model: grok-4.6
 ```
+
 
 ## Non-Negotiable Protocols
 

--- a/references/agents/Quality_Assurance_Guardian_v3.5.md
+++ b/references/agents/Quality_Assurance_Guardian_v3.5.md
@@ -14,15 +14,25 @@ You are the final **16-point** QA gatekeeper (plus **10-point Chain QA** on exte
 |-----------------------------------|-------------------------------|-----------|
 | Full 16-point / Chain QA review   | `grok-4.6` (Chat **Expert**)     | high      |
 | Multi-clip suite audit            | `grok-4.6` (Chat **Heavy**)           | high      |
-| Quick go/no-go checks             | `grok-4-auto`                 | medium    |
+| Quick go/no-go checks             | `grok-4.6`                 | medium    |
 
 **Registry:** `tools/models.py` (schema 1.1+) · `references/agents/MODEL_LAYER_v4.5.md` (v4.5.1) · `models verify`
+
+**Legacy (still selectable):** `grok-4.5` (legacy alias that wraps `grok-4.6`), `grok-v9-4p5-chat-expert`, `grok-v9-4p5-multi`, and `grok-4-auto` are aliases that wrap `grok-4.6`. `grok-imagine-image` (Fast) stays selectable. Legacy `grok-imagine-image-quality` is still selectable if the user or picker names it; it retires 2026-11-02, and unnamed requests map to `grok-imagine-image-2.0` with `quality=low`. Video 1.0 (`grok-imagine-video`) stays selectable for edit/extend and for any clip if named.
+
+**Named-id rule:** If the user or picker names a legacy id, use that id. Do not silently replace a named legacy choice.
 
 ```yaml
 model_compatibility:
   - grok-4.6
+  - grok-4.5  # legacy alias that wraps grok-4.6
+  - grok-v9-4p5-chat-expert
+  - grok-v9-4p5-multi
+  - grok-4-auto
+  - grok-4.3
 preferred_model: grok-4.6
 ```
+
 
 Prefer stable `prompt_cache_key` on multi-turn loops. Reasoning **high** for go/no-go and identity failures.
 

--- a/references/agents/Quota_Dashboard.md
+++ b/references/agents/Quota_Dashboard.md
@@ -3,7 +3,7 @@
 **Skill:** quota-dashboard  
 **Version:** 4.5  
 **Optimized for:** grok-4.6 · grok-4.6 · grok-4-auto  
-**Native Targets:** Grok Imagine Video 1.5 (primary) + Grok Imagine Video 1.0 (fallback)
+**Native Targets:** Grok Imagine Video 1.5 (audio/final) + Grok Imagine Video 1.0 (edit/extend, and still selectable if named)
 
 ---
 
@@ -20,24 +20,34 @@ You turn app screenshots into clear status and optional key-art style dashboard 
 |------------------------------------------------|-------------------------------|-----------|
 | Complex multi-window quota synthesis and visual dashboard design | `grok-4.6` (Chat **Heavy**)         | high      |
 | Single screenshot analysis, status report, key-art style poster | `grok-4.6` (Chat **Expert**)   | high      |
-| Quick status / simple checks                   | `grok-4-auto`               | medium    |
+| Quick status / simple checks                   | `grok-4.6` | medium |
 
 Always record the model used in reports.
 
 ## Grok Imagine Video Compatibility
 
-### Primary: Imagine Video 1.5 Native
+### Audio / final: Imagine Video 1.5 Native
 - Track and report 1.5 usage distinctly when data is available
 
-### Secondary / Fallback: Imagine Video 1.0
+### Edit / extend: Imagine Video 1.0 (still selectable if named; not fallback-only. No Video 2.0.)
 - Track and report 1.0 usage distinctly when data is available
 
+
+**Legacy (still selectable):** `grok-4.5` (legacy alias that wraps `grok-4.6`), `grok-v9-4p5-chat-expert`, `grok-v9-4p5-multi`, and `grok-4-auto` are aliases that wrap `grok-4.6`. `grok-imagine-image` (Fast) stays selectable. Legacy `grok-imagine-image-quality` is still selectable if the user or picker names it; it retires 2026-11-02, and unnamed requests map to `grok-imagine-image-2.0` with `quality=low`. Video 1.0 (`grok-imagine-video`) stays selectable for edit/extend and for any clip if named.
+
+**Named-id rule:** If the user or picker names a legacy id, use that id. Do not silently replace a named legacy choice.
 
 ```yaml
 model_compatibility:
   - grok-4.6
+  - grok-4.5  # legacy alias that wraps grok-4.6
+  - grok-v9-4p5-chat-expert
+  - grok-v9-4p5-multi
+  - grok-4-auto
+  - grok-4.3
 preferred_model: grok-4.6
 ```
+
 
 ## Non-Negotiable Protocols
 


### PR DESCRIPTION
## Summary
- I3 only: thirteen role cards + parent `SKILL.md` (plus the three canonical cards the skill pointers load).
- Defaults: `grok-4.6`, Image 2.0 Quality hero, Video 1.5 audio/final, Video 1.0 edit/extend. No Video 2.0.
- Named-id rule on every file. Every `grok-4.5` line also says legacy alias/wrap on that same line.
- Content `5179428`, then pin-only `.grok-plugin/` at tip.

## Test plan
- [ ] `test_chat_46_copy.py` — no bare `grok-4.5` line
- [ ] Spot-check Named-id rule on one extender card and one Wave A card
- [ ] Confirm ErosForge / NSFW / grok-doctor / github-repo-manager / I4 untouched